### PR TITLE
Ignore RUSTSEC-2023-0071 in security audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,9 +70,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # RUSTSEC-2023-0071 (Marvin Attack): rsa crate is a transitive dependency from jsonwebtoken.
+      # Not affected: This application uses HS256 for internal JWT signing and only performs
+      # RSA public key verification (not private key operations) for OIDC/OAuth2 tokens.
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ignore: RUSTSEC-2023-0071
 
   build:
     name: Build Check


### PR DESCRIPTION
## Description
RUSTSEC-2023-0071 (Marvin Attack) affects RSA private key operations. This application uses HS256 for internal JWT signing and only performs RSA public key verification (not private key operations) for OIDC/OAuth2.

## Related Issue
N/A

## Type of Change

Please check the option that best describes your change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [X] Documentation update

## How Has This Been Tested?
Checking the GitHub CI pipeline.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules