### PR TITLE
fix: resolve CRLF line ending issue for Windows users

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Enforce Unix line endings for shell scripts
+*.sh text eol=lf
+entrypoint.sh text eol=lf
+identifier.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ RUN apk --no-cache upgrade && \
 
 # Copy the compiled binary and entrypoint (--chmod avoids extra RUN chmod layers)
 COPY --from=builder --chmod=755 /app/target/release/oxicloud /usr/local/bin/
-COPY --chmod=755 entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN sed -i 's/\r//' /usr/local/bin/entrypoint.sh && \
+    chmod 755 /usr/local/bin/entrypoint.sh
 
 # Copy processed static files (bundled/minified by build.rs in release)
 COPY --from=builder --chown=oxicloud:oxicloud /app/static-dist /app/static


### PR DESCRIPTION
Windows Git converts LF to CRLF by default, causing `entrypoint.sh` to fail
inside Alpine Linux containers with `no such file or directory`. This affects
all Windows users trying to self-host OxiCloud using the default Git configuration.

Two complementary fixes are applied:
- **Dockerfile:** added `sed -i 's/\r//'` to strip carriage returns from
  `entrypoint.sh` during image build, making it work regardless of host OS
  or Git configuration.
- **.gitattributes:** enforces LF line endings for all `.sh` files at the
  Git level, preventing the issue from occurring on future clones.

## Related Issue
Fixes #289

## Type of Change
Please check the option that best describes your change:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?
Tested on Windows 11 with Docker Desktop and default Git settings
(`core.autocrlf=true`).

**Steps to reproduce the fix:**
1. Clone the repo on Windows with default Git settings
2. Run `docker compose up -d --build`
3. Run `docker ps -a` — `oxicloud` container now shows `Up` instead of `Restarting`
4. Run `docker logs oxicloud-oxicloud-1` — no errors, server listening on port `8086`
5. Open `http://localhost:8086` — OxiCloud loads successfully

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules