### PR TITLE
fix(admin): populate OIDC settings in admin panel from environment variables

### DIFF
--- a/src/application/services/admin_settings_service.rs
+++ b/src/application/services/admin_settings_service.rs
@@ -171,7 +171,7 @@ impl AdminSettingsService {
             admin_groups: effective.admin_groups,
             disable_password_login: effective.disable_password_login,
             provider_name: effective.provider_name,
-            callback_url: self.callback_url(),
+            callback_url: effective.redirect_uri.clone(),
             env_overrides: self.get_env_overrides(),
         })
     }


### PR DESCRIPTION
## Description

    The get_oidc_settings() method was reading directly from the database only,
    without applying environment variable overrides. Now it uses load_effective_oidc_config()
    which properly applies env var overrides (OXICLOUD_OIDC_*), ensuring the admin
    panel accurately reflects the runtime configuration.

    - Use load_effective_oidc_config() to get OIDC settings, which applies env var overrides
    - Use effective.redirect_uri for callback_url instead of calculated value from server_base_url
    - This ensures the admin panel shows the correct OXICLOUD_OIDC_REDIRECT_URI value

## Related Issue

N/A

## Type of Change

Please check the option that best describes your change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

Had environment variables configured, with this change they are present in the admin web UI.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules