### PR TITLE
fix: ARMv7 32-bit compilation overflow

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -207,12 +207,18 @@ pub struct StorageConfig {
 
 impl Default for StorageConfig {
     fn default() -> Self {
+        // Architecture-appropriate max upload size to avoid overflow on 32-bit systems
+        const MAX_UPLOAD_SIZE: usize = if cfg!(target_pointer_width = "64") {
+            10 * 1024 * 1024 * 1024 // 10 GB on 64-bit
+        } else {
+            1024 * 1024 * 1024 // 1 GB on 32-bit
+        };
         Self {
             root_dir: "storage".to_string(),
             chunk_size: 1024 * 1024,                  // 1 MB
             parallel_threshold: 100 * 1024 * 1024,    // 100 MB
             trash_retention_days: 30,                 // 30 days
-            max_upload_size: 10 * 1024 * 1024 * 1024, // 10 GB
+            max_upload_size: MAX_UPLOAD_SIZE,
         }
     }
 }

--- a/src/interfaces/api/routes.rs
+++ b/src/interfaces/api/routes.rs
@@ -150,7 +150,14 @@ pub fn create_api_routes(app_state: &Arc<AppState>) -> Router<Arc<AppState>> {
             get(FileHandler::get_thumbnail).put(FileHandler::upload_thumbnail),
         )
         .route("/{id}/metadata", get(FileHandler::get_file_metadata))
-        .layer(DefaultBodyLimit::max(10 * 1024 * 1024 * 1024)) // 10 GB for file uploads
+        .layer(DefaultBodyLimit::max({
+            // Use architecture-appropriate body limit: 10 GB on 64-bit, 1 GB on 32-bit
+            #[cfg(target_pointer_width = "64")]
+            const FILE_BODY_LIMIT: usize = 10 * 1024 * 1024 * 1024;
+            #[cfg(target_pointer_width = "32")]
+            const FILE_BODY_LIMIT: usize = 1024 * 1024 * 1024;
+            FILE_BODY_LIMIT
+        })) // for file uploads
         .with_state(app_state.clone());
 
     // File operations with trash support

--- a/src/main.rs
+++ b/src/main.rs
@@ -375,9 +375,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Increase the default body limit to 10 GB to allow large file uploads.
+    // Increase the default body limit to allow large file uploads.
+    // Uses architecture-appropriate limit: 10 GB on 64-bit, 1 GB on 32-bit.
     // Without this Axum caps Multipart bodies at 2 MB.
-    app = app.layer(DefaultBodyLimit::max(10 * 1024 * 1024 * 1024));
+    #[cfg(target_pointer_width = "64")]
+    const BODY_LIMIT: usize = 10 * 1024 * 1024 * 1024; // 10 GB
+    #[cfg(target_pointer_width = "32")]
+    const BODY_LIMIT: usize = 1024 * 1024 * 1024; // 1 GB
+    app = app.layer(DefaultBodyLimit::max(BODY_LIMIT));
 
     // ── HTTP compression (gzip + Brotli) ─────────────────────────────────
     // Negotiates the best encoding via Accept-Encoding.  Skips responses


### PR DESCRIPTION
Fixes #206

**Problem**
The constant `10 * 1024 * 1024 * 1024` (10 GB) overflows during compilation on 32-bit systems like ARMv7 where `usize` is 32-bit (max ~4GB). This causes a compilation error.

**Solution**
Use architecture-appropriate limits via conditional compilation:
- 64-bit systems: 10 GB (unchanged behavior)
- 32-bit systems: 1 GB (safe maximum that fits in 32-bit usize)

**Changes**
- `src/common/config.rs`: Use `cfg!` macro for architecture-conditional max upload size
- `src/main.rs`: Use `#[cfg]` attributes for body limit
- `src/interfaces/api/routes.rs`: Use `#[cfg]` attributes for file upload body limit

**Testing**
- All 204 existing tests pass
- Code compiles successfully on 64-bit systems