### PR TITLE
fix(ui): remove default link underline from sidebar nav items

### DIFF
--- a/frontend/src/lib/styles/ported/sidebar.css
+++ b/frontend/src/lib/styles/ported/sidebar.css
@@ -121,7 +121,9 @@
     color: var(--color-sidebar-text);
     font-size: 14.5px;
     font-weight: var(--weight-medium);
-    /* Button resets — .nav-item is a <button> (keyboard-operable nav). */
+    /* .nav-item is an <a> styled as a nav row — drop the default link underline
+       and reset the rest of the inherited link/button chrome. */
+    text-decoration: none;
     font-family: inherit;
     text-align: left;
     appearance: none;


### PR DESCRIPTION
## Why

The sidebar nav rows (Files, Shared, Shared with me, Recent, Favorites, Photos, Music, Trash) rendered with the browser's default link underline.

## Cause

`.nav-item` in `lib/styles/ported/sidebar.css` was ported from a `<button>` (the comment even said so) and carried every button reset *except* `text-decoration`. The new `AppShell.svelte` renders `.nav-item` as an `<a>`, and there's no global anchor reset — so the default link underline showed through.

## Fix

Add `text-decoration: none` to the base `.nav-item` rule (covers normal, hover and active states) and correct the now-inaccurate comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)