### PR TITLE
Docker Image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM alpine:3.21.3 AS builder
+
+COPY . /Oxicloud
+
+WORKDIR /Oxicloud
+
+RUN apk update && \
+    apk add cargo pkgconfig openssl-dev
+
+RUN cargo build --release
+
+# /Oxicloud/target/release/oxicloud
+
+FROM alpine:3.21.3
+
+COPY . /Oxicloud
+
+COPY --from=builder /Oxicloud/target/release/ /Oxicloud
+COPY --from=builder /usr/lib/libgcc_s.so.1 /usr/lib/libgcc_s.so.1
+
+WORKDIR /Oxicloud
+
+CMD ["./oxicloud","--release"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,10 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: oxicloud
-    ports:
-      - "5432:5432"
+#    ports:
+#      - "5432:5432"
+    networks:
+      - oxicloud
     volumes:
       - pg_data:/var/lib/postgresql/data
       - ./db/schema.sql:/docker-entrypoint-initdb.d/10-schema.sql
@@ -16,6 +18,26 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+  
+  oxicloud:
+    image: oxicloud
+    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8086:8086"
+      - "8085:8085"
+    networks:
+      - oxicloud
+    depends_on:
+      - postgres
+    environment:
+    - "OXICLOUD_DB_CONNECTION_STRING=postgres://postgres:postgres@postgres/oxicloud"
+
+networks:
+  oxicloud:
+    driver: bridge
 
 volumes:
   pg_data:

--- a/src/main.rs
+++ b/src/main.rs
@@ -678,7 +678,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
     
     // Start server with clear message
-    let addr = SocketAddr::from(([127, 0, 0, 1], 8086));
+    let addr = SocketAddr::from(([0, 0, 0, 0], 8086));
     tracing::info!("Starting OxiCloud server on http://{}", addr);
     
     // Start the server


### PR DESCRIPTION
## Description

Add support for hosting OxiCloud inside a docker container.
- Dockerfile for container image
- Usage of image in docker-compose.yml
- Changes server bind address to 0.0.0.0 (bind all) to allow forwarding.

Please read the following considerations/changes:
- Database is not accessible externally.
- DB url is provided via environment variable, I wasn't able to get it working via .env
- No files for the server are mounted/persisted, its difficult to determine what needs to be.
- I can write a GitHub action as a test, unless you have another suggestion.
- Migrations are not run, although I wasn't able to run them regardless (needs new issue).
    - This can be done as an extra first start step, ex: `docker run oxicloud migrations`

## Related Issue

- Closes #17 and #20 

## Type of Change

Please check the option that best describes your change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

Locally tested with `docker compose up -d`. There seems to be some issue when trying to view a file unknown if this is because of the container.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules