### PR TITLE
fix: improve error messages for file/folder already exists

### DIFF
--- a/src/infrastructure/repositories/pg/file_blob_write_repository.rs
+++ b/src/infrastructure/repositories/pg/file_blob_write_repository.rs
@@ -257,7 +257,7 @@ impl FileWritePort for FileBlobWriteRepository {
                 {
                     return Err(DomainError::already_exists(
                         "File",
-                        format!("{name} already exists in folder"),
+                        format!("'{name}' already exists in this folder"),
                     ));
                 }
                 return Err(DomainError::internal_error(
@@ -382,7 +382,7 @@ impl FileWritePort for FileBlobWriteRepository {
             {
                 return DomainError::already_exists(
                     "File",
-                    "File with that name already exists in target folder".to_string(),
+                    "a file with this name already exists in the target folder",
                 );
             }
             DomainError::internal_error("FileBlobWrite", format!("copy: {e}"))
@@ -440,7 +440,7 @@ impl FileWritePort for FileBlobWriteRepository {
             if let sqlx::Error::Database(ref db_err) = e
                 && db_err.code().as_deref() == Some("23505")
             {
-                return DomainError::already_exists("File", format!("{new_name} already exists"));
+                return DomainError::already_exists("File", format!("'{new_name}' already exists"));
             }
             DomainError::internal_error("FileBlobWrite", format!("rename: {e}"))
         })?
@@ -632,7 +632,7 @@ impl FileWritePort for FileBlobWriteRepository {
                 if db_err.code().as_deref() == Some("23505") {
                     return DomainError::already_exists(
                         "Folder",
-                        "A folder with that name already exists in the target".to_string(),
+                        "a folder with this name already exists in the target location",
                     );
                 }
             }


### PR DESCRIPTION
## Description

Fixed confusing error messages when copying or renaming files/folders to a location where an item with the same name already exists.

The `already_exists` error formatter produces messages like `File already exists: {message}`. Previously, the message parameter was a full sentence like "File with that name already exists in target folder", resulting in redundant output:
- Before: `File already exists: File with that name already exists in target folder`
- After: `File already exists: a file with this name already exists in the target folder`

Also improved messages for file upload and rename operations to use quoted filenames for clarity.

## Related Issue

Fixes #102

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- `cargo check` passes
- `cargo test` passes (207 tests)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
