### PR TITLE
fix(wopi): decode escaped discovery action URLs

### DIFF
--- a/src/infrastructure/services/wopi_discovery_service.rs
+++ b/src/infrastructure/services/wopi_discovery_service.rs
@@ -202,10 +202,15 @@ impl WopiDiscoveryService {
                     let mut urlsrc = String::new();
 
                     for attr in e.attributes().flatten() {
+                        let value = attr
+                            .decode_and_unescape_value(reader.decoder())
+                            .map(|value| value.into_owned())
+                            .unwrap_or_else(|_| String::from_utf8_lossy(&attr.value).to_string());
+
                         match attr.key.as_ref() {
-                            b"name" => name = String::from_utf8_lossy(&attr.value).to_string(),
-                            b"ext" => ext = String::from_utf8_lossy(&attr.value).to_string(),
-                            b"urlsrc" => urlsrc = String::from_utf8_lossy(&attr.value).to_string(),
+                            b"name" => name = value,
+                            b"ext" => ext = value,
+                            b"urlsrc" => urlsrc = value,
                             _ => {}
                         }
                     }
@@ -333,6 +338,28 @@ mod tests {
         assert_eq!(docx_actions.len(), 2);
         assert!(docx_actions.iter().any(|a| a.name == "view"));
         assert!(docx_actions.iter().any(|a| a.name == "edit"));
+        assert!(
+            docx_actions
+                .iter()
+                .all(|action| !action.urlsrc.contains("&amp;"))
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_action_url_decodes_xml_escaped_ampersands() {
+        let service = WopiDiscoveryService::new("http://example.test/discovery".to_string(), 60);
+        *service.actions.write().await =
+            WopiDiscoveryService::parse_discovery_xml(SAMPLE_DISCOVERY).expect("Should parse");
+        *service.last_fetched.write().await = Some(Instant::now());
+
+        let url = service
+            .get_action_url("docx", "edit", "https://oxicloud.test/wopi/files/abc")
+            .await
+            .expect("Should build URL")
+            .expect("Action URL should exist");
+
+        assert!(url.contains("lang=en-US"));
+        assert!(!url.contains("&amp;"));
     }
 
     #[test]


### PR DESCRIPTION
## Description

OnlyOffice discovery URLs were being stored with literal XML entities like `&amp;`, so the generated editor URL kept the escaped separator instead of a real query delimiter. This change decodes discovery action attributes before they are cached and adds regression coverage for both the parsed action table and the generated edit URL.

Fixes #311

## Related Issue

#311

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

- `cargo test test_get_action_url_decodes_xml_escaped_ampersands -- --nocapture`
- `cargo test wopi_discovery_service -- --nocapture`
- `cargo clippy -- -D warnings`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
