### PR TITLE
style: apply rust format + fix clippy warning

### DIFF
--- a/src/application/services/batch_operations_test.rs
+++ b/src/application/services/batch_operations_test.rs
@@ -7,9 +7,11 @@
 mod tests {
     use std::sync::Arc;
 
-    use crate::application::services::batch_operations::{BatchOperationService, BatchResult, BatchStats};
-    use crate::application::services::file_retrieval_service::FileRetrievalService;
+    use crate::application::services::batch_operations::{
+        BatchOperationService, BatchResult, BatchStats,
+    };
     use crate::application::services::file_management_service::FileManagementService;
+    use crate::application::services::file_retrieval_service::FileRetrievalService;
     use crate::application::services::folder_service::FolderService;
     use crate::common::config::AppConfig;
     use crate::infrastructure::repositories::pg::file_blob_read_repository::FileBlobReadRepository;
@@ -25,17 +27,24 @@ mod tests {
         let trash_result: Result<(), String> = Ok(());
         let id_for_result = folder_id.clone();
         let mapped = trash_result.map(|_| id_for_result);
-        
+
         assert!(mapped.is_ok(), "Ok result should remain Ok after mapping");
-        assert_eq!(mapped.unwrap(), folder_id, "Mapped result should contain the folder_id");
+        assert_eq!(
+            mapped.unwrap(),
+            folder_id,
+            "Mapped result should contain the folder_id"
+        );
 
         // Test Err maps to Err (preserved)
         let folder_id2 = "test-folder-id-2".to_string();
         let trash_result2: Result<(), String> = Err("Some error".to_string());
         let id_for_result2 = folder_id2.clone();
         let mapped2 = trash_result2.map(|_| id_for_result2);
-        
-        assert!(mapped2.is_err(), "Err result should remain Err after mapping");
+
+        assert!(
+            mapped2.is_err(),
+            "Err result should remain Err after mapping"
+        );
     }
 
     /// Test that batch result counting works correctly
@@ -56,16 +65,20 @@ mod tests {
         // Simulate processing 2 successes and 1 failure
         result.successful.push("id1".to_string());
         result.stats.successful += 1;
-        
+
         result.successful.push("id3".to_string());
         result.stats.successful += 1;
-        
+
         result.failed.push(("id2".to_string(), "error".to_string()));
         result.stats.failed += 1;
 
         assert_eq!(result.stats.successful, 2, "Should have 2 successful");
         assert_eq!(result.stats.failed, 1, "Should have 1 failed");
-        assert_eq!(result.successful.len(), 2, "Successful vector should have 2 items");
+        assert_eq!(
+            result.successful.len(),
+            2,
+            "Successful vector should have 2 items"
+        );
         assert_eq!(result.failed.len(), 1, "Failed vector should have 1 item");
     }
 
@@ -75,18 +88,18 @@ mod tests {
         let folder_repo = Arc::new(FolderDbRepository::new_stub());
         let file_read_repo = Arc::new(FileBlobReadRepository::new_stub());
         let file_write_repo = Arc::new(FileBlobWriteRepository::new_stub());
-        
+
         let file_retrieval = Arc::new(FileRetrievalService::new(file_read_repo));
         let file_management = Arc::new(FileManagementService::new(file_write_repo));
         let folder_service = Arc::new(FolderService::new(folder_repo));
-        
+
         let _batch_service = BatchOperationService::new(
             file_retrieval,
             file_management,
             folder_service,
             AppConfig::default(),
         );
-        
+
         // Service created successfully
     }
 }

--- a/src/application/services/file_management_service.rs
+++ b/src/application/services/file_management_service.rs
@@ -139,7 +139,8 @@ impl FileManagementUseCase for FileManagementService {
         // Verify file ownership first
         self.verify_owner(file_id, caller_id).await?;
         // Verify target folder ownership (prevents file from "disappearing")
-        self.verify_target_folder_owner(&folder_id, caller_id).await?;
+        self.verify_target_folder_owner(&folder_id, caller_id)
+            .await?;
         self.move_file(file_id, folder_id).await
     }
 

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -215,9 +215,9 @@ impl Default for StorageConfig {
         };
         Self {
             root_dir: "storage".to_string(),
-            chunk_size: 1024 * 1024,                  // 1 MB
-            parallel_threshold: 100 * 1024 * 1024,    // 100 MB
-            trash_retention_days: 30,                 // 30 days
+            chunk_size: 1024 * 1024,               // 1 MB
+            parallel_threshold: 100 * 1024 * 1024, // 100 MB
+            trash_retention_days: 30,              // 30 days
             max_upload_size: MAX_UPLOAD_SIZE,
         }
     }

--- a/src/domain/entities/calendar.rs
+++ b/src/domain/entities/calendar.rs
@@ -333,12 +333,7 @@ mod tests {
     #[test]
     fn test_init_bad_color_1() {
         let owner_id = Uuid::new_v4();
-        let res = Calendar::new(
-            "Name".to_string(),
-            owner_id,
-            None,
-            Some("foo".to_string()),
-        );
+        let res = Calendar::new("Name".to_string(), owner_id, None, Some("foo".to_string()));
         assert!(res.is_err());
     }
 

--- a/src/interfaces/api/handlers/webdav_handler.rs
+++ b/src/interfaces/api/handlers/webdav_handler.rs
@@ -922,24 +922,23 @@ async fn handle_put(
     let hash = hasher.finalize().to_hex().to_string();
 
     // ── Quota enforcement ────────────────────────────────────
-    if let Some(storage_svc) = state.storage_usage_service.as_ref() {
-        if let Err(err) = storage_svc
+    if let Some(storage_svc) = state.storage_usage_service.as_ref()
+        && let Err(err) = storage_svc
             .check_storage_quota(user.id, total_bytes as u64)
             .await
-        {
-            let _ = tokio::fs::remove_file(&temp_path).await;
-            tracing::warn!(
-                "⛔ WEBDAV PUT REJECTED (quota): user={}, file={}, size={}",
-                user.id,
-                path,
-                total_bytes
-            );
-            return Err(AppError::new(
-                StatusCode::INSUFFICIENT_STORAGE,
-                err.message,
-                "QuotaExceeded",
-            ));
-        }
+    {
+        let _ = tokio::fs::remove_file(&temp_path).await;
+        tracing::warn!(
+            "⛔ WEBDAV PUT REJECTED (quota): user={}, file={}, size={}",
+            user.id,
+            path,
+            total_bytes
+        );
+        return Err(AppError::new(
+            StatusCode::INSUFFICIENT_STORAGE,
+            err.message,
+            "QuotaExceeded",
+        ));
     }
 
     // ── Atomic store: temp file → dedup blob + DB metadata update ──

--- a/src/interfaces/web/mod.rs
+++ b/src/interfaces/web/mod.rs
@@ -15,14 +15,13 @@ pub fn create_web_routes() -> Router<Arc<AppState>> {
     // XXX do we prefer PROFILE or ENV ?
     let is_dev = std::env::var("PROFILE").is_ok_and(|profile| profile == "dev");
 
-    let assets_dir =
-        if is_dev {
-            // take directly the source (permits faster development)
-            "static"
-        } else {
-            // take the compiled assets
-            "static-dist"
-        };
+    let assets_dir = if is_dev {
+        // take directly the source (permits faster development)
+        "static"
+    } else {
+        // take the compiled assets
+        "static-dist"
+    };
 
     // In release builds, serve from static-dist/ (processed assets).
     // In debug builds, serve from the original static/ directory.
@@ -31,7 +30,7 @@ pub fn create_web_routes() -> Router<Arc<AppState>> {
             .static_path
             .parent()
             .unwrap_or(std::path::Path::new("."))
-            .join(assets_dir );
+            .join(assets_dir);
         if dist.exists() {
             dist
         } else {
@@ -48,12 +47,11 @@ pub fn create_web_routes() -> Router<Arc<AppState>> {
     let static_service = ServeDir::new(&static_path);
 
     // By default assets are cached in release/production environement and no cache in dev
-    let cache_control_value =
-        if is_dev {
-            "max-age=0, no-cache, no-store"
-        } else {
-            "public, max-age=604800, stale-while-revalidate=86400"
-        };
+    let cache_control_value = if is_dev {
+        "max-age=0, no-cache, no-store"
+    } else {
+        "public, max-age=604800, stale-while-revalidate=86400"
+    };
 
     Router::new()
         // Add specific routes for clean URLs (without .html)
@@ -66,7 +64,7 @@ pub fn create_web_routes() -> Router<Arc<AppState>> {
         .layer(CompressionLayer::new().br(true).gzip(true))
         .layer(SetResponseHeaderLayer::if_not_present(
             CACHE_CONTROL,
-            HeaderValue::from_static(cache_control_value), 
+            HeaderValue::from_static(cache_control_value),
         ))
 }
 


### PR DESCRIPTION
apply rust format + fix clippy warning
```
error: this `if` statement can be collapsed
   --> src/interfaces/api/handlers/webdav_handler.rs:925:5
    |
925 | /     if let Some(storage_svc) = state.storage_usage_service.as_ref() {
926 | |         if let Err(err) = storage_svc
927 | |             .check_storage_quota(user.id, total_bytes as u64)
928 | |             .await
...   |
943 | |     }
    | |_____^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#collapsible_if
    = note: `-D clippy::collapsible-if` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::collapsible_if)]`
help: collapse nested if block
    |
925 ~     if let Some(storage_svc) = state.storage_usage_service.as_ref()
926 ~         && let Err(err) = storage_svc
927 |             .check_storage_quota(user.id, total_bytes as u64)
...
941 |             ));
942 ~         }
    |

```