### PR TITLE
fix(oidc): redirect callback to /login so the SPA receives oidc_code

### DIFF
--- a/src/interfaces/api/handlers/auth_handler.rs
+++ b/src/interfaces/api/handlers/auth_handler.rs
@@ -886,8 +886,8 @@ pub async fn oidc_authorize(
 /// Handle the OIDC provider callback.
 ///
 /// Validates the `state` / PKCE / nonce, exchanges the code for tokens, then
-/// redirects the browser to the frontend with a short-lived exchange code
-/// (`/?oidc_code=…`).
+/// redirects the browser to the frontend login route with a short-lived
+/// exchange code (`/login?oidc_code=…`), which the SPA swaps for a session.
 #[utoipa::path(
     get,
     path = "/api/auth/oidc/callback",
@@ -937,7 +937,7 @@ pub async fn oidc_callback(
             // Regular web login, redirect to frontend with exchange code
             let config = auth_app.oidc_config().unwrap();
             let frontend_url = config.frontend_url.trim_end_matches('/');
-            let redirect_url = format!("{}/?oidc_code={}", frontend_url, exchange_code);
+            let redirect_url = format!("{}/login?oidc_code={}", frontend_url, exchange_code);
             tracing::info!("OIDC login successful, redirecting with exchange code");
             Ok(Redirect::temporary(&redirect_url))
         }


### PR DESCRIPTION
## Description

Follow-up to #510 / #512. With the duplicate-callback 403 fixed, a **second** bug surfaces that previously never got a chance to fire: a successful OIDC login still dumps the user back on the sign-in form with no session.

### Root cause

After a successful callback the backend redirects the browser to `{frontend_url}/?oidc_code=…` — the site **root** (`frontend_url` defaults to the base URL). But the SvelteKit SPA only reads `oidc_code` in `routes/login/+page.svelte`:

- `routes/+page.svelte` (root) immediately `goto`s `/files`, and
- the root layout's auth guard bounces an unauthenticated visitor to `/login?redirect=…`

…both of which **drop the `oidc_code` query param**. So `POST /api/auth/oidc/exchange` never runs and no session is established, even though the IdP round-trip and callback succeeded.

### Fix

Redirect to `{frontend_url}/login?oidc_code=…` — the route that actually performs the exchange. `/login` is public, so the auth guard doesn't interfere; after a successful exchange the login page navigates on to the app (`redirectTarget`, default `/files`).

```diff
- let redirect_url = format!("{}/?oidc_code={}", frontend_url, exchange_code);
+ let redirect_url = format!("{}/login?oidc_code={}", frontend_url, exchange_code);
```

## Related Issue

Follow-up to #510 (fixed by #512). This is the second bug in the same flow, which #510's 403 had masked.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Verified **live** on a `diocrafts/oxicloud@main`-built image (authentik IdP, Tailscale Serve). Before: callback succeeded but no `/oidc/exchange` followed → bounced to the login form. After this change, the server logs show the full flow completing:

```
GET  /api/auth/oidc/authorize   → authorize redirect generated
GET  /api/auth/oidc/callback    → user.login → exchange code generated → redirecting
POST /api/auth/oidc/exchange    → "OIDC token exchange successful for user: …"
```

…and the user lands authenticated on `/files`. `cargo fmt --all --check` and `cargo clippy --all-features --all-targets -- -D warnings` pass.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)