### PR TITLE
chore(release): bump version to 0.7.0 — "Slipstream"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4076,7 +4076,7 @@ dependencies = [
 
 [[package]]
 name = "oxicloud"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "accept-language",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxicloud"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 default-run = "oxicloud"
 


### PR DESCRIPTION
Version bump for **OxiCloud v0.7.0 — "Slipstream"** (`Cargo.toml` + `Cargo.lock`, `0.6.0 → 0.7.0`). Mirrors the v0.6.0 flow (#370).

Merge this, then publish the GitHub Release on the `v0.7.0` tag using the crafted release notes (delivered separately). 201 commits since v0.6.0 — headlines: the delta-upload protocol, embedded Tantivy content search, chunk-level CDC dedup + resumable uploads, passwordless/magic-link auth, Groups/ReBAC, and a 31-commit performance push.

https://claude.ai/code/session_01DCszkkU11LYxMEUWr4setK

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCszkkU11LYxMEUWr4setK)_