### PR TITLE
Allow container to be started as non root user

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,14 +10,18 @@ STORAGE_DIR="/app/storage"
 STATIC_DIR="/app/static"
 
 # Ensure the storage directory exists and is writable by oxicloud
-if [ -d "$STORAGE_DIR" ]; then
+if [[ -d "$STORAGE_DIR" && "$(id -u)" -eq 0 ]]; then
     chown -R oxicloud:oxicloud "$STORAGE_DIR"
 fi
 
 # Ensure static directory is readable
-if [ -d "$STATIC_DIR" ]; then
+if [[ -d "$STATIC_DIR" && "$(id -u)" -eq 0 ]]; then
     chown -R oxicloud:oxicloud "$STATIC_DIR"
 fi
 
 # Drop privileges and exec the main binary (or whatever was passed as CMD)
-exec su-exec oxicloud "$@"
+if [[ "$(id -u)" -eq 0 ]]; then
+    exec su-exec oxicloud "$@"
+else
+    oxicloud "$@"
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,17 +10,17 @@ STORAGE_DIR="/app/storage"
 STATIC_DIR="/app/static"
 
 # Ensure the storage directory exists and is writable by oxicloud
-if [[ -d "$STORAGE_DIR" && "$(id -u)" -eq 0 ]]; then
+if [ -d "$STORAGE_DIR" ] && [ "$(id -u)" -eq 0 ]; then
     chown -R oxicloud:oxicloud "$STORAGE_DIR"
 fi
 
 # Ensure static directory is readable
-if [[ -d "$STATIC_DIR" && "$(id -u)" -eq 0 ]]; then
+if [ -d "$STATIC_DIR" ] && [ "$(id -u)" -eq 0 ]; then
     chown -R oxicloud:oxicloud "$STATIC_DIR"
 fi
 
 # Drop privileges and exec the main binary (or whatever was passed as CMD)
-if [[ "$(id -u)" -eq 0 ]]; then
+if [ "$(id -u)" -eq 0 ]; then
     exec su-exec oxicloud "$@"
 else
     oxicloud "$@"


### PR DESCRIPTION
## Description

Currently the container cannot be run as arbitrary user as the `entrypoint.sh` assumes that the container is started as root user. Especially when running the container with Podman this assumption is not always valid. When using `user: 1000:1000` in the compose file the container is unable to start and fails with the message:

```
chown: /app/storage: Operation not permitted
```

This PR addresses this problem and only executes the permission change if the container is started as root user. Therefore this is a non breaking change. In case the container is started as non root user the two directories must be create beforehand which is okay I guess as the user is probably knowing what he/she is doing.

## Related Issue

<!-- Please link to the issue here if applicable. -->

## Type of Change

Please check the option that best describes your change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

I build the docker image locally with following changes:

```
oxicloud:
  # image: diocrafts/oxicloud:latest     # To force local build
  user: 1000:1000                        # uid and gid from local user
  volumes:
    - ./data:/app/storage                # Create before container start
```

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules