### PR TITLE
add WWW-Authenticate handshake for spec-compliancy 

### DIFF
--- a/src/interfaces/middleware/auth.rs
+++ b/src/interfaces/middleware/auth.rs
@@ -238,6 +238,21 @@ pub async fn auth_middleware(
                         }
                         Err(e) => {
                             tracing::warn!("App password verification failed: {}", e);
+                            // For WebDAV: include WWW-Authenticate so the client
+                            // knows to re-prompt rather than silently failing.
+                            if request.uri().path().starts_with("/webdav") {
+                                return Ok(Response::builder()
+                                    .status(StatusCode::UNAUTHORIZED)
+                                    .header(
+                                        header::WWW_AUTHENTICATE,
+                                        r#"Basic realm="OxiCloud""#,
+                                    )
+                                    .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+                                    .body(axum::body::Body::from(
+                                        "Invalid username or app password",
+                                    ))
+                                    .unwrap());
+                            }
                             return Err(AuthError::InvalidToken(
                                 "Invalid username or app password".to_string(),
                             ));
@@ -291,10 +306,24 @@ pub async fn auth_middleware(
         }
     }
 
-    // No valid credentials found via any method
+    // No valid credentials found via any method.
     if state.auth_service.is_none() {
         tracing::error!("Auth middleware invoked but auth service is not configured");
         return Err(AuthError::AuthServiceUnavailable);
+    }
+
+    // For WebDAV requests with no credentials at all: return 401 with
+    // WWW-Authenticate so that spec-compliant clients (Nautilus, Cyberduck,
+    // Windows Explorer, macOS Finder) know to prompt for a username/password.
+    // Non-WebDAV routes return the standard AuthError which renders without
+    // this header — keeping browser sessions redirecting to /login as before.
+    if request.uri().path().starts_with("/webdav") {
+        return Ok(Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header(header::WWW_AUTHENTICATE, r#"Basic realm="OxiCloud""#)
+            .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
+            .body(axum::body::Body::from("Authentication required"))
+            .unwrap());
     }
 
     Err(AuthError::TokenNotProvided)


### PR DESCRIPTION
fixes https://github.com/DioCrafts/OxiCloud/issues/276 - especially nautilus and other spec-compliant browsers. Before was killed silently without prompt or modal


<img width="581" height="538" alt="image" src="https://github.com/user-attachments/assets/bbfde4d9-5418-4261-b0a7-07492810ef87" />

<img width="586" height="551" alt="Screenshot from 2026-04-13 02-19-52" src="https://github.com/user-attachments/assets/28dfd0ef-1841-437c-b6b3-4572c22a199f" />

