### PR TITLE
fix(thumbnail): add timeout protection for large image processing

### DIFF
--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -34,15 +34,18 @@ pub struct TimeoutConfig {
     pub lock_acquisition_ms: u64,
     /// Timeout for network operations (ms)
     pub network_operation_ms: u64,
+    /// Timeout for thumbnail generation (ms)
+    pub thumbnail_generation_ms: u64,
 }
 
 impl Default for TimeoutConfig {
     fn default() -> Self {
         Self {
-            file_operation_ms: 10000,    // 10 seconds
-            dir_operation_ms: 30000,     // 30 seconds
-            lock_acquisition_ms: 5000,   // 5 seconds
-            network_operation_ms: 15000, // 15 seconds
+            file_operation_ms: 10000,      // 10 seconds
+            dir_operation_ms: 30000,       // 30 seconds
+            lock_acquisition_ms: 5000,     // 5 seconds
+            network_operation_ms: 15000,   // 15 seconds
+            thumbnail_generation_ms: 30000, // 30 seconds
         }
     }
 }
@@ -81,6 +84,11 @@ impl TimeoutConfig {
     /// Gets a Duration for network operations
     pub fn network_timeout(&self) -> Duration {
         Duration::from_millis(self.network_operation_ms)
+    }
+
+    /// Gets a Duration for thumbnail generation operations
+    pub fn thumbnail_timeout(&self) -> Duration {
+        Duration::from_millis(self.thumbnail_generation_ms)
     }
 }
 

--- a/src/common/di.rs
+++ b/src/common/di.rs
@@ -119,12 +119,13 @@ impl AppServiceFactory {
         }));
         tracing::info!("FileContentCache initialized: max 10MB/file, 512MB total, 10k entries");
 
-        // Thumbnail service for thumbnail generation
+        // Thumbnail service for thumbnail generation with timeout protection
         let thumbnail_service = Arc::new(
             crate::infrastructure::services::thumbnail_service::ThumbnailService::new(
                 &self.storage_path,
                 5000,              // max 5000 thumbnails in cache
                 100 * 1024 * 1024, // max 100MB cache
+                Some(self.config.timeouts.thumbnail_timeout()),
             ),
         );
         // Initialize thumbnail directories

--- a/src/infrastructure/services/thumbnail_service.rs
+++ b/src/infrastructure/services/thumbnail_service.rs
@@ -12,11 +12,14 @@ use image::imageops::FilterType;
  * - JPEG output (lossy q=80) for compact thumbnails
  * - Lock-free moka cache with weight-based eviction
  * - Lazy generation on first request if not pre-generated
+ * - Timeout protection for large image processing
  */
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::fs;
 use tokio::sync::Semaphore;
+use tokio::time::timeout;
 
 use crate::application::ports::thumbnail_ports::{
     ThumbnailPort, ThumbnailSize as PortThumbnailSize, ThumbnailStatsDto,
@@ -90,6 +93,9 @@ pub struct ThumbnailService {
     /// Without this, 50 simultaneous uploads would decode 50 bitmaps
     /// (~96 MB each for 6000×4000) = 4.8 GB peak.
     decode_semaphore: Arc<Semaphore>,
+    /// Timeout for thumbnail generation operations to prevent hanging on large images.
+    /// Defaults to 30 seconds.
+    generation_timeout: Duration,
 }
 
 impl ThumbnailService {
@@ -99,7 +105,13 @@ impl ThumbnailService {
     /// * `storage_root` - Root path of file storage
     /// * `max_cache_entries` - (ignored — moka uses weight-based eviction)
     /// * `max_cache_bytes` - Maximum total bytes to cache
-    pub fn new(storage_root: &Path, max_cache_entries: usize, max_cache_bytes: usize) -> Self {
+    /// * `generation_timeout` - Timeout for thumbnail generation operations
+    pub fn new(
+        storage_root: &Path,
+        max_cache_entries: usize,
+        max_cache_bytes: usize,
+        generation_timeout: Option<Duration>,
+    ) -> Self {
         let thumbnails_root = storage_root.join(".thumbnails");
 
         // Ignore max_cache_entries — weight-based eviction is more accurate
@@ -123,6 +135,7 @@ impl ThumbnailService {
             cache,
             max_cache_bytes: max_cache_bytes as u64,
             decode_semaphore: Arc::new(Semaphore::new(DEFAULT_MAX_CONCURRENT_DECODES)),
+            generation_timeout: generation_timeout.unwrap_or(Duration::from_secs(30)),
         }
     }
 
@@ -347,8 +360,9 @@ impl ThumbnailService {
     /// Generate a thumbnail from an image file.
     ///
     /// Concurrency is bounded by `decode_semaphore` to prevent OOM when
-    /// many images are uploaded simultaneously.  Resolution is also
+    /// many images are uploaded simultaneously. Resolution is also
     /// capped at `MAX_DECODE_PIXELS` to reject pathologically large images.
+    /// A timeout prevents the operation from hanging indefinitely on large images.
     async fn generate_thumbnail(
         &self,
         original_path: &Path,
@@ -356,6 +370,7 @@ impl ThumbnailService {
     ) -> Result<Bytes, ThumbnailError> {
         let path = original_path.to_path_buf();
         let max_dim = size.max_dimension();
+        let timeout_duration = self.generation_timeout;
 
         // Acquire semaphore permit — bounds peak RAM from concurrent decodes
         let _permit = self
@@ -364,8 +379,8 @@ impl ThumbnailService {
             .await
             .map_err(|_| ThumbnailError::TaskError("Decode semaphore closed".into()))?;
 
-        // Run image processing in blocking thread pool
-        let result = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, ThumbnailError> {
+        // Run image processing in blocking thread pool with timeout
+        let spawn_result = tokio::task::spawn_blocking(move || -> Result<Vec<u8>, ThumbnailError> {
             // Single read: load file once into memory, then work from the buffer
             let data =
                 std::fs::read(&path).map_err(|e| ThumbnailError::ImageError(e.to_string()))?;
@@ -426,9 +441,16 @@ impl ThumbnailService {
                 .map_err(|e| ThumbnailError::ImageError(e.to_string()))?;
 
             Ok(buffer)
-        })
-        .await
-        .map_err(|e| ThumbnailError::TaskError(e.to_string()))?;
+        });
+
+        // Apply timeout to prevent hanging on large images
+        let result = timeout(timeout_duration, spawn_result)
+            .await
+            .map_err(|_| ThumbnailError::TaskError(format!(
+                "Thumbnail generation timed out after {:?}",
+                timeout_duration
+            )))?
+            .map_err(|e| ThumbnailError::TaskError(e.to_string()))?;
 
         result.map(Bytes::from)
     }

--- a/src/infrastructure/services/thumbnail_service_test.rs
+++ b/src/infrastructure/services/thumbnail_service_test.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use super::thumbnail_service::{ThumbnailService, ThumbnailSize};
 
@@ -29,7 +30,12 @@ async fn generate_thumbnail_from_blob_path() {
     let blob_path = blob_dir.join("ab1234567890.blob");
     std::fs::write(&blob_path, tiny_png()).expect("write test blob");
 
-    let svc = Arc::new(ThumbnailService::new(storage_root, 100, 10 * 1024 * 1024));
+    let svc = Arc::new(ThumbnailService::new(
+        storage_root,
+        100,
+        10 * 1024 * 1024,
+        Some(Duration::from_secs(30)),
+    ));
     svc.initialize().await.expect("init thumbnail dirs");
 
     // The key assertion: the service can read from a blob path (not a logical path)
@@ -51,7 +57,12 @@ async fn generate_thumbnail_from_blob_path() {
 #[tokio::test]
 async fn generate_thumbnail_nonexistent_path_returns_error() {
     let tmp = tempfile::tempdir().expect("create temp dir");
-    let svc = Arc::new(ThumbnailService::new(tmp.path(), 100, 10 * 1024 * 1024));
+    let svc = Arc::new(ThumbnailService::new(
+        tmp.path(),
+        100,
+        10 * 1024 * 1024,
+        Some(Duration::from_secs(30)),
+    ));
     svc.initialize().await.expect("init thumbnail dirs");
 
     let bad_path = tmp.path().join("does-not-exist.png");


### PR DESCRIPTION
## Problem

Thumbnail generation for large images could hang indefinitely because there was no timeout protection on the `spawn_blocking` call that processes images.

## Solution

Add configurable timeout (default 30s) for thumbnail generation operations:

- Added `thumbnail_generation_ms` to `TimeoutConfig` with 30 second default
- Added `generation_timeout` field to `ThumbnailService`  
- Wrapped `spawn_blocking` call in `tokio::time::timeout` to prevent hanging
- Updated DI to pass timeout from config
- Updated tests to provide timeout parameter

## Testing

- `cargo check --lib` passes
- Code compiles with no new warnings

## Related

This fix prevents potential DoS issues where processing very large images could exhaust worker threads.