### PR TITLE
Remove redundent `apk --no-cache update` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # Stage 1: Cache dependencies
 FROM rust:1.85-alpine AS cacher
 WORKDIR /app
-RUN apk --no-cache update && \
-    apk --no-cache upgrade && \
+RUN apk --no-cache upgrade && \
     apk add --no-cache musl-dev openssl-dev pkgconfig postgresql-dev
 COPY Cargo.toml Cargo.lock ./
 # Create a minimal project to download and cache dependencies
@@ -14,8 +13,7 @@ RUN mkdir -p src && \
 # Stage 2: Build the application
 FROM rust:1.85-alpine AS builder
 WORKDIR /app
-RUN apk --no-cache update && \
-    apk --no-cache upgrade && \
+RUN apk --no-cache upgrade && \
     apk add --no-cache musl-dev openssl-dev pkgconfig postgresql-dev
 # Copy cached dependencies
 COPY --from=cacher /app/target target
@@ -31,8 +29,7 @@ RUN cargo build --release
 # Stage 3: Create minimal final image
 FROM alpine:3.21.3
 # Install only necessary runtime dependencies and update packages
-RUN apk --no-cache update && \
-    apk --no-cache upgrade && \
+RUN apk --no-cache upgrade && \
     apk add --no-cache libgcc openssl ca-certificates libpq tzdata
 
 # Copy only the compiled binary


### PR DESCRIPTION
## Description

`apk` with `--no-cache` will ensure the package index updated without leaving temporary files. Additional `apk --no-cache update` will be unnecessary. Besides, `--no-cache` is kind of conflicts with `apk update` command.

## Type of Change

Please check the option that best describes your change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

Just build the docker image as usual ;)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules