### PR TITLE
fix blank login page regression

### DIFF
--- a/static/css/base/reset.css
+++ b/static/css/base/reset.css
@@ -22,6 +22,5 @@ html[dir="rtl"] .fa-sign-out-alt {
 }
 /* Utility: hide elements without inline style="" (CSP-safe) */
 .hidden {
-    /* biome-ignore lint/complexity/noImportantStyles: this case to overide the display when hiddenis selected */
-    display: none !important;
+    display: none;
 }


### PR DESCRIPTION
## Description

Removing `!important` from the `.hidden` class in `reset.css` allows JS to override the `display: none` property using inline styles.

Previously, the `!important` flag caused all UI panels to remain invisible after initialization, resulting in a blank /login screen.

## Related Issue

Fixes #265 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

Clean install of 0.5.4 on a k8s cluster with helm results in the blank login page.

> Caution! The following custom image is based on `main` branch, which contains new database migrations. You will not be able to downgrade to 0.5.4.

Switching to `docker.io/kabakaev/oxicloud:fix-blank-login-page` image fixes the issue. 

```bash
npx @biomejs/biome lint static/css/base/reset.css
Checked 1 file in 1779µs. No fixes applied.

npx -y @biomejs/biome check . --max-diagnostics 500
Checked 101 files in 142ms. No fixes applied.
Found 8 errors.
Found 48 warnings.
Found 8 infos.

cargo test --workspace && echo Passed || echo Failed
Passed
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules