### PR TITLE
fix(webdav): enforce storage quota on WebDAV PUT uploads

### DIFF
--- a/src/interfaces/api/handlers/webdav_handler.rs
+++ b/src/interfaces/api/handlers/webdav_handler.rs
@@ -23,6 +23,7 @@ use crate::application::dtos::folder_dto::FolderDto;
 use crate::application::ports::file_ports::FileRetrievalUseCase;
 use crate::application::ports::file_ports::{FileManagementUseCase, FileUploadUseCase};
 use crate::application::ports::inbound::FolderUseCase;
+use crate::application::ports::storage_ports::StorageUsagePort;
 use crate::application::services::file_retrieval_service::FileRetrievalService;
 use crate::application::services::folder_service::FolderService;
 use crate::common::di::AppState;
@@ -919,6 +920,27 @@ async fn handle_put(
     drop(file);
 
     let hash = hasher.finalize().to_hex().to_string();
+
+    // ── Quota enforcement ────────────────────────────────────
+    if let Some(storage_svc) = state.storage_usage_service.as_ref() {
+        if let Err(err) = storage_svc
+            .check_storage_quota(user.id, total_bytes as u64)
+            .await
+        {
+            let _ = tokio::fs::remove_file(&temp_path).await;
+            tracing::warn!(
+                "⛔ WEBDAV PUT REJECTED (quota): user={}, file={}, size={}",
+                user.id,
+                path,
+                total_bytes
+            );
+            return Err(AppError::new(
+                StatusCode::INSUFFICIENT_STORAGE,
+                err.message,
+                "QuotaExceeded",
+            ));
+        }
+    }
 
     // ── Atomic store: temp file → dedup blob + DB metadata update ──
     let result = file_upload_service


### PR DESCRIPTION
Fixes #104

## Problem
The WebDAV PUT handler was missing storage quota enforcement that exists in other upload handlers (regular file upload and chunked upload). This allowed users to bypass storage quotas when uploading via WebDAV.

## Solution
Added quota checking to the WebDAV PUT handler (`handle_put` in `webdav_handler.rs`).

The quota check happens:
1. After the file is fully spooled to a temp file (so we know the exact size)
2. Before the file is moved to permanent storage

If the quota is exceeded:
- The temp file is cleaned up
- A 507 Insufficient Storage error is returned with a descriptive message
- The upload is rejected before any permanent changes are made

## Changes
- Added import for `StorageUsagePort` trait
- Added quota enforcement block before atomic store operation
- Proper cleanup of temp file on quota violation

## Testing
- Code compiles successfully (`cargo check` passes)
- Follows existing patterns from `file_handler.rs` and `chunked_upload_handler.rs`

---
cc @DioCrafts