### PR TITLE
fix(auth): sanitize claims.sub when padding/truncating OIDC usernames

### DIFF
--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -1159,9 +1159,18 @@ impl AuthApplicationService {
                     .take(32)
                     .collect::<String>();
 
-                // Ensure minimum length
+                // Filter helper: removes any chars that are not valid in a username
+                let filter_username_chars = |s: &str| {
+                    s.chars()
+                        .filter(|c| c.is_ascii_alphanumeric() || *c == '-' || *c == '_' || *c == '.')
+                        .take(32)
+                        .collect::<String>()
+                };
+
+                // Ensure minimum length (the padding suffix must also be filtered)
                 if username.len() < 3 {
-                    username = format!("user_{}", &claims.sub[..8.min(claims.sub.len())]);
+                    let filtered_sub = filter_username_chars(&claims.sub);
+                    username = format!("user_{}", &filtered_sub[..filtered_sub.len().min(8)]);
                 }
 
                 // Check for username collision
@@ -1171,7 +1180,8 @@ impl AuthApplicationService {
                     .await
                     .is_ok()
                 {
-                    let suffix = &claims.sub[..4.min(claims.sub.len())];
+                    let filtered_sub = filter_username_chars(&claims.sub);
+                    let suffix = &filtered_sub[..filtered_sub.len().min(4)];
                     username = format!("{}_{}", &username[..username.len().min(27)], suffix);
                 }
 


### PR DESCRIPTION
## Summary

When OIDC providers (e.g. Keycloak) return an email address as the preferred username, the existing code correctly extracts the local part before . However, when that extracted part is too short (< 3 chars), the fallback padding uses  directly without filtering. If  also contains  or other invalid characters (as some OIDC providers use email-style subjects), the resulting username fails validation.

The same issue affects the collision-suffix logic, which also used unfiltered .

## Fix

Filter  through the same allowed-character filter before using it in:
1. The minimum-length padding suffix ()
2. The collision-resolution suffix ()

## Root cause



## Verification

- All 235 existing tests pass
- The fix applies the same  helper to  before any concatenation

Fixes #259