### PR TITLE
fix(ui): resolve broken menu navigation

### DIFF
--- a/static/css/layout/sidebar.css
+++ b/static/css/layout/sidebar.css
@@ -166,13 +166,15 @@
 .nav-item:nth-child(2) i, .nav-item:nth-child(2) .oxi-icon { color: #74b9ff; } /* Shared - blue */
 .nav-item:nth-child(3) i, .nav-item:nth-child(3) .oxi-icon { color: #81ecec; } /* Recent - teal */
 .nav-item:nth-child(4) i, .nav-item:nth-child(4) .oxi-icon { color: #ffd43b; } /* Favorites - gold */
-.nav-item:nth-child(5) i, .nav-item:nth-child(5) .oxi-icon { color: #ff7675; } /* Trash - red */
+.nav-item:nth-child(5) i, .nav-item:nth-child(5) .oxi-icon { color: #ff6b9d; } /* Photos - pink */
+.nav-item:nth-child(6) i, .nav-item:nth-child(6) .oxi-icon { color: #ff7675; } /* Trash - red */
 
 .nav-item.active:nth-child(1) i, .nav-item.active:nth-child(1) .oxi-icon { color: #ff5e3a; }
 .nav-item.active:nth-child(2) i, .nav-item.active:nth-child(2) .oxi-icon { color: #0984e3; }
 .nav-item.active:nth-child(3) i, .nav-item.active:nth-child(3) .oxi-icon { color: #00cec9; }
 .nav-item.active:nth-child(4) i, .nav-item.active:nth-child(4) .oxi-icon { color: #f0c800; }
-.nav-item.active:nth-child(5) i, .nav-item.active:nth-child(5) .oxi-icon { color: #e74c3c; }
+.nav-item.active:nth-child(5) i, .nav-item.active:nth-child(5) .oxi-icon { color: #e84393; }
+.nav-item.active:nth-child(6) i, .nav-item.active:nth-child(6) .oxi-icon { color: #e74c3c; }
 
 .nav-item:hover i,
 .nav-item:hover .oxi-icon {


### PR DESCRIPTION
## Problem
The sidebar navigation had incorrect CSS selectors for nav item colors. When the Photos menu item was added as the 5th nav item, the CSS wasn't updated to account for this change, causing the Trash item (now 6th) to have incorrect styling.

## Fix
- Added color styling for the Photos nav item (5th child) - pink color
- Updated Trash nav item styling to use :nth-child(6) instead of :nth-child(5)
- Added corresponding active state colors for both positions

## Changes
- `static/css/layout/sidebar.css`: Updated :nth-child() selectors for nav item icon colors

Fixes #194