### PR TITLE
docs(readme): add feature status table to clarify working features

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,28 @@ NextCloud was too slow on my home server. So I built OxiCloud — a complete clo
 
 ---
 
+## Feature Status
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| **File storage & upload** | ✅ Working | Chunked uploads, deduplication, thumbnails |
+| **WebDAV** | ✅ Working | Fully compatible with major clients |
+| **CalDAV (Thunderbird, iOS)** | ✅ Working | Calendar sync functional |
+| **CardDAV (Thunderbird, iOS)** | ✅ Working | Contacts sync functional |
+| **DAVx⁵ (Android)** | ⚠️ Partial | File sync works; calendar/contacts in progress |
+| **WOPI / Office editing** | ✅ Working | Collabora/OnlyOffice integration |
+| **OIDC / SSO** | ✅ Working | Keycloak, Authentik, Google, Azure AD |
+| **Trash / recycle bin** | ✅ Working | Soft-delete with restore |
+| **Full-text search** | ✅ Working | Recursive subtree search |
+| **Shared links** | ✅ Working | Optional password protection |
+| **Desktop sync client** | ❌ Planned | Not yet available |
+| **Android / iOS app** | ❌ Planned | Not yet available |
+| **End-to-end encryption** | ❌ Planned | Roadmap item |
+
+> **Note:** The DAVx⁵ Android app currently works for file sync via WebDAV, but calendar and contacts sync via CalDAV/CardDAV is still being refined. Use Thunderbird or iOS native clients for full CalDAV/CardDAV support.
+
+---
+
 ## Quick Start
 
 ### Docker (recommended)


### PR DESCRIPTION
Adds a feature status table to the README to clarify which features are working, partially implemented, or planned. This addresses user confusion about feature completeness, particularly for DAVx⁵ Android integration where calendar/contacts sync is still in progress.

The table uses clear status indicators (✅ Working, ⚠️ Partial, ❌ Planned) and includes a note about the DAVx⁵ calendar/contacts limitation mentioned in #201.