### PR TITLE
fix(share): permit scrolldown+ keep header sticky on the top

### DIFF
--- a/static/css/views/share-public.css
+++ b/static/css/views/share-public.css
@@ -11,8 +11,10 @@ body {
     color: var(--color-text-heading);
     display: flex;
     justify-content: center;
-    align-items: center;
+    align-items: safe center;
+    height: auto;
     min-height: 100vh;
+    overflow: auto;
     padding: 1rem;
 }
 
@@ -183,6 +185,11 @@ body.gallery-mode .share-logo {
     align-items: center;
     gap: 0.75rem;
     margin-bottom: 1rem;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--color-bg-surface);
+    padding: 0.75rem 0;
 }
 .gallery-title {
     flex: 1 1 200px;


### PR DESCRIPTION
this solves scrolling issue raised on #253
    
<img width="1322" height="1036" alt="Capture d’écran 2026-05-19 à 22 54 15" src="https://github.com/user-attachments/assets/31c4a25e-6197-47b0-9aeb-a27c55822476" />

