### PR TITLE
fix(style): correct file list display (was overlapped by header)

### DIFF
--- a/static/css/components/cards.css
+++ b/static/css/components/cards.css
@@ -22,6 +22,10 @@
     display: none;
 }
 
+.files-container {
+    padding-top: 3px; /* due to cards animation on mouse hover and page-sticky-header with a positive z-index */
+}
+
 .files-grid-view .file-item {
     background-color: white;
     border-radius: 12px;


### PR DESCRIPTION
fix mouseover & overlap:

<img width="675" height="416" alt="Capture d’écran 2026-04-11 à 18 15 08" src="https://github.com/user-attachments/assets/4e757451-2630-4f0a-a06d-1af98521f899" />
