### PR TITLE
fix(docker) Fix start up for non root users

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,5 +35,5 @@ fi
 if [ "$(id -u)" -eq 0 ]; then
     exec su-exec oxicloud "$@"
 else
-    oxicloud "$@"
+    "$@"
 fi


### PR DESCRIPTION
## Description

The container is currently not able to start as non root user as the command `oxicloud` is already set in the Dockerfile.
During startup the container fails with the message: `Unknown argument: oxicloud - Try oxicloud --help.`

## Type of Change

Please check the option that best describes your change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?
With the following changes locally to the docker-compose.yml

```yaml
oxicloud:
  # use local build
  # image: diocrafts/oxicloud:latest
  user: 1000:1000
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules