### PR TITLE
fix(webdav): preserve correct status codes for file rename/move failures

### DIFF
--- a/src/interfaces/api/handlers/webdav_handler.rs
+++ b/src/interfaces/api/handlers/webdav_handler.rs
@@ -1236,9 +1236,7 @@ async fn handle_move(
                 folder_service
                     .move_folder(&folder.id, move_dto, user.id)
                     .await
-                    .map_err(|e| {
-                        AppError::internal_error(format!("Failed to move folder: {}", e))
-                    })?;
+                    .map_err(AppError::from)?;
 
                 if folder.name != dest_folder_name {
                     let rename_dto = crate::application::dtos::folder_dto::RenameFolderDto {
@@ -1247,9 +1245,7 @@ async fn handle_move(
                     folder_service
                         .rename_folder(&folder.id, rename_dto, user.id)
                         .await
-                        .map_err(|e| {
-                            AppError::internal_error(format!("Failed to rename folder: {}", e))
-                        })?;
+                        .map_err(AppError::from)?;
                 }
             }
             Ok(ResolvedResource::File(file)) => {
@@ -1283,17 +1279,13 @@ async fn handle_move(
                     file_management_service
                         .move_file(&file.id, Some(dest_parent_path.to_string()))
                         .await
-                        .map_err(|e| {
-                            AppError::internal_error(format!("Failed to move file: {}", e))
-                        })?;
+                        .map_err(AppError::from)?;
                 }
                 if file.name != dest_filename {
                     file_management_service
                         .rename_file(&file.id, dest_filename)
                         .await
-                        .map_err(|e| {
-                            AppError::internal_error(format!("Failed to rename file: {}", e))
-                        })?;
+                        .map_err(AppError::from)?;
                 }
             }
             Err(_) => {
@@ -1354,9 +1346,7 @@ async fn handle_move(
                 folder_service
                     .rename_folder(&folder.id, rename_dto, user.id)
                     .await
-                    .map_err(|e| {
-                        AppError::internal_error(format!("Failed to rename folder: {}", e))
-                    })?;
+                    .map_err(AppError::from)?;
             }
         } else {
             let file = file_retrieval_service
@@ -1396,15 +1386,13 @@ async fn handle_move(
                 file_management_service
                     .move_file(&file.id, Some(dest_parent_path.to_string()))
                     .await
-                    .map_err(|e| AppError::internal_error(format!("Failed to move file: {}", e)))?;
+                    .map_err(AppError::from)?;
             }
             if file.name != dest_filename {
                 file_management_service
                     .rename_file(&file.id, dest_filename)
                     .await
-                    .map_err(|e| {
-                        AppError::internal_error(format!("Failed to rename file: {}", e))
-                    })?;
+                    .map_err(AppError::from)?;
             }
         }
     }


### PR DESCRIPTION
WebDAV handlers were converting all file and folder rename/move errors to HTTP 500 Internal Server Error. This masked specific error types that clients need to handle properly:

- AlreadyExists (duplicate name) → should return 409 CONFLICT
- NotFound (missing resource) → should return 404 NOT FOUND  
- AccessDenied (permission denied) → should return 403 FORBIDDEN

Changed error handling from AppError::internal_error() to AppError::from() which preserves the original DomainError type and maps to the correct HTTP status code.

All 207 existing tests pass.