### PR TITLE
fix(ui): resolve dark mode toggle and file search errors

### DIFF
--- a/static/js/app/searchView.js
+++ b/static/js/app/searchView.js
@@ -27,12 +27,16 @@ async function performSearch(query, sortBy) {
         };
 
         if (!app.isTrashView) {
-            options.folder_id = app.currentPath;
-
-            if (!options.folder_id || options.folder_id === '') {
+            // Ensure we have a valid folder_id before searching
+            if (!app.currentPath || app.currentPath === '') {
                 await window.resolveHomeFolder();
+            }
+
+            // Only set folder_id if we have a valid value
+            if (app.currentPath && app.currentPath !== '') {
                 options.folder_id = app.currentPath;
             }
+            // If still no valid folder_id, search will be global (without folder_id)
         }
 
         const searchResults = await window.search.searchFiles(query, options);

--- a/static/js/app/userMenu.js
+++ b/static/js/app/userMenu.js
@@ -52,24 +52,54 @@ function setupUserMenu() {
 
     if (themeBtn) {
         const pill = document.getElementById('theme-toggle-pill');
-        const isDark = localStorage.getItem('oxicloud_theme') === 'dark';
-        if (isDark) {
-            if (pill) pill.classList.add('active');
-            document.documentElement.setAttribute('data-theme', 'dark');
+
+        // Sync pill UI with current theme state
+        function syncThemePill() {
+            const isDark = localStorage.getItem('oxicloud_theme') === 'dark';
+            if (pill) {
+                if (isDark) {
+                    pill.classList.add('active');
+                } else {
+                    pill.classList.remove('active');
+                }
+            }
+            // Ensure document theme matches localStorage
+            if (isDark) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            } else {
+                document.documentElement.removeAttribute('data-theme');
+            }
         }
+
+        // Initialize pill state on load
+        syncThemePill();
 
         themeBtn.addEventListener('click', (e) => {
             e.stopPropagation();
-            if (pill) {
-                pill.classList.toggle('active');
-                const dark = pill.classList.contains('active');
-                localStorage.setItem('oxicloud_theme', dark ? 'dark' : 'light');
-                document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
-                window.ui.showNotification(
-                    dark ? '🌙' : '☀️',
-                    dark ? 'Dark mode enabled' : 'Light mode enabled'
-                );
+            // Toggle theme based on current state, not pill state
+            const currentIsDark = localStorage.getItem('oxicloud_theme') === 'dark';
+            const newIsDark = !currentIsDark;
+
+            localStorage.setItem('oxicloud_theme', newIsDark ? 'dark' : 'light');
+
+            if (newIsDark) {
+                document.documentElement.setAttribute('data-theme', 'dark');
+            } else {
+                document.documentElement.removeAttribute('data-theme');
             }
+
+            if (pill) {
+                if (newIsDark) {
+                    pill.classList.add('active');
+                } else {
+                    pill.classList.remove('active');
+                }
+            }
+
+            window.ui.showNotification(
+                newIsDark ? '🌙' : '☀️',
+                newIsDark ? 'Dark mode enabled' : 'Light mode enabled'
+            );
         });
     }
 


### PR DESCRIPTION
## Description

This PR fixes two UI issues reported in #102:

### 1. Dark Mode Toggle Not Working
The theme toggle button was not responding correctly because the theme state was being derived from the UI pill's CSS class rather than from localStorage. This could cause the toggle to get out of sync with the actual theme.

**Changes:**
- Added `syncThemePill()` function to ensure the UI pill and document theme always match localStorage state
- Toggle now derives new theme from current localStorage state instead of pill state
- Properly handles both enabling and disabling dark mode

### 2. File Search Returning Error
When the user's home folder hadn't been resolved yet (`currentPath` was empty), the search would send an empty string as `folder_id` to the backend, which expected a valid UUID format.

**Changes:**
- Check and resolve home folder before searching if needed
- Only set `folder_id` in search options when it contains a valid value
- When no valid `folder_id` is available, search operates globally (omitting the parameter)

## Related Issue
Fixes #102

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- All 207 existing tests pass
- Verified dark mode toggle correctly switches between light and dark themes
- Verified search works both with and without a resolved home folder

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes