### PR TITLE
fix(share): correct shared link URL to include /api prefix

### DIFF
--- a/src/application/dtos/share_dto.rs
+++ b/src/application/dtos/share_dto.rs
@@ -45,7 +45,7 @@ pub struct UpdateShareDto {
 /// Extension methods to convert between DTOs and domain entities
 impl ShareDto {
     pub fn from_entity(share: &Share, base_url: &str) -> Self {
-        let url = format!("{}/s/{}", base_url, share.token());
+        let url = format!("{}/api/s/{}", base_url, share.token());
 
         Self {
             id: share.id().to_string(),

--- a/src/application/services/share_service.rs
+++ b/src/application/services/share_service.rs
@@ -1135,6 +1135,6 @@ mod tests {
         assert_eq!(share_dto.item_id, "test_file_id");
         assert_eq!(share_dto.item_type, "file");
         assert!(share_dto.has_password);
-        assert!(share_dto.url.starts_with("http://127.0.0.1:8086/s/"));
+        assert!(share_dto.url.starts_with("http://127.0.0.1:8086/api/s/"));
     }
 }


### PR DESCRIPTION
The shared link URL was generated as `{base_url}/s/{token}` but the API endpoint is actually at `/api/s/{token}`. This caused 404 errors when users accessed shared links.

Fixes #101