### PR TITLE
fix(css): align size values in table view

### DIFF
--- a/static/css/components/fileList.css
+++ b/static/css/components/fileList.css
@@ -316,6 +316,7 @@
 	color: #718096;
 	font-size: 14px;
 	text-align: right;
+	font-variant-numeric: tabular-nums;
 }
 
 .file-item .type-cell {


### PR DESCRIPTION
## Description

Fixes size value misalignment in the file list table view by adding `font-variant-numeric: tabular-nums` to the size-cell CSS class. This ensures numeric characters use equal-width glyphs, aligning values like "1 B", "2.5 KB", and "100 MB" properly.

## Related Issue

Fixes #101

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Verified CSS syntax is valid
- Change is minimal and targeted to the reported issue

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings