### PR TITLE
fix(carddav): resolve PROPFIND 404 and MKCOL 500 bugs

### DIFF
--- a/src/infrastructure/repositories/pg/address_book_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/address_book_pg_repository.rs
@@ -26,7 +26,7 @@ impl AddressBookRepository for AddressBookPgRepository {
         let row = sqlx::query(
             r#"
             INSERT INTO carddav.address_books (id, name, owner_id, description, color, is_public, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            VALUES ($1, $2, $3::uuid, $4, $5, $6, $7, $8)
             RETURNING id, name, owner_id, description, color, is_public, created_at, updated_at
             "#
         )

--- a/src/interfaces/api/handlers/carddav_handler.rs
+++ b/src/interfaces/api/handlers/carddav_handler.rs
@@ -228,8 +228,10 @@ async fn handle_propfind(
         .map_err(|e| AppError::bad_request(format!("Failed to parse PROPFIND: {}", e)))?
     };
 
-    if path.is_empty() {
-        // Root CardDAV path — list user's address books
+    let effective_path = strip_username_prefix(path);
+
+    if effective_path.is_empty() {
+        // Root CardDAV path or user home — list user's address books
         let address_books = addressbook_service
             .list_user_address_books(user.id)
             .await
@@ -237,13 +239,18 @@ async fn handle_propfind(
                 AppError::internal_error(format!("Failed to list address books: {}", e))
             })?;
 
-        let base_href = "/carddav/";
+        let base_href = if path.is_empty() {
+            "/carddav/".to_string()
+        } else {
+            let user_part = path.split('/').next().unwrap_or(path);
+            format!("/carddav/{}/", user_part)
+        };
         let mut response_body = Vec::new();
         CardDavAdapter::generate_addressbooks_propfind_response(
             &mut response_body,
             &address_books,
             &propfind_request,
-            base_href,
+            &base_href,
         )
         .map_err(|e| AppError::internal_error(format!("Failed to generate XML: {}", e)))?;
 
@@ -253,8 +260,7 @@ async fn handle_propfind(
             .body(Body::from(response_body))
             .unwrap())
     } else {
-        let effective_path = strip_username_prefix(path);
-    let parts: Vec<&str> = effective_path.splitn(2, '/').collect();
+        let parts: Vec<&str> = effective_path.splitn(2, '/').collect();
         let address_book_id = parts[0];
 
         if parts.len() == 1 {
@@ -730,4 +736,58 @@ async fn handle_proppatch(
         .header(header::CONTENT_TYPE, "application/xml; charset=utf-8")
         .body(Body::from(response_body))
         .unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_username_prefix;
+
+    #[test]
+    fn test_strip_username_prefix_uuid_only() {
+        let uuid = "ae8ae236-709f-4939-b766-37ad589ac7f2";
+        assert_eq!(strip_username_prefix(uuid), uuid);
+    }
+
+    #[test]
+    fn test_strip_username_prefix_uuid_with_contact() {
+        let path = "ae8ae236-709f-4939-b766-37ad589ac7f2/contact.vcf";
+        assert_eq!(strip_username_prefix(path), path);
+    }
+
+    #[test]
+    fn test_strip_username_prefix_username_and_uuid() {
+        let path = "timm/ae8ae236-709f-4939-b766-37ad589ac7f2";
+        assert_eq!(
+            strip_username_prefix(path),
+            "ae8ae236-709f-4939-b766-37ad589ac7f2"
+        );
+    }
+
+    #[test]
+    fn test_strip_username_prefix_username_uuid_and_contact() {
+        let path = "timm/ae8ae236-709f-4939-b766-37ad589ac7f2/contact.vcf";
+        assert_eq!(
+            strip_username_prefix(path),
+            "ae8ae236-709f-4939-b766-37ad589ac7f2/contact.vcf"
+        );
+    }
+
+    #[test]
+    fn test_strip_username_prefix_bare_username() {
+        assert_eq!(strip_username_prefix("timm"), "");
+    }
+
+    #[test]
+    fn test_strip_username_prefix_empty() {
+        assert_eq!(strip_username_prefix(""), "");
+    }
+
+    #[test]
+    fn test_strip_username_prefix_email_style_username() {
+        let path = "user@example.com/ae8ae236-709f-4939-b766-37ad589ac7f2/contact.vcf";
+        assert_eq!(
+            strip_username_prefix(path),
+            "ae8ae236-709f-4939-b766-37ad589ac7f2/contact.vcf"
+        );
+    }
 }


### PR DESCRIPTION
## Description

This PR fixes two pre-existing bugs in the CardDAV endpoints:

1. **CardDAV PROPFIND 404 on User Home:** Standard clients discover the CardDAV addressbook-home-set as `/carddav/{username}/`. The recent routing fixes (`strip_username_prefix`) made this effective path an empty string, but the `PROPFIND` handler was only falling back to user address book listing when the *original* path was empty (the `/carddav/` root). Now, an empty `effective_path` will list the user's address books and return the proper `base_href`.
2. **CardDAV MKCOL 500 (`owner_id` UUID mismatch):** Creating a new address book via `MKCOL` resulted in a 500 Internal Server Error because the `owner_id` was bound as a `String` (from `AddressBook.owner_id()`), but the database expects a `uuid` type. The SQL query in `create_address_book` now correctly casts the parameter to `$3::uuid`.

## Related Issue

Follow-up to #336 (CalDAV username prefix routing).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

Integration tested against a live OxiCloud instance (Postgres):

- **PROPFIND `/carddav/deeprot/`** → Returns `207 Multi-Status` with the user's address books (previously `404 Not Found`).
- **MKCOL `/carddav/deeprot/`** → Returns `201 Created` (previously `500 Internal Server Error`).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (N/A)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules (N/A)