### PR TITLE
fix dutch language selection

### DIFF
--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -13,6 +13,7 @@ JSON-based translation system. Translations are loaded from static files, cached
 | Portuguese | `pt` | `static/locales/pt.json` |
 | Persian | `fa` | `static/locales/fa.json` |
 | Chinese | `zh` | `static/locales/zh.json` |
+| Dutch | `nl` | `static/locales/nl.json` |
 
 Default locale: **en** (English).
 

--- a/static/js/core/i18n.js
+++ b/static/js/core/i18n.js
@@ -13,7 +13,7 @@ let currentLocale =
 
 // Supported locales (languages that have locale files on the server)
 // When a locale file is not found, the system gracefully falls back to English
-const supportedLocales = ['en', 'es', 'zh', 'fa', 'fr', 'de', 'pt'];
+const supportedLocales = ['en', 'es', 'zh', 'fa', 'fr', 'de', 'pt', 'nl'];
 
 // Fallback to English if locale is not supported
 if (!supportedLocales.includes(currentLocale)) {

--- a/static/js/core/languageSelector.js
+++ b/static/js/core/languageSelector.js
@@ -18,6 +18,7 @@ function getAvailableLanguages() {
         { code: 'de', name: 'Deutsch', flag: '🇩🇪' },
         { code: 'pt', name: 'Português', flag: '🇧🇷' },
         { code: 'it', name: 'Italiano', flag: '🇮🇹' }
+        { code: 'nl', name: 'Nederlands', flag: '🇳🇱' }
     ];
 }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and the related issue (if applicable). Please also include relevant motivation and context. -->
I saw that the Dutch language was not available in the language selector dropdown. Now it should be there.

## Related Issue

<!-- Please link to the issue here if applicable. -->

## Type of Change

Please check the option that best describes your change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules