### PR TITLE
fix(thumbnails): drop encoded image data after decoding to reduce memory

### DIFF
--- a/src/infrastructure/services/thumbnail_service.rs
+++ b/src/infrastructure/services/thumbnail_service.rs
@@ -347,8 +347,10 @@ impl ThumbnailService {
     /// Generate a thumbnail from an image file.
     ///
     /// Concurrency is bounded by `decode_semaphore` to prevent OOM when
-    /// many images are uploaded simultaneously.  Resolution is also
+    /// many images are uploaded simultaneously. Resolution is also
     /// capped at `MAX_DECODE_PIXELS` to reject pathologically large images.
+    /// After decoding, the encoded image buffer is explicitly dropped before
+    /// processing to minimize peak memory usage.
     async fn generate_thumbnail(
         &self,
         original_path: &Path,
@@ -395,6 +397,8 @@ impl ThumbnailService {
                 let orientation = ExifService::extract(&data)
                     .and_then(|m| m.orientation)
                     .unwrap_or(1);
+                // Free the encoded image data now that image is decoded and EXIF extracted
+                drop(data);
                 apply_orientation(img, orientation)
             };
 
@@ -436,9 +440,11 @@ impl ThumbnailService {
     /// Generate all thumbnail sizes for a file in the background.
     ///
     /// Loads the image **once** and produces all 3 sizes (Icon, Preview,
-    /// Large) inside a single `spawn_blocking` call.  This avoids 3×
+    /// Large) inside a single `spawn_blocking` call. This avoids 3×
     /// I/O reads and 3× JPEG/PNG decode — reducing CPU time by ~45%
     /// and peak RAM from ~540 MB to ~180 MB for concurrent uploads.
+    /// The encoded image buffer is explicitly dropped after decoding
+    /// to further reduce peak memory by the size of the original file.
     pub fn generate_all_sizes_background(self: Arc<Self>, file_id: String, original_path: PathBuf) {
         tokio::spawn(async move {
             tracing::info!("🖼️ Background thumbnail generation starting: {}", file_id);
@@ -488,6 +494,8 @@ impl ThumbnailService {
                     let orientation = ExifService::extract(&data)
                         .and_then(|m| m.orientation)
                         .unwrap_or(1);
+                    // Free the encoded image data now that image is decoded and EXIF extracted
+                    drop(data);
                     apply_orientation(img, orientation)
                 };
 


### PR DESCRIPTION
## Description

Explicitly drop the encoded image buffer after decoding and extracting EXIF orientation data. This reduces peak memory consumption during thumbnail generation by the size of the original file.

**Root Cause**: In both `generate_thumbnail` and `generate_all_sizes_background`, the encoded image data (`data: Vec<u8>`) was being held in memory for the entire duration of the `spawn_blocking` closure, even though it's no longer needed after the image is decoded into a `DynamicImage`. This effectively doubled memory usage during thumbnail generation - holding both the encoded bytes and the decoded image simultaneously.

**Fix**: Add explicit `drop(data)` after the image is decoded and EXIF orientation is extracted, before the image resizing operations begin.

## Related Issue

Fixes excessive memory consumption in thumbnail generation.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance improvement

## How Has This Been Tested?

Code compiles and follows existing patterns in the codebase. The change is minimal and only affects memory lifecycle, not logic.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
