### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3646,7 +3646,7 @@ dependencies = [
 
 [[package]]
 name = "oxicloud"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "aes-gcm",
  "argon2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxicloud"
-version = "0.5.6"
+version = "0.6.0"
 edition = "2024"
 default-run = "oxicloud"
 


### PR DESCRIPTION
Prepara la publicación de **OxiCloud 0.6.0**.

## Cambios

- `Cargo.toml`: `0.5.6` → `0.6.0`
- `Cargo.lock`: actualizado vía `cargo update -p oxicloud`

## Cómo publicar la release

1. Merge este PR a `main`.
2. Tag desde `main`:
   ```bash
   git checkout main && git pull
   git tag v0.6.0
   git push origin v0.6.0
   ```
3. El workflow `.github/workflows/release.yml` creará la release automáticamente con notas auto-generadas.
4. Editar la descripción de la release y reemplazar con el cuerpo propuesto más abajo (basado en 123 commits entre `v0.5.6..main` de 6 colaboradores).

## Cuerpo propuesto para la release (con los agradecimientos)

```markdown
OxiCloud 0.6.0 reúne 123 commits y 295 ficheros cambiados desde v0.5.6. Esta versión refuerza los protocolos (CalDAV/CardDAV, WebDAV, WOPI), abre el camino a IPv6, añade una API completa de contactos, mejora la compartición pública con navegación de carpetas y refuerza la seguridad de tokens y permisos.

## Highlights

- Soporte de IPv6 en el servidor.
- API completa de contactos: address-books, contactos y grupos, con feature flag para exponer (o no) usuarios en address-book.
- Compartición pública de carpetas con navegación tipo galería, soporte de descargas con `Range`, ZIP y desbloqueo mediante cookie firmada para shares con contraseña.
- Drag & drop bidireccional con el sistema operativo desde la interfaz web.
- Generación de miniaturas en cliente como fallback cuando no están en servidor; corregida también la generación de miniaturas para almacenamiento CDC.
- Refactor `file_lifecycle` / `blob_lifecycle` y corrección del conteo de referencias en copy-on-write y al eliminar ficheros.
- Cobertura OpenAPI completa en todas las rutas.
- Pruebas E2E con Playwright, suite de tests de API (ficheros, carpetas, favoritos, recientes, papelera, contactos, compartidos), y tests WebDAV de dedup, contadores de referencia y miniaturas.

## Seguridad

- Rotación obligatoria de refresh tokens para reducir la superficie ante un token robado.
- `copy_file_owned` y `move_folder` ahora validan la propiedad del destino.
- Validación estricta de caracteres reservados en nombres de fichero y carpeta.
- Refresh transparente de sesiones expiradas en el frontend.
- Auditoría con `X-Request-Id`, `client_ip` del HTTP, usuario autenticado y soporte de proxy de confianza vía CIDR.
- Audit de dependencias integrado en `justfile` y reglas globales en `.cargo/audit.toml`.

## Fixes

- CalDAV/CardDAV: prefijos de usuario respetados en todos los handlers; resueltos `PROPFIND 404` y `MKCOL 500` en CardDAV.
- WOPI: decodificación de URLs escapadas en discovery; documentación de URLs públicas y de callback.
- UI: panel de admin con la librería de iconos restaurada, modal de input oculto por defecto, badges (favoritos / compartidos) en orden consistente, botón de cerrar del diálogo de compartir, refresco del badge de compartido al cambiar.
- Frontend: `go to parent` corregido, refactor de tipos, traducción al polaco añadida, claves i18n añadidas y limpiadas.

## Refactor y calidad

- CSS: uso exclusivo de variables `var(--*)` para colores.
- JS/UI: clase `hidden` consistente para modales, menús y notificaciones; biome aplicado; tipos requeridos en todos los módulos JS.
- Server: clippy alineado con la CI y warnings corregidos.
- Docs: migración de la documentación legacy al sitio oficial.

## Gracias

Esta release ha sido posible gracias al trabajo, las revisiones, las pruebas y la paciencia de mucha gente. **Mil gracias** a todos los que habéis colaborado en 0.6.0:

- **Edouard Vanbelle** ([@EdouardVanbelle](https://github.com/EdouardVanbelle)) — 73 commits: IPv6, OpenAPI completo, copy folder con ownership, refactor de ciclos de vida de fichero/blob, drag & drop al sistema, generación de miniaturas en cliente, refresh token, auditoría con client_ip, suite E2E con Playwright, tests de API, refactor i18n, CSS con variables, y muchísimo más.
- **Dionisio Pozo / DioCrafts** ([@DioCrafts](https://github.com/DioCrafts)) — 38 commits: dirección del proyecto, release engineering, fixes de Docker publish, miniaturas para CDC, y mantenimiento general.
- **abnvle** ([@abnvle](https://github.com/abnvle)) — 7 commits: navegación pública de carpetas compartidas, descargas con `Range`, ZIP, desbloqueo de shares con contraseña, traducción al polaco.
- **onthebed** ([@onthebed](https://github.com/onthebed)) — fix de unescape en WOPI discovery y documentación de URLs públicas/callback de WOPI.
- **Timm / gidsi** ([@gidsi](https://github.com/gidsi)) — fixes críticos de CalDAV/CardDAV (prefijo de usuario en handlers, `PROPFIND 404`, `MKCOL 500`).
- **DeepRot** — contribución a la release.

Y gracias también a todas las personas que han abierto issues, probado en pre-release, revisado PRs, traducido o simplemente dado feedback. Esta release es vuestra. ❤️
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01KrmeKokVni5A9pJi79CjcF)_