### PR TITLE
fix(navigation): correct recent section

### DIFF
--- a/static/js/app/navigation.js
+++ b/static/js/app/navigation.js
@@ -284,7 +284,7 @@ function switchToRecentFilesSection() {
 
     if (recent) {
         sharedView.loadItems().then(() => {
-            favorites.displayFavorites();
+            recent.displayRecentFiles();
         });
     } else {
         console.error('Recent files module not loaded or initialized');


### PR DESCRIPTION
small bug due to copy/paste, restore `recent` section