### PR TITLE
Add email_verified check for OIDC login

### DIFF
--- a/src/application/ports/auth_ports.rs
+++ b/src/application/ports/auth_ports.rs
@@ -140,6 +140,7 @@ pub struct OidcTokenSet {
 pub struct OidcIdClaims {
     pub sub: String,
     pub email: Option<String>,
+    pub email_verified: Option<bool>,
     pub preferred_username: Option<String>,
     pub name: Option<String>,
     pub groups: Vec<String>,

--- a/src/infrastructure/services/oidc_service.rs
+++ b/src/infrastructure/services/oidc_service.rs
@@ -58,6 +58,7 @@ struct TokenResponse {
 struct IdTokenClaims {
     sub: String,
     email: Option<String>,
+    email_verified: Option<bool>,
     preferred_username: Option<String>,
     name: Option<String>,
     groups: Option<Vec<String>>,
@@ -81,6 +82,7 @@ struct IdTokenClaims {
 struct UserInfoResponse {
     sub: String,
     email: Option<String>,
+    email_verified: Option<bool>,
     preferred_username: Option<String>,
     name: Option<String>,
     groups: Option<Vec<String>>,
@@ -437,6 +439,7 @@ impl OidcServicePort for OidcService {
         Ok(OidcIdClaims {
             sub: claims.sub,
             email: claims.email,
+            email_verified: claims.email_verified,
             preferred_username: claims.preferred_username,
             name: claims.name,
             groups: claims.groups.unwrap_or_default(),
@@ -487,6 +490,7 @@ impl OidcServicePort for OidcService {
         Ok(OidcIdClaims {
             sub: info.sub,
             email: info.email,
+            email_verified: info.email_verified,
             preferred_username: info.preferred_username,
             name: info.name,
             groups: info.groups.unwrap_or_default(),


### PR DESCRIPTION
## Description
Add `email_verified` claim checking from UserInfo and/or ID token responses. This ensures the email provided by the external OIDC compatible IDP is legitimately owned by the user. This prevents spoofing and ensures emails sent would go to the correct user.
 
- Parse email_verified from ID token and UserInfo endpoint
- Reject OIDC login if email is present and not verified
- Only applies when email is in OIDC claims (not required otherwise)

## Related Issue
N/A

## Type of Change

Please check the option that best describes your change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?
Verified logging in continues to work with email_verified true via OIDC login.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules