### PR TITLE
docs(wopi): clarify public base URL for split-host office setups

### DIFF
--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -72,9 +72,13 @@ See the [WOPI configuration guide](/config/wopi) for details.
 |---|---|---|
 | `OXICLOUD_WOPI_ENABLED` | `false` | Enable WOPI |
 | `OXICLOUD_WOPI_DISCOVERY_URL` | — | Collabora/OnlyOffice discovery URL |
+| `OXICLOUD_WOPI_BASE_URL` | `OXICLOUD_BASE_URL` | URL the editor uses to call OxiCloud's `/wopi/*` endpoints |
+| `OXICLOUD_WOPI_PUBLIC_BASE_URL` | `OXICLOUD_WOPI_BASE_URL` | URL the browser uses to open OxiCloud's WOPI host page and `postMessage` origin |
 | `OXICLOUD_WOPI_SECRET` | (JWT secret) | WOPI token signing key |
 | `OXICLOUD_WOPI_TOKEN_TTL_SECS` | `86400` | Token lifetime |
 | `OXICLOUD_WOPI_LOCK_TTL_SECS` | `1800` | Lock expiration |
+
+When Collabora or OnlyOffice runs on a different hostname, set `OXICLOUD_WOPI_PUBLIC_BASE_URL` to the public OxiCloud URL that the browser can reach. If the editor reaches OxiCloud through a different internal URL, also set `OXICLOUD_WOPI_BASE_URL` for those callbacks.
 
 ## Allocator Tuning
 

--- a/docs/config/wopi.md
+++ b/docs/config/wopi.md
@@ -29,9 +29,13 @@ OXICLOUD_WOPI_DISCOVERY_URL="http://collabora:9980/hosting/discovery"
 |---|---|---|
 | `OXICLOUD_WOPI_ENABLED` | `false` | Enable WOPI integration |
 | `OXICLOUD_WOPI_DISCOVERY_URL` | — | Editor's WOPI discovery URL |
+| `OXICLOUD_WOPI_BASE_URL` | `OXICLOUD_BASE_URL` | URL the editor uses to call OxiCloud's `/wopi/*` endpoints |
+| `OXICLOUD_WOPI_PUBLIC_BASE_URL` | `OXICLOUD_WOPI_BASE_URL` | URL the browser uses to open the host page and the `postMessage` origin |
 | `OXICLOUD_WOPI_SECRET` | (JWT secret) | Token signing key |
 | `OXICLOUD_WOPI_TOKEN_TTL_SECS` | `86400` | Access token lifetime |
 | `OXICLOUD_WOPI_LOCK_TTL_SECS` | `1800` | Lock expiration |
+
+If Collabora or OnlyOffice runs on a separate hostname, `OXICLOUD_WOPI_PUBLIC_BASE_URL` should still point to OxiCloud's public URL, not the office URL. Use `OXICLOUD_WOPI_BASE_URL` only when the editor reaches OxiCloud through a different callback URL (for example an internal Docker or cluster address).
 
 ## Docker Compose with Collabora
 
@@ -68,7 +72,17 @@ services:
     environment:
       OXICLOUD_WOPI_ENABLED: "true"
       OXICLOUD_WOPI_DISCOVERY_URL: "http://onlyoffice/hosting/discovery"
+      OXICLOUD_WOPI_PUBLIC_BASE_URL: "https://cloud.example.com"
+      # Optional when OnlyOffice reaches OxiCloud through a different internal URL.
+      # Otherwise OxiCloud falls back to OXICLOUD_WOPI_PUBLIC_BASE_URL / OXICLOUD_BASE_URL.
+      OXICLOUD_WOPI_BASE_URL: "http://oxicloud:8086"
 ```
+
+In that example:
+
+- the browser loads OxiCloud from `https://cloud.example.com`, so `OXICLOUD_WOPI_PUBLIC_BASE_URL` must use that public OxiCloud URL
+- OnlyOffice calls OxiCloud from the Docker network, so `OXICLOUD_WOPI_BASE_URL` can use `http://oxicloud:8086`
+- if both the browser and the editor use the same OxiCloud URL, you can omit both variables and rely on `OXICLOUD_BASE_URL`
 
 ## WOPI Endpoints
 

--- a/example.env
+++ b/example.env
@@ -150,6 +150,16 @@ OXICLOUD_WOPI_ENABLED=false
 # Example for OnlyOffice: http://onlyoffice/hosting/discovery
 #OXICLOUD_WOPI_DISCOVERY_URL=
 
+# Public OxiCloud URL used by the browser for the WOPI host page.
+# Keep this on the OxiCloud hostname, even when OnlyOffice/Collabora runs elsewhere.
+# Example: https://cloud.example.com
+#OXICLOUD_WOPI_PUBLIC_BASE_URL=
+
+# Optional callback URL the editor uses to reach OxiCloud's /wopi/* endpoints.
+# Set this only when the editor uses a different internal address than the browser.
+# Example: http://oxicloud:8086
+#OXICLOUD_WOPI_BASE_URL=
+
 # Secret key for signing WOPI access tokens
 # Falls back to OXICLOUD_JWT_SECRET if not set
 #OXICLOUD_WOPI_SECRET=


### PR DESCRIPTION
## Description

The WOPI docs only listed discovery, secret, and TTL settings, so split-host deployments had to discover `OXICLOUD_WOPI_PUBLIC_BASE_URL` and `OXICLOUD_WOPI_BASE_URL` from `src/main.rs`.

This updates the WOPI config page, the env var reference, and `example.env` to explain which URL the browser should use, which URL the editor callbacks can use, and how that looks for an OnlyOffice-on-another-host setup.

## Related Issue

Fixes #316

## Type of Change

Please check the option that best describes your change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Documentation update

## How Has This Been Tested?

- `cd docs && npm install --no-package-lock`
- `cd docs && npm run docs:build`
- verified the documented behavior against `src/main.rs`, which falls back between `OXICLOUD_WOPI_BASE_URL`, `OXICLOUD_WOPI_PUBLIC_BASE_URL`, and `OXICLOUD_BASE_URL`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules