### PR TITLE
feat(openapi): complete openapi with new shares routes

### DIFF
--- a/src/interfaces/api/mod.rs
+++ b/src/interfaces/api/mod.rs
@@ -117,6 +117,11 @@ use crate::interfaces::api::handlers::file_handler::MoveFilePayload;
         handlers::share_handler::access_shared_item,
         handlers::share_handler::verify_shared_item_password,
         handlers::share_handler::download_shared_file,
+        handlers::share_handler::list_share_contents_root,
+        handlers::share_handler::list_share_contents_subfolder,
+        handlers::share_handler::download_share_file_in_folder,
+        handlers::share_handler::download_share_zip_root,
+        handlers::share_handler::download_share_zip_subfolder,
         // Favorites handlers (free functions)
         handlers::favorites_handler::get_favorites,
         handlers::favorites_handler::add_favorite,


### PR DESCRIPTION
cover openapi exposition

  - GET /api/s/{token}/contents — list root folder of a shared folder
  - GET /api/s/{token}/contents/{folder_id} — list subfolder
  - GET /api/s/{token}/file/{file_id} — download a file within a shared folder
  - GET /api/s/{token}/zip — download root as ZIP
  - GET /api/s/{token}/zip/{folder_id} — download subfolder as ZIP

  (added from @abnvle)