### PR TITLE
chore(vitepress): ignore non relevant docs, link ReBAC documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -11,6 +11,17 @@ export default defineConfig({
     lastmodDateOnly: false,
   },
 
+  // Internal planning notes (docs/plan/*) and AI hand-off prompts
+  // aren't user-facing docs and contain raw Rust/pseudocode whose
+  // generics (Option<String>, Vec<SubjectGroup>, …) trip Vue's
+  // template parser ("Element is missing end tag" because <String>,
+  // <SubjectGroup>, etc. look like unclosed HTML tags). Keep them
+  // in-tree for engineering reference but skip them at site-build time.
+  srcExclude: [
+    "plan/**",
+    "**/*.prompt",
+  ],
+
   markdown: {
     image: {
       lazyLoading: true,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -102,6 +102,7 @@ export default defineConfig({
             { text: "Share Integration", link: "/architecture/share-integration" },
             { text: "Storage Quotas", link: "/architecture/storage-quotas" },
             { text: "File and Blob lifecycle", link: "/architecture/file-and-blob-lifecycle" },
+            { text: "ReBAC & Authorization", link: "/architecture/rebac-authorization" },
           ],
         },
         { text: "FAQ", link: "/faq" },


### PR DESCRIPTION
no change on code
ignore docs/plan & *.prompt so vitepress can build
add explicitly architecture/ReBAC documentation to vitepress