### PR TITLE
Migrate Nextcloud login page from build.rs to askama templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,6 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-Dwarnings"
   DATABASE_URL: "postgres://postgres:postgres@localhost/oxicloud_test"
-  # Re-enable the legacy build.rs static-dist + OUT_DIR HTML pipeline.
-  # Required while login_v2_handler.rs still uses
-  # `include_str!(concat!(env!("OUT_DIR"), "/nextcloud-login.html"))`;
-  # without this, every cargo job fails to compile that file.
-  # Remove once the Nextcloud login page moves off include_str! (askama).
-  OXICLOUD_RUST_ASSETS: "1"
 
 jobs:
 

--- a/.github/workflows/load-nightly.yml
+++ b/.github/workflows/load-nightly.yml
@@ -22,8 +22,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # See ci.yml — required while login_v2_handler.rs uses include_str! against OUT_DIR.
-  OXICLOUD_RUST_ASSETS: "1"
 
 jobs:
   load:

--- a/.github/workflows/load-smoke.yml
+++ b/.github/workflows/load-smoke.yml
@@ -18,8 +18,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # See ci.yml — required while login_v2_handler.rs uses include_str! against OUT_DIR.
-  OXICLOUD_RUST_ASSETS: "1"
 
 jobs:
   smoke:

--- a/build.rs
+++ b/build.rs
@@ -25,7 +25,6 @@ const HTML_INCLUDE: &[&str] = &[
     "profile.html",
     "admin.html",
     "device-verify.html",
-    "nextcloud-login.html",
     "share.html",
 ];
 
@@ -1239,14 +1238,21 @@ fn fnv_hash(data: &[u8]) -> String {
     format!("{h:016x}")
 }
 
-/// Recursively copy a directory tree.
+/// Recursively copy a directory tree, following symlinks.
+///
+/// `fs::metadata` (not `entry.file_type()`) is used to classify each entry so
+/// that symlinked directories are traversed into rather than handed to
+/// `fs::copy`. `static/locales` is a symlink to `frontend/static/locales`;
+/// `entry.file_type()` reports the link itself, so the old code routed it to
+/// the `fs::copy` branch and failed with "the source path is neither a regular
+/// file nor a symlink to a regular file".
 fn copy_dir_recursive(src: &Path, dst: &Path) -> io::Result<()> {
     fs::create_dir_all(dst)?;
     for entry in fs::read_dir(src)? {
         let entry = entry?;
         let src_path = entry.path();
         let dst_path = dst.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
+        if fs::metadata(&src_path)?.is_dir() {
             copy_dir_recursive(&src_path, &dst_path)?;
         } else {
             fs::copy(&src_path, &dst_path)?;

--- a/src/interfaces/nextcloud/login_v2_handler.rs
+++ b/src/interfaces/nextcloud/login_v2_handler.rs
@@ -29,6 +29,14 @@ struct DrivePickerTemplate {
     drives: Vec<DriveOption>,
 }
 
+/// The Nextcloud Login Flow v2 "Grant Access" page. Rendered server-side via
+/// askama (no template variables — the username/password are collected by the
+/// embedded form) instead of `include_str!` so the build no longer depends on
+/// the legacy `build.rs` static-asset pipeline / `OUT_DIR`.
+#[derive(Template)]
+#[template(path = "nextcloud/login.html")]
+struct NextcloudLoginTemplate;
+
 // Home identification is via `position_of_user_home_root_folder` from
 // `domain::repositories::drive_repository` — a generic helper that
 // keys off `drives.default_for_user == user_id` rather than folder
@@ -36,7 +44,7 @@ struct DrivePickerTemplate {
 // picker UX.
 
 /// Serve an HTML page with a Content-Security-Policy header as defense-in-depth.
-fn html_with_csp(html: &'static str) -> Response {
+fn html_with_csp(html: String) -> Response {
     (
         [(
             header::CONTENT_SECURITY_POLICY,
@@ -160,10 +168,13 @@ pub async fn handle_login_page(
         return StatusCode::NOT_FOUND.into_response();
     }
 
-    html_with_csp(include_str!(concat!(
-        env!("OUT_DIR"),
-        "/nextcloud-login.html"
-    )))
+    match NextcloudLoginTemplate.render() {
+        Ok(html) => html_with_csp(html),
+        Err(e) => {
+            tracing::error!(error = %e, "Login Flow v2: login page template render failed");
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
 }
 
 pub async fn handle_login_submit(

--- a/templates/nextcloud/login.html
+++ b/templates/nextcloud/login.html
@@ -19,40 +19,40 @@
                 </div>
                 <div class="auth-logo-text">OxiCloud</div>
             </div>
-            
+
             <h1 class="auth-title">Grant Access</h1>
             <p class="auth-subtitle">
                 A Nextcloud client is requesting access to your account.
             </p>
-            
+
             <form class="auth-form" method="POST" id="login-flow-form">
                 <div class="auth-input-group">
                     <label class="auth-label" for="user">Username</label>
-                    <input 
-                        type="text" 
+                    <input
+                        type="text"
                         id="user"
-                        name="user" 
-                        class="auth-input" 
+                        name="user"
+                        class="auth-input"
                         placeholder="Enter your username"
                         required
                         autocomplete="username"
                         autofocus
                     >
                 </div>
-                
+
                 <div class="auth-input-group">
                     <label class="auth-label" for="password">Password</label>
-                    <input 
-                        type="password" 
+                    <input
+                        type="password"
                         id="password"
-                        name="password" 
-                        class="auth-input" 
+                        name="password"
+                        class="auth-input"
                         placeholder="Enter your password"
                         required
                         autocomplete="current-password"
                     >
                 </div>
-                
+
                 <button type="submit" class="auth-button" id="password-submit">Grant Access</button>
             </form>
 
@@ -65,7 +65,7 @@
             </div>
         </div>
     </div>
-    
+
     <script src="/js/views/nextcloud/login.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Description

Removes the legacy `build.rs` static-asset pipeline dependency for the Nextcloud Login Flow v2 page by migrating it to server-side rendering via askama templates.

**Changes:**

1. **`src/interfaces/nextcloud/login_v2_handler.rs`**
   - Added `NextcloudLoginTemplate` struct with askama `#[derive(Template)]` to render `templates/nextcloud/login.html` at runtime
   - Updated `html_with_csp()` to accept `String` instead of `&'static str` to support dynamic template rendering
   - Modified `handle_login_page()` to call `NextcloudLoginTemplate.render()` instead of using `include_str!` against `OUT_DIR`
   - Added error handling for template render failures

2. **`templates/nextcloud/login.html`**
   - Whitespace normalization (trailing spaces removed, consistent formatting)
   - No functional changes to the HTML structure or styling

3. **`build.rs`**
   - Removed `"nextcloud-login.html"` from `HTML_INCLUDE` constant (no longer needs to be processed by the legacy pipeline)
   - Fixed `copy_dir_recursive()` to follow symlinks by using `fs::metadata()` instead of `entry.file_type()` for directory classification
   - Updated documentation to explain the symlink-following behavior

4. **CI workflows** (`.github/workflows/ci.yml`, `load-nightly.yml`, `load-smoke.yml`)
   - Removed `OXICLOUD_RUST_ASSETS: "1"` environment variable and associated comments
   - This variable is no longer needed since the login page no longer depends on the `OUT_DIR` pipeline

## Related Issue

Removes technical debt from the legacy build system and simplifies the compilation pipeline.

## Type of Change

- [x] Code refactoring
- [x] Performance improvement (eliminates build.rs processing for this asset)

## How Has This Been Tested?

- Existing CI pipeline validates that the template compiles and renders correctly
- The login page functionality remains unchanged; only the rendering mechanism has moved from build-time to runtime
- `build.rs` symlink fix is validated by the successful build of the static assets directory

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing tests pass locally with my changes

https://claude.ai/code/session_01CNCEMN6fC2xSmxqCVbstkd