### PR TITLE
fix(ui): photos view bleeding into trash view

### DIFF
--- a/static/js/app/main.js
+++ b/static/js/app/main.js
@@ -445,42 +445,20 @@ function setupEventListeners() {
 
             // Check if this is the trash item
             if (item === elements.trashBtn) {
-                // Hide shared view if active
-                if (app.isSharedView) {
-                    // Hide shared view
-                    if (window.sharedView) {
-                        window.sharedView.hide();
-                    }
-                    
-                    // Reset shared view flag
-                    app.isSharedView = false;
-                    
-                    // Clean up shared containers if they exist
-                    const sharedContainer = document.getElementById('shared-container');
-                    if (sharedContainer) {
-                        sharedContainer.style.display = 'none';
-                    }
-                }
-                
+                setCurrentSection('trash');
+
                 // Hide breadcrumb (only shown in Files view)
                 const breadcrumb = document.querySelector('.breadcrumb');
                 if (breadcrumb) breadcrumb.style.display = 'none';
-                
-                // Show trash view
-                app.isTrashView = true;
-                app.currentSection = 'trash';
-                
+
                 // Show files containers (to be filled with trash)
                 const filesGrid = document.getElementById('files-grid');
                 const filesListView = document.getElementById('files-list-view');
                 if (filesGrid) { filesGrid.style.display = app.currentView === 'grid' ? 'grid' : 'none'; filesGrid.classList.toggle('hidden', app.currentView !== 'grid'); }
                 if (filesListView) { filesListView.style.display = app.currentView === 'list' ? 'flex' : 'none'; filesListView.classList.toggle('hidden', app.currentView !== 'list'); }
-                
-                // Update UI
-                elements.pageTitle.textContent = window.i18n ? window.i18n.t('nav.trash') : 'Trash';
-                elements.pageTitle.setAttribute('data-i18n', 'nav.trash');
+
                 setActionsBarMode('trash');
-                
+
                 // Load trash items
                 window.loadTrashItems();
             } else {


### PR DESCRIPTION
## Summary
- Trash nav handler bypassed `setCurrentSection()` and manually set view flags, so the photos container was never hidden when switching to trash
- Now uses the central `setCurrentSection('trash')` which properly hides photos and shared views before activating trash

## Test plan
- [ ] Navigate to Photos view, then switch to Trash — photos should no longer appear below trash items
- [ ] Switch between all nav sections (Files, Shared, Recent, Favorites, Photos, Trash) and verify only the active view is visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)