### PR TITLE
chore: static: if PROFILE=dev assets are directly /static without any…

### DIFF
--- a/src/interfaces/web/mod.rs
+++ b/src/interfaces/web/mod.rs
@@ -12,6 +12,18 @@ pub fn create_web_routes() -> Router<Arc<AppState>> {
     // Get config to access static path
     let config = AppConfig::from_env();
 
+    // XXX do we prefer PROFILE or ENV ?
+    let is_dev = std::env::var("PROFILE").is_ok_and(|profile| profile == "dev");
+
+    let assets_dir =
+        if is_dev {
+            // take directly the source (permits faster development)
+            "static"
+        } else {
+            // take the compiled assets
+            "static-dist"
+        };
+
     // In release builds, serve from static-dist/ (processed assets).
     // In debug builds, serve from the original static/ directory.
     let static_path = if cfg!(not(debug_assertions)) {
@@ -19,7 +31,7 @@ pub fn create_web_routes() -> Router<Arc<AppState>> {
             .static_path
             .parent()
             .unwrap_or(std::path::Path::new("."))
-            .join("static-dist");
+            .join(assets_dir );
         if dist.exists() {
             dist
         } else {
@@ -35,6 +47,14 @@ pub fn create_web_routes() -> Router<Arc<AppState>> {
     // do NOT pass through these layers.
     let static_service = ServeDir::new(&static_path);
 
+    // By default assets are cached in release/production environement and no cache in dev
+    let cache_control_value =
+        if is_dev {
+            "max-age=0, no-cache, no-store"
+        } else {
+            "public, max-age=604800, stale-while-revalidate=86400"
+        };
+
     Router::new()
         // Add specific routes for clean URLs (without .html)
         .route("/login", get(serve_login_page))
@@ -46,7 +66,7 @@ pub fn create_web_routes() -> Router<Arc<AppState>> {
         .layer(CompressionLayer::new().br(true).gzip(true))
         .layer(SetResponseHeaderLayer::if_not_present(
             CACHE_CONTROL,
-            HeaderValue::from_static("public, max-age=604800, stale-while-revalidate=86400"),
+            HeaderValue::from_static(cache_control_value), 
         ))
 }
 


### PR DESCRIPTION
This request fasten the test of any change in /static, 

usage:

```
PROFILE=dev cargo run
```
daemon will serve directly /static source without any cache