### PR TITLE
fix(oidc): make SSO callback idempotent + evict stale legacy service worker (#510)

### DIFF
--- a/frontend/src/lib/utils/killLegacyServiceWorker.ts
+++ b/frontend/src/lib/utils/killLegacyServiceWorker.ts
@@ -1,0 +1,28 @@
+export async function killLegacyServiceWorker(): Promise<void> {
+	if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
+
+	try {
+		const registrations = await navigator.serviceWorker.getRegistrations();
+		const legacy = registrations.filter((r) => {
+			const url = r.active?.scriptURL ?? r.waiting?.scriptURL ?? r.installing?.scriptURL ?? '';
+			return url.endsWith('/sw.js');
+		});
+		if (legacy.length === 0) return;
+
+		await Promise.all(legacy.map((r) => r.unregister()));
+
+		if ('caches' in window) {
+			const keys = await caches.keys();
+			await Promise.all(
+				keys.filter((k) => k.startsWith('oxicloud-cache')).map((k) => caches.delete(k))
+			);
+		}
+
+		if (navigator.serviceWorker.controller && !sessionStorage.getItem('legacy-sw-killed')) {
+			sessionStorage.setItem('legacy-sw-killed', '1');
+			location.reload();
+		}
+	} catch {
+		/* best-effort cleanup */
+	}
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -9,6 +9,7 @@
 	import { session } from '$lib/stores/session.svelte';
 	import { ui } from '$lib/stores/ui.svelte';
 	import { hashUrlToPath } from '$lib/utils/hashRedirect';
+	import { killLegacyServiceWorker } from '$lib/utils/killLegacyServiceWorker';
 
 	let { children } = $props();
 
@@ -33,6 +34,8 @@
 	let ready = $state(false);
 
 	onMount(async () => {
+		await killLegacyServiceWorker();
+
 		// The instant HTML boot splash has done its job — the app is mounted, so
 		// the route (login renders immediately; protected routes show their own
 		// loading state) is already in the DOM behind it.

--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -137,6 +137,7 @@ pub struct AuthApplicationService {
     /// Pending one-time token codes for secure token delivery after OIDC callback.
     /// Auto-expires after 60 seconds via moka TTL; max 10 000 entries for DoS protection.
     pending_oidc_tokens: Cache<String, PendingOidcToken>,
+    completed_oidc_logins: Cache<String, String>,
     /// Magic-link token repository — populated when the magic-link feature
     /// is enabled (PR 8+). `None` means redemption endpoints return 503.
     magic_link_repo: Option<Arc<dyn MagicLinkTokenRepository>>,
@@ -180,6 +181,10 @@ impl AuthApplicationService {
             pending_oidc_tokens: Cache::builder()
                 .max_capacity(10_000)
                 .time_to_live(Duration::from_secs(60))
+                .build(),
+            completed_oidc_logins: Cache::builder()
+                .max_capacity(10_000)
+                .time_to_live(Duration::from_secs(120))
                 .build(),
             magic_link_repo: None,
             user_flags_cache: Cache::builder()
@@ -2020,13 +2025,31 @@ impl AuthApplicationService {
     ) -> Result<OidcCallbackResult, DomainError> {
         // 0. Validate CSRF state and retrieve PKCE verifier + nonce + optional NC token
         //    (entry is auto-expired by moka TTL — remove returns None if expired)
-        let flow = self.pending_oidc_flows.remove(state).ok_or_else(|| {
-            tracing::warn!("OIDC callback with invalid/expired state token");
-            DomainError::new(
-                ErrorKind::AccessDenied, "OIDC",
-                "Invalid or expired OIDC state — possible CSRF attack. Please try logging in again.",
-            )
-        })?;
+        let flow = match self.pending_oidc_flows.remove(state) {
+            Some(flow) => flow,
+            None => {
+                if let Some(exchange_code) = self.completed_oidc_logins.get(state) {
+                    tracing::info!(
+                        target: "audit",
+                        event = "oidc.callback_replayed",
+                        reason = "duplicate_callback",
+                        "👮🏻‍♂️ Replayed a recently-completed OIDC login for a duplicate callback (consumed state)",
+                    );
+                    return Ok(OidcCallbackResult::WebLogin { exchange_code });
+                }
+                tracing::warn!(
+                    target: "audit",
+                    event = "oidc.callback_rejected",
+                    reason = "invalid_or_expired_state",
+                    "👮🏻‍♂️ OIDC callback with invalid/expired state token",
+                );
+                return Err(DomainError::new(
+                    ErrorKind::AccessDenied,
+                    "OIDC",
+                    "Invalid or expired OIDC state — possible CSRF attack. Please try logging in again.",
+                ));
+            }
+        };
         let (pkce_verifier, nonce, nc_flow_token) =
             (flow.pkce_verifier, flow.nonce, flow.nc_flow_token);
 
@@ -2323,6 +2346,9 @@ impl AuthApplicationService {
         // Store auth response (auto-expires after 60 s via moka TTL)
         self.pending_oidc_tokens
             .insert(exchange_code.clone(), PendingOidcToken { auth_response });
+
+        self.completed_oidc_logins
+            .insert(state.to_string(), exchange_code.clone());
 
         tracing::info!("OIDC login successful, one-time exchange code generated");
 


### PR DESCRIPTION
## Description

OIDC SSO login intermittently ends on a **403 `Invalid or expired OIDC state — possible CSRF attack`** even though the login has already **succeeded** server-side. Reproduced and confirmed on `diocrafts/oxicloud:0.8.0` (authentik 2025.8.1, behind Tailscale Serve).

### Root cause

The legacy vanilla-JS frontend (removed in #509) registered a `/sw.js` service worker that, with **navigation preload** enabled, **double-fetches** the top-level navigation to `/api/auth/oidc/callback`. The OIDC `state` is single-use, so:

1. callback #1 consumes the state, creates/logs in the user, mints the exchange code, and 307-redirects — *but the browser discards this response*;
2. callback #2 (~0.4 s later, distinct `request_id`) finds the state already consumed → **403**, which is the response the browser renders.

The new SvelteKit frontend registers **no** service worker, so *fresh* clients can't double-fire — but a browser that previously loaded the old frontend still has the stale `/sw.js` registered at scope `/`, and since `/sw.js` now 404s the browser's own cleanup is unreliable. (A reverse-proxy retry would cause the same single-use-state failure.)

Server-side proof from a v0.8.0 instance (two `/authorize`, then callback `…7bea` succeeds and duplicate `…7d82` 403s) is posted on the issue: https://github.com/AtalayaLabs/OxiCloud/issues/510#issuecomment-4762564559

### The fix (two layers)

**Backend — idempotent callback** (`auth_application_service.rs`). After a successful web login, `state → exchange_code` is remembered in a short-lived (120 s) cache. A duplicate callback whose state was already consumed now **replays that same redirect** instead of 403-ing, returning the cached result directly **without** re-running the IdP code exchange (the authorization `code` is single-use too). Keyed by the unguessable 32-byte `state`, so it adds no new attack surface, and it fixes the 403 regardless of *what* caused the duplicate (service worker, proxy retry, …). New audit events: `oidc.callback_replayed` / `oidc.callback_rejected`. The Nextcloud login-flow path is intentionally untouched (it runs in the device's system browser, not the SPA).

> Note: the replay is a best-effort backstop. Because the SW's navigation-preload fallback is sequential, the duplicate reliably arrives *after* the first callback completes and populates the cache. A duplicate racing in *during* the first callback's IdP round-trip would still 403 (rare, self-recovering on retry); the real cure is the frontend half below.

**Frontend — evict the stale worker** (`killLegacyServiceWorker.ts`, wired first in the root layout's `onMount`). Surgically unregisters only `/sw.js` workers, drops only the legacy `oxicloud-cache-*` caches, and reloads once (guarded by `sessionStorage`). This removes the double-fire at its source for returning users; it never disturbs a future intentional service worker.

## Related Issue

Fixes #510.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- **Reproduced** on a live v0.8.0 instance via container logs (see the issue comment linked above).
- `cargo fmt --all --check`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo test --workspace` (all green).
- `cd frontend && npm run check` — svelte-check **0 errors / 0 warnings**, eslint + stylelint clean, the two changed frontend files prettier-clean.

> CI note: the **Frontend** job's `prettier --check .` currently fails on a **pre-existing**, unrelated `manifest.webmanifest` formatting issue on `main` (not touched by this PR). That's fixed by #511 — once it merges I'll rebase this branch and the frontend check goes green.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)