### PR TITLE
docs: fix docker image reference from oxicloud to diocrafts/oxicloud

### DIFF
--- a/doc/deployment.md
+++ b/doc/deployment.md
@@ -43,7 +43,7 @@ services:
       retries: 5
 
   oxicloud:
-    image: oxicloud:latest
+    image: diocrafts/oxicloud:latest
     ports:
       - "8086:8086"
     env_file:

--- a/doc/oidc-config-examples.md
+++ b/doc/oidc-config-examples.md
@@ -58,7 +58,7 @@ OXICLOUD_OIDC_DISABLE_PASSWORD_LOGIN="false"
 version: '3'
 services:
   oxicloud:
-    image: oxicloud:latest
+    image: diocrafts/oxicloud:latest
     environment:
       OXICLOUD_OIDC_ENABLED: "true"
       OXICLOUD_OIDC_PROVIDER_NAME: "Authentik"
@@ -113,7 +113,7 @@ identity_providers:
 version: '3'
 services:
   oxicloud:
-    image: oxicloud:latest
+    image: diocrafts/oxicloud:latest
     environment:
       OXICLOUD_OIDC_ENABLED: "true"
       OXICLOUD_OIDC_PROVIDER_NAME: "Authelia"
@@ -159,7 +159,7 @@ services:
 version: '3'
 services:
   oxicloud:
-    image: oxicloud:latest
+    image: diocrafts/oxicloud:latest
     environment:
       OXICLOUD_OIDC_ENABLED: "true"
       OXICLOUD_OIDC_PROVIDER_NAME: "KeyCloak"

--- a/doc/oidc-integration.md
+++ b/doc/oidc-integration.md
@@ -235,7 +235,7 @@ KeyCloak setup via docker-compose:
 version: '3'
 services:
   oxicloud:
-    image: oxicloud:latest
+    image: diocrafts/oxicloud:latest
     environment:
       OXICLOUD_OIDC_ENABLED: "true"
       OXICLOUD_OIDC_ISSUER_URL: "https://keycloak.example.com/realms/your-realm"

--- a/doc/wopi-integration.md
+++ b/doc/wopi-integration.md
@@ -1048,7 +1048,7 @@ services:
       retries: 5
 
   oxicloud:
-    image: oxicloud
+    image: diocrafts/oxicloud:latest
     restart: always
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       retries: 5
 
   oxicloud:
-    image: oxicloud
+    image: diocrafts/oxicloud:latest
     restart: always
     build:
       context: .

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -31,7 +31,7 @@ services:
       retries: 5
 
   oxicloud:
-    image: oxicloud:latest
+    image: diocrafts/oxicloud:latest
     ports:
       - "8086:8086"
     env_file:


### PR DESCRIPTION
Fixes #277 - The docker-compose examples incorrectly reference `image: oxicloud` which does not exist on Docker Hub. Changed to the correct image name: `diocrafts/oxicloud:latest`.

Files changed:
- docker-compose.yml
- docs/guide/installation.md
- doc/deployment.md
- doc/oidc-integration.md
- doc/oidc-config-examples.md
- doc/wopi-integration.md