### PR TITLE
Allow the use of system certificates to trust OIDC provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5705,6 +5705,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.40",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ blake3 = { version = "1.8.5", features = ["rayon", "mmap"] }
 hex = "0.4.3"
 http-body-util = "0.1.3"
 percent-encoding = "2.3.2"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots","rustls-tls-native-roots"] }
 base64 = "0.22.1"
 fs2 = "0.4"
 rayon = "1.12.0"


### PR DESCRIPTION
## Description

Activating `rustls-tls-native-roots`  allows successful OIDC login even with self-signed certificate authority deployed in system store.

No code change : only dependency features.

## Related Issue

This PR solves https://github.com/AtalayaLabs/OxiCloud/issues/184

## Type of Change

Please check the option that best describes your change:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

Manual test with Keycloak 26 OIDC provider using a self-signed certificate authority deployed on OxiCloud hosting system and monted into the Docker image via `-v /etc/ssl:/etc/ssl` (and additional related links bind mounts).

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules