### PR TITLE
fix(i18n): use translation keys for upload notification titles

### DIFF
--- a/static/js/core/notifications.js
+++ b/static/js/core/notifications.js
@@ -143,11 +143,11 @@ const notifications = (() => {
         item.className = 'notif-item';
         item.id = batchId;
 
-        const locale = window.i18n?.getCurrentLocale?.() || 'en';
+        const t = window.i18n?.t || ((k) => k);
         const uploadingText = folderName
-            ? (locale.startsWith('es') ? `📁 Subiendo ${_esc(folderName)}…` : `📁 Uploading ${_esc(folderName)}…`)
-            : (locale.startsWith('es') ? 'Subiendo…' : 'Uploading…');
-        const filesLabel = locale.startsWith('es') ? 'archivos' : 'files';
+            ? `📁 ${t('upload.uploading')} ${_esc(folderName)}…`
+            : t('upload.uploading');
+        const filesLabel = t('upload.files');
 
         item.innerHTML = `
             <div class="notif-item-icon upload"><i class="fas fa-cloud-upload-alt"></i></div>
@@ -254,8 +254,8 @@ const notifications = (() => {
         const pctEl   = $(batchId + '-pct');
         const statsEl = $(batchId + '-stats');
 
-        const locale = window.i18n?.getCurrentLocale?.() || 'en';
-        const filesLabel = locale.startsWith('es') ? 'archivos' : 'files';
+        const t = window.i18n?.t || ((k) => k);
+        const filesLabel = t('upload.files');
 
         if (fillEl)  fillEl.style.width = pctVal + '%';
         if (pctEl)   pctEl.textContent = pctVal + '%';
@@ -282,11 +282,9 @@ const notifications = (() => {
         const curEl = $(batchId + '-current');
         if (curEl) curEl.textContent = '';
 
-        const locale = window.i18n?.getCurrentLocale?.() || 'en';
-        const filesLabel = locale.startsWith('es') ? 'archivos' : 'files';
-        const completeText = locale.startsWith('es')
-            ? `✅ ${successCount} / ${totalFiles} ${filesLabel} subidos`
-            : `✅ ${successCount} / ${totalFiles} ${filesLabel} uploaded`;
+        const t = window.i18n?.t || ((k) => k);
+        const filesLabel = t('upload.files');
+        const completeText = t('upload.complete', { count: successCount, total: totalFiles });
         if (titleEl) titleEl.textContent = completeText;
 
         if (iconEl) {

--- a/static/locales/ar.json
+++ b/static/locales/ar.json
@@ -27,6 +27,7 @@
     "upload_folder": "رفع مجلد",
     "upload.uploading": "جارٍ الرفع...",
     "upload.complete": "{count} / {total} تم رفعها",
+    "upload.files": "ملفات",
     "rename": "إعادة التسمية",
     "move": "نقل إلى...",
     "move_to": "نقل إلى",

--- a/static/locales/de.json
+++ b/static/locales/de.json
@@ -27,6 +27,7 @@
     "upload_folder": "Ordner hochladen",
     "upload.uploading": "Wird hochgeladen...",
     "upload.complete": "{count} / {total} hochgeladen",
+    "upload.files": "Dateien",
     "rename": "Umbenennen",
     "move": "Verschieben nach...",
     "move_to": "Verschieben nach",

--- a/static/locales/en.json
+++ b/static/locales/en.json
@@ -27,6 +27,7 @@
     "upload_folder": "Upload folder",
     "upload.uploading": "Uploading...",
     "upload.complete": "{count} / {total} uploaded",
+    "upload.files": "files",
     "rename": "Rename",
     "move": "Move to...",
     "move_to": "Move to",

--- a/static/locales/es.json
+++ b/static/locales/es.json
@@ -146,6 +146,7 @@
     "upload_folder": "Subir carpeta",
     "upload.uploading": "Subiendo...",
     "upload.complete": "{count} / {total} subidos",
+    "upload.files": "archivos",
     "rename": "Renombrar",
     "move": "Mover a...",
     "move_to": "Mover a",

--- a/static/locales/fa.json
+++ b/static/locales/fa.json
@@ -27,6 +27,7 @@
     "upload_folder": "بارگذاری پوشه",
     "upload.uploading": "...در حال بارگذاری",
     "upload.complete": "{count} / {total} بارگذاری شد",
+    "upload.files": "فایل‌ها",
     "rename": "تغییر نام",
     "move": "انتقال به...",
     "move_to": "انتقال به",

--- a/static/locales/fr.json
+++ b/static/locales/fr.json
@@ -27,6 +27,7 @@
     "upload_folder": "Téléverser un dossier",
     "upload.uploading": "Envoi en cours...",
     "upload.complete": "{count} / {total} envoyés",
+    "upload.files": "fichiers",
     "rename": "Renommer",
     "move": "Déplacer vers...",
     "move_to": "Déplacer vers",

--- a/static/locales/hi.json
+++ b/static/locales/hi.json
@@ -27,6 +27,7 @@
     "upload_folder": "फ़ोल्डर अपलोड करें",
     "upload.uploading": "अपलोड हो रहा है...",
     "upload.complete": "{count} / {total} अपलोड हुईं",
+    "upload.files": "फ़ाइलें",
     "rename": "नाम बदलें",
     "move": "यहाँ ले जाएँ...",
     "move_to": "यहाँ ले जाएँ",

--- a/static/locales/it.json
+++ b/static/locales/it.json
@@ -27,6 +27,7 @@
     "upload_folder": "Carica cartella",
     "upload.uploading": "Caricamento...",
     "upload.complete": "{count} / {total} caricati",
+    "upload.files": "file",
     "rename": "Rinomina",
     "move": "Sposta in...",
     "move_to": "Sposta in",

--- a/static/locales/ja.json
+++ b/static/locales/ja.json
@@ -27,6 +27,7 @@
     "upload_folder": "フォルダをアップロード",
     "upload.uploading": "アップロード中...",
     "upload.complete": "{count} / {total} アップロード完了",
+    "upload.files": "ファイル",
     "rename": "名前を変更",
     "move": "移動先...",
     "move_to": "移動先",

--- a/static/locales/ko.json
+++ b/static/locales/ko.json
@@ -27,6 +27,7 @@
     "upload_folder": "폴더 업로드",
     "upload.uploading": "업로드 중...",
     "upload.complete": "{count} / {total} 업로드 완료",
+    "upload.files": "파일",
     "rename": "이름 변경",
     "move": "이동...",
     "move_to": "이동 대상",

--- a/static/locales/nl.json
+++ b/static/locales/nl.json
@@ -27,6 +27,7 @@
     "upload_folder": "Map uploaden",
     "upload.uploading": "Uploaden...",
     "upload.complete": "{count} / {total} geüpload",
+    "upload.files": "bestanden",
     "rename": "Hernoemen",
     "move": "Verplaatsen naar...",
     "move_to": "Verplaatsen naar",

--- a/static/locales/pt.json
+++ b/static/locales/pt.json
@@ -27,6 +27,7 @@
     "upload_folder": "Enviar pasta",
     "upload.uploading": "Enviando...",
     "upload.complete": "{count} / {total} enviados",
+    "upload.files": "arquivos",
     "rename": "Renomear",
     "move": "Mover para...",
     "move_to": "Mover para",

--- a/static/locales/ru.json
+++ b/static/locales/ru.json
@@ -27,6 +27,7 @@
     "upload_folder": "Загрузить папку",
     "upload.uploading": "Загрузка...",
     "upload.complete": "{count} / {total} загружено",
+    "upload.files": "файлов",
     "rename": "Переименовать",
     "move": "Переместить в...",
     "move_to": "Переместить в",

--- a/static/locales/zh.json
+++ b/static/locales/zh.json
@@ -27,6 +27,7 @@
     "upload_folder": "上传文件夹",
     "upload.uploading": "上传中...",
     "upload.complete": "{count} / {total} 已上传",
+    "upload.files": "文件",
     "rename": "重命名",
     "move": "移动到...",
     "move_to": "移动到",


### PR DESCRIPTION
## Description

Fixes #108 - The upload notification title shows "upload.uploading" instead of the localized content.

The upload notification system was using hardcoded English/Spanish strings instead of the i18n translation system. This caused non-localized text to be displayed for languages other than English and Spanish.

## Changes

- Added `upload.files` translation key to all 14 locale files (en, es, de, fr, pt, it, nl, zh, fa, ja, ko, ru, hi, ar)
- Updated `notifications.js` to use `window.i18n.t()` for:
  - `upload.uploading` - The upload title text
  - `upload.files` - The file count label
  - `upload.complete` - The completion message

## Testing

- Verified JavaScript syntax with `node --check`
- Verified all JSON locale files are valid
- The fix properly uses the existing i18n infrastructure

## Related Issue

Closes #108