### PR TITLE
Nixos - Minor bugfix - Corrected sso to oauth2 in config

### DIFF
--- a/tools/nix/module.nix
+++ b/tools/nix/module.nix
@@ -29,13 +29,13 @@
     OXICLOUD_ENABLE_TRASH=${lib.boolToString cfg.features.trash}
     OXICLOUD_ENABLE_SEARCH=${lib.boolToString cfg.features.search}
 
-    OXICLOUD_OIDC_ENABLED=${lib.boolToString cfg.sso.enable}
-    OXICLOUD_OIDC_ISSUER_URL=${cfg.sso.issuerUrl}
-    OXICLOUD_OIDC_CLIENT_ID=${cfg.sso.clientId}
-    OXICLOUD_OIDC_CLIENT_SECRET=${builtins.readFile cfg.sso.clientSecret.file}
-    OXICLOUD_OIDC_REDIRECT_URI=${cfg.sso.redirectUri}
-    OXICLOUD_OIDC_SCOPES=${cfg.sso.scopes}
-    OXICLOUD_OIDC_FRONTEND_URL=${cfg.sso.frontendUrl}
+    OXICLOUD_OIDC_ENABLED=${lib.boolToString cfg.oauth2.enable}
+    OXICLOUD_OIDC_ISSUER_URL=${cfg.oauth2.issuerUrl}
+    OXICLOUD_OIDC_CLIENT_ID=${cfg.oauth2.clientId}
+    OXICLOUD_OIDC_CLIENT_SECRET=${builtins.readFile cfg.oauth2.clientSecret.file}
+    OXICLOUD_OIDC_REDIRECT_URI=${cfg.oauth2.redirectUri}
+    OXICLOUD_OIDC_SCOPES=${cfg.oauth2.scopes}
+    OXICLOUD_OIDC_FRONTEND_URL=${cfg.oauth2.frontendUrl}
 
     OXICLOUD_WOPI_ENABLED=${lib.boolToString cfg.wopi.enable}
     OXICLOUD_WOPI_DISCOVERY_URL=${cfg.wopi.discoveryUrl}
@@ -88,12 +88,6 @@ in {
     };
 
     database = {
-      url = lib.mkOption {
-        type = lib.types.str;
-        default = "";
-        description = "PostgreSQL connection string: postgres://postgres:postgres@localhost:5432/oxicloud";
-      };
-
       user = lib.mkOption {
         type = lib.types.str;
         default = "oxicloud";


### PR DESCRIPTION
## Description

I changed the OIDC/SSO initially to SSO and then OAUTH2, but forgot to bring that forward to module.nix. This corrects my oversight.

## Related Issue

#19

#307

## Type of Change

Please check the option that best describes your change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

I don't actually use this module in my oxicloud.gv.je implementation, but copy-pasted what I do use. I will figure out a way to use it directly. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules