### PR TITLE
fix: cap admin initial quota to available disk space

### DIFF
--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -736,14 +736,8 @@ impl AuthApplicationService {
             _ => UserRole::User,
         };
 
-        // Determine quota
-        let quota = dto.quota_bytes.unwrap_or_else(|| {
-            if role == UserRole::Admin {
-                107_374_182_400
-            } else {
-                1_073_741_824
-            }
-        });
+        // Determine quota, capped to available disk space
+        let quota = dto.quota_bytes.unwrap_or_else(|| self.capped_quota(&role));
 
         // Hash password
         let password_hash = self.password_hasher.hash_password(&dto.password).await?;


### PR DESCRIPTION
The admin registration flow sets an initial quota without checking available disk space. This PR caps the quota to the actual available space to prevent issues.

Fixes #92