### PR TITLE
fix(ci): add PostgreSQL service to Docker publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,10 +18,32 @@ jobs:
   test:
     name: Pre-publish Tests
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: oxicloud_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: "postgres://postgres:postgres@localhost/oxicloud_test"
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+
+      - name: Initialize test database
+        run: psql -h localhost -U postgres -d oxicloud_test -f migrations/20260307000000_initial_schema.sql
+        env:
+          PGPASSWORD: postgres
+
       - run: cargo test --workspace
 
   # Build and push multi-arch image in a single job


### PR DESCRIPTION
## Description

The Docker Hub Release workflow (`docker-publish.yml`) was failing because the test job lacked the PostgreSQL service required by `cargo test`. This prevented the Docker image from being built and published when tags were pushed (e.g., v0.5.2).

## Related Issue

Fixes #193

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The PostgreSQL service configuration matches the working setup in `ci.yml`. YAML syntax validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
