### PR TITLE
feat(ui): improve mobile search and consolidate language selector

### DIFF
--- a/static/css/components/languageSelector.css
+++ b/static/css/components/languageSelector.css
@@ -1,7 +1,6 @@
 /* Language Selector - Custom Dropdown */
 .language-selector {
     position: relative;
-    margin-right: 15px;
 }
 
 .language-selector-toggle {
@@ -107,4 +106,72 @@
 
 .language-option.active .lang-check {
     opacity: 1;
+}
+
+/* ── Language selector inside user menu ── */
+.user-menu .language-selector {
+    width: 100%;
+}
+
+/* Match user-menu-item appearance exactly */
+.user-menu .language-selector-toggle {
+    width: 100%;
+    background: none !important;
+    border: none !important;
+    border-radius: 0 !important;
+    box-shadow: none !important;
+    outline: none !important;
+    padding: 12px 20px;
+    gap: 12px;
+    color: var(--color-text-dark);
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.user-menu .language-selector-toggle:hover,
+.user-menu .language-selector-toggle:focus {
+    background: var(--color-bg-hover) !important;
+    border: none !important;
+    outline: none !important;
+}
+
+.user-menu .language-selector-toggle i.fa-globe {
+    width: 20px;
+    text-align: center;
+    font-size: 15px;
+    color: var(--color-text-subtle);
+}
+
+.user-menu .language-selector-toggle .lang-code {
+    font-weight: 500;
+    font-size: 13px;
+    color: var(--color-text-dark);
+}
+
+/* Inline accordion — no floating */
+.user-menu .language-selector-dropdown {
+    position: static !important;
+    box-shadow: none !important;
+    border: none !important;
+    border-top: 1px solid var(--color-border-light);
+    border-radius: 0 !important;
+    background: var(--color-bg-muted);
+    max-height: 0;
+    overflow: hidden;
+    opacity: 1 !important;
+    visibility: visible !important;
+    transform: none !important;
+    transition: max-height 0.25s ease;
+    z-index: auto !important;
+}
+
+.user-menu .language-selector.open .language-selector-dropdown {
+    max-height: 260px;
+    overflow-y: auto;
+}
+
+/* Language options inside user menu — compact rows */
+.user-menu .language-option {
+    padding: 10px 20px 10px 28px;
+    font-size: 13.5px;
 }

--- a/static/css/components/userMenu.css
+++ b/static/css/components/userMenu.css
@@ -48,6 +48,7 @@
     position: absolute;
     top: calc(100% + 10px);
     right: 0;
+    left: auto;
     width: 300px;
     background: var(--color-bg-surface);
     border-radius: 16px;
@@ -61,6 +62,11 @@
 
 .user-menu-wrapper.open .user-menu {
     display: block;
+}
+
+[dir="rtl"] .user-menu {
+    right: auto;
+    left: 0;
 }
 
 @keyframes userMenuIn {

--- a/static/css/layout/topbar.css
+++ b/static/css/layout/topbar.css
@@ -45,17 +45,45 @@
     font-size: 20px;
 }
 
-/* Mobile responsive styles for top bar */
-@media (max-width: 768px) {
-    .top-bar {
-        padding: 0 16px;
-    }
+/* Mobile search toggle button — hidden on desktop */
+.search-toggle-btn {
+    display: none;
+    background: none;
+    border: none;
+    padding: 10px;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    border-radius: 8px;
+    font-size: 18px;
+    transition:
+        background-color 0.2s,
+        color 0.2s;
+    flex-shrink: 0;
+}
 
-    .sidebar-toggle {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-    }
+.search-toggle-btn:hover {
+    background-color: var(--color-border);
+}
+
+/* Back button inside expanded mobile search — hidden everywhere by default */
+.search-back-btn {
+    display: none;
+    background: none;
+    border: none;
+    padding: 10px;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    border-radius: 8px;
+    font-size: 18px;
+    transition:
+        background-color 0.2s,
+        color 0.2s;
+    flex-shrink: 0;
+}
+
+.search-back-btn:hover {
+    background-color: var(--color-border);
+    color: var(--color-text-heading);
 }
 
 .search-container {
@@ -162,4 +190,58 @@
     display: flex;
     align-items: center;
     gap: 12px;
+}
+
+/* Mobile responsive styles for top bar */
+@media (max-width: 768px) {
+    .top-bar {
+        padding: 0 16px;
+    }
+
+    .sidebar-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    /* Hide full search bar on mobile by default */
+    .search-container {
+        display: none;
+    }
+
+    /* Show icon-only search button; push it to the right before user-controls */
+    .search-toggle-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        margin-left: auto;
+    }
+
+    /* Expanded mobile search: full-width overlay of the top bar */
+    .top-bar--search-active .search-back-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+    }
+
+    .top-bar--search-active .search-container {
+        display: flex;
+        flex-grow: 1;
+        max-width: none;
+        margin: 0;
+    }
+
+    .top-bar--search-active .search-icon {
+        display: none;
+    }
+
+    .top-bar--search-active .search-container input {
+        padding-left: 16px;
+    }
+
+    .top-bar--search-active .sidebar-toggle,
+    .top-bar--search-active .search-toggle-btn,
+    .top-bar--search-active .user-controls {
+        display: none;
+    }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -118,6 +118,14 @@
             <button class="sidebar-toggle" id="sidebar-toggle" aria-label="Toggle navigation menu">
                 <i class="fas fa-bars"></i>
             </button>
+            <!-- Mobile search icon (replaces full bar on small screens) -->
+            <button class="search-toggle-btn" id="search-toggle-btn" aria-label="Search">
+                <i class="fas fa-search"></i>
+            </button>
+            <!-- Back button shown when mobile search is expanded -->
+            <button class="search-back-btn" id="search-back-btn" aria-label="Close search">
+                <i class="fas fa-arrow-left"></i>
+            </button>
             <div class="search-container">
                 <i class="fas fa-search search-icon"></i>
                 <input type="text" id="search-input" data-i18n-placeholder="actions.search" placeholder="Search files, folders...">
@@ -127,8 +135,6 @@
             </div>
 
             <div class="user-controls">
-                <div id="language-selector"></div>
-
                 <!-- Notification Bell -->
                 <div class="notif-wrapper" id="notif-wrapper">
                     <button class="notif-bell-btn" id="notif-bell-btn" title="Notifications">
@@ -186,6 +192,7 @@
                             <span data-i18n="user_menu.profile">My profile</span>
                         </button>
                         <div class="user-menu-divider hidden" id="user-menu-admin-divider"></div>
+                        <div id="language-selector"></div>
                         <button class="user-menu-item" id="user-menu-theme">
                             <i class="fas fa-moon"></i>
                             <span data-i18n="user_menu.appearance">Appearance</span>

--- a/static/js/app/main.js
+++ b/static/js/app/main.js
@@ -516,8 +516,32 @@ function setupEventListeners() {
         }
     });
 
+    // Mobile search toggle
+    const topBar = document.querySelector('.top-bar');
+    document.getElementById('search-toggle-btn')?.addEventListener('click', () => {
+        topBar?.classList.add('top-bar--search-active');
+        elements.searchInput?.focus();
+    });
+
+    const collapseSearch = () => {
+        topBar?.classList.remove('top-bar--search-active');
+        if (elements.searchInput) elements.searchInput.value = '';
+        if (app.isSearchMode) {
+            app.isSearchMode = false;
+            app.currentPath = '';
+            document.querySelector('.search-results-header')?.remove();
+            ui.updateBreadcrumb();
+            loadFiles();
+        }
+    };
+    document.getElementById('search-back-btn')?.addEventListener('click', collapseSearch);
+
     // Search input — Enter key
     elements.searchInput?.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            collapseSearch();
+            return;
+        }
         if (e.key === 'Enter') {
             // Cancel any pending debounce
             if (searchDebounceTimer) clearTimeout(searchDebounceTimer);


### PR DESCRIPTION
- On mobile (≤768px), replace the full search bar in the topbar with a search icon button; tapping it expands a full-width search overlay with a back arrow to collapse (Google Drive-style pattern)
- Escape key also collapses the mobile search overlay
- Hide the redundant inline search icon when the mobile search bar is active (submit button already has one)
- Move the language selector from the topbar into the user menu for all screen sizes, reducing topbar clutter; it renders as an accordion row matching other menu items
- Fix user menu positioning in RTL layouts (Arabic/Persian): anchor to left:0 instead of right:0 so the panel opens inward rather than off-screen

## Description

<!-- Please include a summary of the changes and the related issue (if applicable). Please also include relevant motivation and context. -->

## Related Issue

<!-- Please link to the issue here if applicable. -->

## Type of Change

Please check the option that best describes your change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

before: 
<img width="447" height="575" alt="image" src="https://github.com/user-attachments/assets/adebe524-1929-491f-81d5-ec9603113e68" />

<img width="447" height="575" alt="image" src="https://github.com/user-attachments/assets/775c183e-14d2-4c26-8746-c62dea83f6b2" />

after:
<img width="447" height="575" alt="image" src="https://github.com/user-attachments/assets/a2ffa090-c87d-4bff-91c0-8274328da992" />

<img width="447" height="575" alt="image" src="https://github.com/user-attachments/assets/60f956e8-bdb6-4bba-b608-3ec2ad3c0db1" />
