### PR TITLE
chore(rust): use same params for clippy as the CI + correct clippy warnings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,8 @@ Database setup: `docker compose up -d postgres` — schema is applied automatica
 Always run these before committing, in this order:
 
 ```bash
-cargo fmt --all                      # Auto-format
-cargo clippy -- -D warnings          # Lint (must pass with zero warnings)
+cargo fmt --all                                              # Auto-format
+cargo clippy --all-features --all-targets -- -D warnings     # Lint (must pass with zero warnings)
 ```
 
 CI enforces both — commits that fail either check will not merge.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Integration docs: [OIDC setup](docs/config/oidc.md) · [OIDC architecture](docs/
 
 ```bash
 cargo fmt --all --check
-cargo clippy -- -D warnings
+cargo clippy --all-features --all-targets -- -D warnings
 cargo test --workspace
 ```
 

--- a/justfile
+++ b/justfile
@@ -31,11 +31,11 @@ fmt-check:
     cargo fmt --all --check
 
 lint:
-    cargo clippy -- -D warnings
+    cargo clippy --all-features --all-targets -- -D warnings
 
 check:
     cargo fmt --all
-    cargo clippy -- -D warnings
+    cargo clippy --all-features --all-targets -- -D warnings
 
 openapi:
     cargo run --bin generate-openapi

--- a/src/infrastructure/services/dedup_service.rs
+++ b/src/infrastructure/services/dedup_service.rs
@@ -1517,7 +1517,7 @@ mod tests {
             let is_last = i == chunks.len() - 1;
             if !is_last {
                 assert!(
-                    chunk.length >= CDC_MIN_CHUNK as usize,
+                    chunk.length >= CDC_MIN_CHUNK,
                     "non-last chunk {} too small: {} < {}",
                     i,
                     chunk.length,
@@ -1525,7 +1525,7 @@ mod tests {
                 );
             }
             assert!(
-                chunk.length <= CDC_MAX_CHUNK as usize,
+                chunk.length <= CDC_MAX_CHUNK,
                 "chunk {} too large: {} > {}",
                 i,
                 chunk.length,


### PR DESCRIPTION
- apply rust linter recos
- upgrade clippy parameter to reflect CI