### PR TITLE
style(frontend): format manifest.webmanifest with prettier

### DIFF
--- a/frontend/static/manifest.webmanifest
+++ b/frontend/static/manifest.webmanifest
@@ -1,42 +1,42 @@
 {
-  "name": "OxiCloud",
-  "short_name": "OxiCloud",
-  "description": "Fast, private cloud storage built with Rust.",
-  "start_url": "/",
-  "scope": "/",
-  "display": "standalone",
-  "background_color": "#0f172a",
-  "theme_color": "#0f172a",
-  "icons": [
-    {
-      "src": "/logo/logo-plain.svg",
-      "sizes": "any",
-      "type": "image/svg+xml",
-      "purpose": "any"
-    },
-    {
-      "src": "/logo/logo-maskable.svg",
-      "sizes": "any",
-      "type": "image/svg+xml",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/logo/maskable-192.png",
-      "sizes": "192x192",
-      "type": "image/png",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/logo/maskable-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "maskable"
-    },
-    {
-      "src": "/logo/maskable-512.png",
-      "sizes": "512x512",
-      "type": "image/png",
-      "purpose": "any"
-    }
-  ]
+	"name": "OxiCloud",
+	"short_name": "OxiCloud",
+	"description": "Fast, private cloud storage built with Rust.",
+	"start_url": "/",
+	"scope": "/",
+	"display": "standalone",
+	"background_color": "#0f172a",
+	"theme_color": "#0f172a",
+	"icons": [
+		{
+			"src": "/logo/logo-plain.svg",
+			"sizes": "any",
+			"type": "image/svg+xml",
+			"purpose": "any"
+		},
+		{
+			"src": "/logo/logo-maskable.svg",
+			"sizes": "any",
+			"type": "image/svg+xml",
+			"purpose": "maskable"
+		},
+		{
+			"src": "/logo/maskable-192.png",
+			"sizes": "192x192",
+			"type": "image/png",
+			"purpose": "maskable"
+		},
+		{
+			"src": "/logo/maskable-512.png",
+			"sizes": "512x512",
+			"type": "image/png",
+			"purpose": "maskable"
+		},
+		{
+			"src": "/logo/maskable-512.png",
+			"sizes": "512x512",
+			"type": "image/png",
+			"purpose": "any"
+		}
+	]
 }


### PR DESCRIPTION
## Description

`frontend/static/manifest.webmanifest` is not prettier-formatted on `main` (2-space indent vs the repo's tab style). Because `npm run check` ends in `prettier --check .`, the **Frontend — svelte-check, ESLint, Stylelint, Prettier** CI job fails on it for every PR that touches the frontend.

This runs `prettier --write` on that one file to bring it in line. **Whitespace only — no semantic change** to the web app manifest.

```
cd frontend && npx prettier --check static/manifest.webmanifest
# before: [warn] static/manifest.webmanifest
# after:  All matched files use Prettier code style!
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) — unblocks frontend CI

## How Has This Been Tested?

`cd frontend && npm run check` — `prettier --check .` now passes; svelte-check/eslint/stylelint unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)