### PR TITLE
docs: fix incorrect branch path in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Enhancement suggestions are welcome! Please include:
    ```
 5. Commit your changes with a descriptive message
 6. Push to your branch
-7. Create a Pull Request to the `dev` branch
+7. Create a Pull Request to the `main` branch
 
 ### Development Guidelines
 


### PR DESCRIPTION
The CONTRIBUTING.md referenced the `dev` branch for pull requests, but the repository's default branch is `main`. Updated to point to the correct branch.

Fixes #201