### PR TITLE
Change PostgreSQL data directory to /var/lib/postgresql/

### DIFF
--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -34,7 +34,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/
       - ./db/schema.sql:/docker-entrypoint-initdb.d/schema.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/doc/wopi-integration.md
+++ b/doc/wopi-integration.md
@@ -1039,7 +1039,7 @@ services:
     networks:
       - oxicloud
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/
       - ./db/schema.sql:/docker-entrypoint-initdb.d/10-schema.sql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     networks:
       - oxicloud
     volumes:
-      - pg_data:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s


### PR DESCRIPTION
## Description

Starting with PostgreSQL 18, the data directory (`PGDATA`) of the Docker Image has changed to be version specific. For PostgreSQL 18 it is `/var/lib/postgresql/18/docker/`.

This means that to persist data, mounts and volumes should target the new location: `/var/lib/postgresql/`.

## Related Issue

Fixes DioCrafts/OxiCloud#281.

## Type of Change

Please check the option that best describes your change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Documentation update

## How Has This Been Tested?

Updated my `docker-compose.yml` with the new location for `PGDATA`: the database is now persisted across containers restart

## Checklist:

This PR changes only the reference Docker Compose and the documentation.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules