### PR TITLE
feat(drive): add drive creation/management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4776,9 +4776,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/docs/plan/drive.md
+++ b/docs/plan/drive.md
@@ -637,13 +637,39 @@ accommodates them without schema migration)
 
 | URL | Resolves to |
 |---|---|
-| `/webdav/<path>` | Caller's personal drive root + `<path>` (back-compat with today's behaviour) |
-| `/webdav/drives/<drive-uuid>/<path>` | Specific drive root + `<path>` |
+| `/webdav/<path>` | Caller's default personal drive root + `<path>` (back-compat with today's behaviour) |
+| `/webdav/@drive/<drive-uuid>/<path>` | Specific drive root + `<path>` |
 
 Today's `/webdav/<path>` handler implicitly looks up the caller's
 home folder and prepends it. Post-drives, the same handler looks up
 the caller's personal drive and resolves paths inside it. **Zero
 breakage** for existing native WebDAV clients.
+
+**Why the `@drive` sigil and NOT `/webdav/drives/<uuid>/...`**
+(earlier draft) or top-level `/drives/<uuid>/...` (also
+considered): `@` is the established structural-routing sigil
+(GitHub `@user/repo`, npm `@scope/pkg`, LDAP `@domain`) — it
+reads as "this is not user content, this is a routing token."
+Realistic collision risk drops to near-zero: nobody creates a
+top-level folder named exactly `@drive` by accident, and the
+defensive layer collapses to a single one-liner in MKCOL / PUT /
+REST create paths that refuses that literal name at any drive
+root. Compared to top-level `/drives/<uuid>/...`, the `@drive`
+shape keeps **one URL root for everything WebDAV** — single
+`<Location>` block in reverse-proxy configs, single mental model
+for sysadmins, single dispatcher in `webdav_routes()`.
+
+**Implementation notes:**
+- Route parser accepts both `/webdav/@drive/<uuid>/...` and the
+  URL-encoded form `/webdav/%40drive/<uuid>/...` — WebDAV clients
+  percent-encode `@` inconsistently.
+- One-liner guard in upload paths refuses creation of a folder
+  literally named `@drive` at any drive root (case-sensitive).
+- `webdav_href()` (today at `webdav_handler.rs:94`) becomes
+  drive-context-aware: responses for a request under
+  `/webdav/@drive/<uuid>/...` must reference back to
+  `/webdav/@drive/<uuid>/...`, otherwise the client follows the
+  `<D:href>` and lands on the back-compat surface (wrong drive).
 
 The `drives` path segment is **reserved**: a folder literally named
 `drives` cannot exist at the top level of any drive. Migration
@@ -1359,9 +1385,13 @@ Pre-flight checks the migration script runs before any writes:
   operator can sanity-check ("Ed has 4 root folders, expected
   ≤1; verify those are real and intended before promoting them
   to drives").
-- Refuse if any sibling root folder is literally named `drives`
-  (would collide with the reserved URL segment on the native
-  `/webdav/drives/<uuid>/...` surface). Operator renames first.
+- (Obsolete with the `/drives/<uuid>/...` top-level URL — kept
+  here for historical context.) Originally the migration was
+  going to refuse any sibling root folder literally named
+  `drives` because the URL surface was `/webdav/drives/<uuid>/...`.
+  D1 moved the explicit-drive selector to a separate top-level
+  `/drives/<uuid>/...` prefix (see §9 "Native WebDAV"), so the
+  collision no longer exists and the pre-check is unnecessary.
 - Refuse if any user has `storage_used_bytes > storage_quota_bytes`
   by an amount that wouldn't fit the destination drive's quota
   semantics (sanity check).
@@ -1382,7 +1412,7 @@ us a real rollback window while the new model bakes in production.
 |---|---|---|
 | **D-Prep — role_grants refactor** | `access_grants → role_grants` schema migration with role-bundle semantics. `Manage` Permission added to the enum + role bundle. Engine reads role_grants only; `access_grants` removed (after one dual-write release if compat is needed). API gains `role` parameter on grant endpoints; audit log emits one `role_grant.*` event per role assignment instead of N permission events. **No Drive concept yet.** Sets the foundation that all subsequent PRs build on. **Data shape confirmed**: empirical audit shows >99% of existing `access_grants` rows already cluster into the standard bundles (viewer/editor/owner) — the migration is mechanical for the vast majority of data; the <1% edge cases get absorbed by shipping `commenter` and `contributor` roles on day one or get an explicit per-row migration decision logged. | **Medium** — touches the load-bearing authorisation table, but the data shape removes the main migration risk |
 | **D0 — foundation** | `storage.drives` schema (no `drive_members` — uses `role_grants` from D-Prep); `Drive` domain entity; migration creating personal drives + backfilling `drive_id` on every resource; read-only `GET /api/drives` listing the caller's drives (single query: `SELECT … FROM role_grants WHERE subject_id=$caller AND resource_type='drive'`). Dual-write `user_id` alongside `drive_id` for safety. **No new UI.** **Every upload path stamps `drive_id` at insert**: classic multipart (`file_handler::upload`), chunked NC (`uploads_handler`), streaming CDC (`upload_ingest`), delta upload (`delta_upload_service`), instant upload by hash. Tantivy reindex (see §11) is part of this PR. **Provenance columns added** (see §14): `created_by` and `updated_by` on both `storage.folders` and `storage.files`, FK to `auth.users` with `ON DELETE SET NULL`; backfilled from `user_id` so pre-Drive content has provenance from day one; every mutation path that touches `updated_at` also sets `updated_by`. | **High** — every storage query touches, all upload paths touched |
-| **D1 — UI switcher + URL routing** | Sidebar drive picker, `/files/<folder-id>` reused for cross-drive navigation (existing route — drive context recovered server-side from `folders.drive_id`), `/config/drive/<drive-uuid>` new route for drive admin. `/` redirects to `/files/<root-folder-id>` of the caller's default personal drive (internal users) or `/shared-with-me` (external users with no personal drive). WebDAV path dispatcher recognising `drives/<uuid>` as the drive-explicit prefix on `/webdav/` (NC keeps the credential-side scheme — see §9). `/drive/<...>` reserved for future use. | Medium |
+| **D1 — UI switcher + URL routing** | Sidebar drive picker, `/files/<folder-id>` reused for cross-drive navigation (existing route — drive context recovered server-side from `folders.drive_id`), `/config/drive/<drive-uuid>` new route for drive admin. `/` redirects to `/files/<root-folder-id>` of the caller's default personal drive (internal users) or `/shared-with-me` (external users with no personal drive). Native WebDAV gets a new `/webdav/@drive/<uuid>/...` route alongside the existing `/webdav/<path>` (which keeps mapping to the caller's default drive — zero back-compat breakage); the `@drive` sigil keeps everything WebDAV under one URL root with near-zero collision risk. NC keeps the credential-side scheme — see §9. `/drive/<...>` (singular, on the SPA) reserved for future use. | Medium |
 | **D2 — drive membership API + per-drive trash auth** | `POST /api/drives/{id}/members`, `DELETE`, `PUT` for role changes — thin handlers that translate to `role_grants` INSERT/DELETE/UPDATE with `resource_type='drive'`. `Resource::Drive(Uuid)` (added in D-Prep at the enum level) gets its specialised handler surface here. Shared-drive last-owner protection. Group-as-subject support reuses the existing `subject_groups` machinery. **Personal-drive guards** (`add_member`, `remove_member`, `delete_drive` refuse on `kind='personal'` — see §2). **Per-drive trash authorisation** (§12): trash listing filters by drive(s) the caller can read; trash mutations (send/restore/permanent-delete) require `role='owner'` on the drive; `storage.trash_items` VIEW updated to surface `drive_id`; orphan/aborted-upload sweep becomes per-drive. | Medium |
 | **D3 — group-owned shared drives** | "Create shared drive" flow — admin or group owner triggers, drive created with `kind='shared'`, initial owner row is the group. Group-deletion guard refuses if the group is the last owner of any drive. Drive-rename, drive-delete. | Low |
 | **D4 — per-drive quota** | Move storage accounting off `auth.users.storage_used_bytes` onto `storage.drives.used_bytes`. **Re-point the existing per-user incremental CTE** (introduced in v0.7.0 — see `b5b80549`, `d6987329`) at drive rows; don't reinvent the counting logic. Upload paths check `drive.quota_bytes` instead of (or in addition to) the user's quota for the dual-write window. **Per-chunk incremental quota check on the NC chunked path** (see §13): MKCOL refuses when the drive is already over quota; each PUT chunk runs an O(1) `used + session_so_far + chunk_size > quota` test and refuses with 507 within one chunk of wasted upload. Closes a pre-existing wart where NC clients could upload GB before learning they were over quota. Reconciliation job runs once per day to fix drift. | Medium |
@@ -1656,8 +1686,14 @@ test`), **(c)** `cargo fmt && cargo clippy --all-features
 
 ### D1
 - **Routing**: `cargo build` clean; WebDAV dispatcher routes
-  `/webdav/drives/<uuid>/...` correctly; `/webdav/<path>` still
-  resolves to the caller's default drive (back-compat).
+  `/webdav/@drive/<uuid>/...` correctly (also accepts the
+  URL-encoded `/webdav/%40drive/<uuid>/...` form);
+  `/webdav/<path>` still resolves to the caller's default drive
+  (back-compat).
+- **Collision guard**: MKCOL / PUT / REST refuse creation of a
+  folder literally named `@drive` at any drive root (case-sensitive,
+  exact match — sub-folders named `@drive` deeper in the tree are
+  allowed, the guard is only at root depth).
 - **NC client back-compat**: a real NC sync client pointed at
   `/remote.php/dav/files/admin/` continues syncing the user's default
   personal drive without reconfiguration. The chroot POC's `~`

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5277,21 +5277,6 @@
         }
       }
     },
-    "node_modules/svelte-check/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/svelte-eslint-parser": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/svelte-eslint-parser/-/svelte-eslint-parser-1.8.0.tgz",
@@ -6545,24 +6530,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/frontend/src/lib/api/endpoints/admin.ts
+++ b/frontend/src/lib/api/endpoints/admin.ts
@@ -5,7 +5,7 @@
  */
 import { apiFetch, apiJson } from '$lib/api/client';
 import { getCsrfHeaders } from '$lib/api/csrf';
-import type { User } from '$lib/api/types';
+import type { Drive, DriveMember, DriveMemberSubject, DriveRole, User } from '$lib/api/types';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
@@ -67,6 +67,94 @@ export interface GeneratedKey {
 /** Generate a random AES-256 key for at-rest blob encryption. */
 export function generateEncryptionKey(): Promise<GeneratedKey> {
 	return postJson<GeneratedKey>('/api/admin/settings/storage/generate-key');
+}
+
+// ── Drives ──────────────────────────────────────────────────────────────
+
+/**
+ * `GET /api/admin/drives` — every drive on the system, admin-only.
+ *
+ * Distinct from `listDrives()` in `$lib/api/endpoints/drives`, which is
+ * the caller's own listing (filtered through `role_grants`). An admin
+ * who creates a shared drive for someone else has no role on it, so
+ * the user-facing listing would skip it — this endpoint returns
+ * everything for the admin panel's "Drives" tab.
+ */
+export function listAllDrives(): Promise<Drive[]> {
+	return apiJson<Drive[]>('/api/admin/drives', { credentials: 'same-origin' });
+}
+
+/**
+ * `GET /api/admin/drives/{id}/members` — every role grant on a drive,
+ * admin-only. The user-facing `/api/drives/{id}/members` requires
+ * `Permission::Read` on the drive; an admin who created the drive
+ * for someone else has no role on it and would hit a 404 there. This
+ * endpoint reuses `list_grants_on_resource` with the admin guard at
+ * the route edge, so the same `DriveMember` shape comes back.
+ */
+export function listDriveMembersAdmin(driveId: string): Promise<DriveMember[]> {
+	return apiJson<DriveMember[]>(`/api/admin/drives/${encodeURIComponent(driveId)}/members`, {
+		credentials: 'same-origin'
+	});
+}
+
+/**
+ * `POST /api/admin/drives/{id}/members` — add (or refresh) a member as
+ * an admin, bypassing the per-drive `Manage` check. Personal-drive
+ * guard + last-owner protection still apply. Throws on non-2xx.
+ */
+export async function addDriveMemberAdmin(
+	driveId: string,
+	subject: DriveMemberSubject,
+	role: DriveRole,
+	expiresAt?: string | null
+): Promise<DriveMember> {
+	const res = await apiFetch(`/api/admin/drives/${encodeURIComponent(driveId)}/members`, {
+		method: 'POST',
+		credentials: 'same-origin',
+		headers: { ...JSON_HEADERS, ...getCsrfHeaders() },
+		body: JSON.stringify({ subject, role, expires_at: expiresAt ?? null })
+	});
+	if (!res.ok) {
+		let detail = '';
+		try {
+			const parsed = (await res.json()) as { error?: string; message?: string };
+			detail = parsed.error ?? parsed.message ?? '';
+		} catch {
+			/* response body wasn't JSON */
+		}
+		throw new Error(detail || `add member failed: ${res.status}`);
+	}
+	return (await res.json()) as DriveMember;
+}
+
+/**
+ * `DELETE /api/admin/drives/{id}/members/{kind}/{sid}` — remove a
+ * member as an admin. Idempotent (removing a non-member returns 204).
+ * Last-owner protection still applies (400 with `reason='last_owner'`).
+ */
+export async function removeDriveMemberAdmin(
+	driveId: string,
+	subject: DriveMemberSubject
+): Promise<void> {
+	const url =
+		`/api/admin/drives/${encodeURIComponent(driveId)}/members/` +
+		`${encodeURIComponent(subject.type)}/${encodeURIComponent(subject.id)}`;
+	const res = await apiFetch(url, {
+		method: 'DELETE',
+		credentials: 'same-origin',
+		headers: getCsrfHeaders()
+	});
+	if (!res.ok) {
+		let detail = '';
+		try {
+			const parsed = (await res.json()) as { error?: string; message?: string };
+			detail = parsed.error ?? parsed.message ?? '';
+		} catch {
+			/* response body wasn't JSON */
+		}
+		throw new Error(detail || `remove member failed: ${res.status}`);
+	}
 }
 
 // ── Users ───────────────────────────────────────────────────────────────

--- a/frontend/src/lib/api/endpoints/drives.ts
+++ b/frontend/src/lib/api/endpoints/drives.ts
@@ -1,6 +1,6 @@
 /**
- * Drives endpoints. D0 ships read-only listing; D2 adds the membership API.
- * D3 will add the create-shared-drive flow under the same module.
+ * Drives endpoints. D0 ships read-only listing; D2 adds the membership API;
+ * D3a adds the create-shared-drive flow.
  *
  * Consumers usually go through the `drives` store (`$lib/stores/drives.svelte`)
  * which dedupes the request and caches the list — touch this module directly
@@ -8,13 +8,46 @@
  */
 import { apiFetch, apiJson } from '$lib/api/client';
 import { getCsrfHeaders } from '$lib/api/csrf';
-import type { Drive, DriveMember, DriveMemberSubject, DriveRole } from '$lib/api/types';
+import type {
+	CreateDriveBody,
+	Drive,
+	DriveMember,
+	DriveMemberSubject,
+	DriveRole
+} from '$lib/api/types';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 /** `GET /api/drives` — every drive the caller can read, default first by convention. */
 export function listDrives(): Promise<Drive[]> {
 	return apiJson<Drive[]>('/api/drives', { credentials: 'same-origin' });
+}
+
+/**
+ * `POST /api/drives` — create a drive (D3a). Today only `kind: 'shared'` is
+ * implemented; `kind: 'personal'` is accepted on the wire but returns 501.
+ * Admin-only at the server; callers should already have gated the UI on
+ * `session.user?.role === 'admin'`. Throws on non-2xx with the server's
+ * error body parsed where possible.
+ */
+export async function createDrive(body: CreateDriveBody): Promise<Drive> {
+	const res = await apiFetch('/api/drives', {
+		method: 'POST',
+		headers: { ...JSON_HEADERS, ...getCsrfHeaders() },
+		credentials: 'same-origin',
+		body: JSON.stringify(body)
+	});
+	if (!res.ok) {
+		let detail = '';
+		try {
+			const parsed = (await res.json()) as { error?: string; message?: string };
+			detail = parsed.error ?? parsed.message ?? '';
+		} catch {
+			/* response body wasn't JSON */
+		}
+		throw new Error(detail || `create drive failed: ${res.status}`);
+	}
+	return (await res.json()) as Drive;
 }
 
 /** `GET /api/drives/{id}/members` — every role grant on the drive. */

--- a/frontend/src/lib/api/endpoints/drives.ts
+++ b/frontend/src/lib/api/endpoints/drives.ts
@@ -1,15 +1,92 @@
 /**
- * Drives endpoints. D0 ships read-only listing; mutations (create / rename /
- * member changes) land in D2/D3 and will be added here under the same shape.
+ * Drives endpoints. D0 ships read-only listing; D2 adds the membership API.
+ * D3 will add the create-shared-drive flow under the same module.
  *
  * Consumers usually go through the `drives` store (`$lib/stores/drives.svelte`)
  * which dedupes the request and caches the list — touch this module directly
  * only when bypassing the cache is intentional (e.g. an explicit refresh).
  */
-import { apiJson } from '$lib/api/client';
-import type { Drive } from '$lib/api/types';
+import { apiFetch, apiJson } from '$lib/api/client';
+import { getCsrfHeaders } from '$lib/api/csrf';
+import type { Drive, DriveMember, DriveMemberSubject, DriveRole } from '$lib/api/types';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 /** `GET /api/drives` — every drive the caller can read, default first by convention. */
 export function listDrives(): Promise<Drive[]> {
 	return apiJson<Drive[]>('/api/drives', { credentials: 'same-origin' });
+}
+
+/** `GET /api/drives/{id}/members` — every role grant on the drive. */
+export function listDriveMembers(driveId: string): Promise<DriveMember[]> {
+	return apiJson<DriveMember[]>(`/api/drives/${encodeURIComponent(driveId)}/members`, {
+		credentials: 'same-origin'
+	});
+}
+
+/**
+ * `POST /api/drives/{id}/members` — add a member (or refresh an existing
+ * subject's role; the underlying `set_role` is idempotent via UNIQUE
+ * `(subject, resource)`).
+ *
+ * Refused with 405 on personal drives (immutable membership) and 400 if a
+ * last-owner demotion would orphan a shared drive.
+ */
+export async function addDriveMember(
+	driveId: string,
+	subject: DriveMemberSubject,
+	role: DriveRole,
+	expiresAt?: string | null
+): Promise<DriveMember> {
+	const res = await apiFetch(`/api/drives/${encodeURIComponent(driveId)}/members`, {
+		method: 'POST',
+		headers: { ...JSON_HEADERS, ...getCsrfHeaders() },
+		credentials: 'same-origin',
+		body: JSON.stringify({ subject, role, expires_at: expiresAt ?? null })
+	});
+	if (!res.ok) throw new Error(`add member failed: ${res.status}`);
+	return (await res.json()) as DriveMember;
+}
+
+/**
+ * `PATCH /api/drives/{id}/members/{kind}/{sid}` — change a member's role.
+ * Same guards as `addDriveMember` apply.
+ */
+export async function updateDriveMember(
+	driveId: string,
+	subject: DriveMemberSubject,
+	role: DriveRole,
+	expiresAt?: string | null
+): Promise<DriveMember> {
+	const url =
+		`/api/drives/${encodeURIComponent(driveId)}/members/` +
+		`${encodeURIComponent(subject.type)}/${encodeURIComponent(subject.id)}`;
+	const res = await apiFetch(url, {
+		method: 'PATCH',
+		headers: { ...JSON_HEADERS, ...getCsrfHeaders() },
+		credentials: 'same-origin',
+		body: JSON.stringify({ role, expires_at: expiresAt ?? null })
+	});
+	if (!res.ok) throw new Error(`update member failed: ${res.status}`);
+	return (await res.json()) as DriveMember;
+}
+
+/**
+ * `DELETE /api/drives/{id}/members/{kind}/{sid}` — remove a member.
+ * Idempotent (removing a non-member returns 204). Refused with 400 if it
+ * would leave a shared drive without an owner.
+ */
+export async function removeDriveMember(
+	driveId: string,
+	subject: DriveMemberSubject
+): Promise<void> {
+	const url =
+		`/api/drives/${encodeURIComponent(driveId)}/members/` +
+		`${encodeURIComponent(subject.type)}/${encodeURIComponent(subject.id)}`;
+	const res = await apiFetch(url, {
+		method: 'DELETE',
+		headers: getCsrfHeaders(),
+		credentials: 'same-origin'
+	});
+	if (!res.ok) throw new Error(`remove member failed: ${res.status}`);
 }

--- a/frontend/src/lib/api/endpoints/grants.ts
+++ b/frontend/src/lib/api/endpoints/grants.ts
@@ -4,6 +4,15 @@ import { getCsrfHeaders } from '$lib/api/csrf';
 import type { ItemType } from '$lib/api/types';
 import type { ResourceBody, ResourcePage } from './resources';
 
+/**
+ * Resource kinds the `/api/grants` family addresses. File/folder grants flow
+ * through the cascade engine; drive grants flow through
+ * `DriveManagementService` server-side, which layers personal-drive guard +
+ * last-owner protection on top of the same role-grant write. Either way the
+ * wire shape is identical, so the FE helpers below accept all three.
+ */
+export type GrantResourceType = ItemType | 'drive';
+
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
 export type SubjectType = 'user' | 'group' | 'email' | 'token';
@@ -38,7 +47,7 @@ export interface Grant {
 	granted_by?: string;
 	subject: GrantSubject;
 	role: string;
-	resource: { type: ItemType; id: string };
+	resource: { type: GrantResourceType; id: string };
 	expires_at?: string | null;
 }
 
@@ -80,14 +89,14 @@ export function expiryToIso(date: string | null | undefined): string | null {
 	return date ? new Date(`${date}T00:00:00Z`).toISOString() : null;
 }
 
-export function fetchGrantsForResource(type: ItemType, id: string): Promise<Grant[]> {
+export function fetchGrantsForResource(type: GrantResourceType, id: string): Promise<Grant[]> {
 	const params = new URLSearchParams({ resource_type: type, resource_id: id });
 	return apiJson<Grant[]>(`/api/grants?${params}`, { credentials: 'same-origin' });
 }
 
 export async function createGrant(
 	subject: GrantSubjectInput,
-	resource: { type: ItemType; id: string },
+	resource: { type: GrantResourceType; id: string },
 	role: ShareRole,
 	expiresAt?: string | null
 ): Promise<CreateGrantResponse> {
@@ -106,7 +115,7 @@ export async function createGrant(
 
 export async function updateGrantRole(
 	subject: GrantSubject,
-	resource: { type: ItemType; id: string },
+	resource: { type: GrantResourceType; id: string },
 	role: ShareRole,
 	expiresAt?: string | null
 ): Promise<void> {
@@ -148,7 +157,7 @@ export async function notifyGrantRecipient(grantId: string): Promise<NotifyOutco
 }
 
 export interface IncomingGrantItem {
-	resource_type: ItemType;
+	resource_type: GrantResourceType;
 	resource: ResourceBody;
 	granted_by?: string;
 	granted_at?: string;
@@ -169,7 +178,7 @@ export interface OutgoingResourceGrant {
 }
 
 export interface OutgoingGrantItem {
-	resource_type: ItemType;
+	resource_type: GrantResourceType;
 	resource: ResourceBody;
 	first_shared_at?: string;
 	/** One entry per (subject, permissions) pair. */

--- a/frontend/src/lib/api/endpoints/recipients.ts
+++ b/frontend/src/lib/api/endpoints/recipients.ts
@@ -40,28 +40,45 @@ function looksLikeEmail(q: string): boolean {
 }
 
 // The system book lists all users; we filter client-side (matches the original).
+// Two caches because the backend response differs (default excludes the caller,
+// `?include_self=1` returns them). Keying by flag avoids one variant overwriting
+// the other.
 let contactCache: Contact[] | null = null;
+let contactCacheWithSelf: Contact[] | null = null;
 /** `false` once we confirm the system address book is unavailable. */
 let directoryAvailable: boolean | null = null;
 
-async function systemContacts(): Promise<Contact[]> {
-	if (contactCache) return contactCache;
+async function systemContacts(includeSelf = false): Promise<Contact[]> {
+	const cached = includeSelf ? contactCacheWithSelf : contactCache;
+	if (cached) return cached;
 	try {
-		const res = await apiFetch('/api/address-books/system/contacts', {
-			credentials: 'same-origin'
-		});
+		const url = includeSelf
+			? '/api/address-books/system/contacts?include_self=1'
+			: '/api/address-books/system/contacts';
+		const res = await apiFetch(url, { credentials: 'same-origin' });
 		if (!res.ok) {
 			directoryAvailable = false;
+			if (includeSelf) {
+				contactCacheWithSelf = [];
+				return contactCacheWithSelf;
+			}
 			contactCache = [];
 			return contactCache;
 		}
 		directoryAvailable = true;
-		contactCache = (await res.json()) as Contact[];
+		const list = (await res.json()) as Contact[];
+		if (includeSelf) contactCacheWithSelf = list;
+		else contactCache = list;
+		return list;
 	} catch {
 		directoryAvailable = false;
+		if (includeSelf) {
+			contactCacheWithSelf = [];
+			return contactCacheWithSelf;
+		}
 		contactCache = [];
+		return contactCache;
 	}
-	return contactCache;
 }
 
 /**
@@ -135,16 +152,23 @@ export function resolveRecipient(type: 'user' | 'group', id: string): Recipient 
 /**
  * Combined user + group results matching the query (case-insensitive), plus a
  * synthetic invite-by-email suggestion when the query is an email that no
- * contact already owns. The current logged-in user is excluded — you can't
- * share with yourself. Capped at 8 combined (groups, then users, then email).
+ * contact already owns. Capped at 8 combined (groups, then users, then email).
+ *
+ * `includeSelf` defaults to `false` — the share modal excludes the current
+ * caller from the picker because "you can't share with yourself". The admin
+ * drive-owners surface flips it on: an admin legitimately needs to add
+ * themselves (or anyone) as Owner without that personal-share restriction.
  */
-export async function searchRecipients(query: string): Promise<Recipient[]> {
+export async function searchRecipients(
+	query: string,
+	{ includeSelf = false }: { includeSelf?: boolean } = {}
+): Promise<Recipient[]> {
 	const q = query.toLowerCase().trim();
 	if (!q) return [];
 	const currentUserId = session.user?.id ?? null;
-	const [contacts, groups] = await Promise.all([systemContacts(), searchGroups(q)]);
+	const [contacts, groups] = await Promise.all([systemContacts(includeSelf), searchGroups(q)]);
 	const matched = contacts
-		.filter((c) => c.id !== currentUserId)
+		.filter((c) => includeSelf || c.id !== currentUserId)
 		.map((c) => ({ c, ...contactLabel(c) }))
 		.filter(
 			({ label, email }) => label.toLowerCase().includes(q) || email.toLowerCase().includes(q)

--- a/frontend/src/lib/api/endpoints/recipients.ts
+++ b/frontend/src/lib/api/endpoints/recipients.ts
@@ -52,8 +52,11 @@ async function systemContacts(includeSelf = false): Promise<Contact[]> {
 	const cached = includeSelf ? contactCacheWithSelf : contactCache;
 	if (cached) return cached;
 	try {
+		// `?include_self=true` (not `=1`) — Axum's `Query` extractor uses
+		// `serde_urlencoded`, which only deserialises `"true"`/`"false"`
+		// for `bool`. Sending `=1` would 400 before the handler runs.
 		const url = includeSelf
-			? '/api/address-books/system/contacts?include_self=1'
+			? '/api/address-books/system/contacts?include_self=true'
 			: '/api/address-books/system/contacts';
 		const res = await apiFetch(url, { credentials: 'same-origin' });
 		if (!res.ok) {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -120,6 +120,14 @@ export interface TrashResourceItem {
 	resource_type: ItemType;
 	trashed_at: string;
 	deletion_date: string;
+	/**
+	 * Drive the trashed item belongs to (D2b). Enables client-side
+	 * group-by-drive in the `/trash` UI without resolving the drive from
+	 * `resource.drive_id` per row. The drive's display name resolves
+	 * against `drives.svelte` (the in-memory store already populated by
+	 * the sidebar picker / config pages — no extra round-trip).
+	 */
+	drive_id: string;
 	resource: FileItem | FolderItem;
 }
 

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -244,6 +244,19 @@ export interface Drive {
 }
 
 /**
+ * Request body for `POST /api/drives` (D3a). Mirrors `CreateDriveDto` in
+ * `src/interfaces/api/handlers/drive_handler.rs`. `kind: 'personal'` is a
+ * recognised wire shape but returns 501 today (the authz model + quota
+ * source for secondary personals are still open product questions).
+ */
+export interface CreateDriveBody {
+	kind: DriveKind;
+	name: string;
+	owner: DriveMemberSubject;
+	quota_bytes?: number | null;
+}
+
+/**
  * One row from `GET /api/drives/{id}/members`. Mirrors `GrantDto` in
  * `src/application/dtos/grant_dto.rs` — the shape is the same as any
  * other role-grant; drive membership just constrains `resource.type` to

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -199,11 +199,27 @@ export interface SearchResults {
 
 export type DriveKind = 'personal' | 'shared';
 
+/** Role-keyed share strength. Matches `Role` in the backend authz model. */
+export type DriveRole = 'owner' | 'editor' | 'contributor' | 'commenter' | 'viewer';
+
+/** Subject of a grant. Mirrors `SubjectDto`. */
+export type SubjectKind = 'user' | 'group' | 'token';
+export interface DriveMemberSubject {
+	type: SubjectKind;
+	id: string;
+}
+
 /**
  * One row from `GET /api/drives`. Mirrors `DriveDto` in
  * `src/application/dtos/drive_dto.rs`. `default_for_user` is the caller's
  * id when present, `null`/undefined otherwise — used to pick the default
  * personal drive without hard-coding name conventions.
+ *
+ * `caller_role` is the strongest role the calling user holds on this drive
+ * (direct + group-mediated, collapsed). Drives the permission-aware UI
+ * gating on `/config/drive/<id>` and similar pages. `undefined` in
+ * contexts where the caller is the granter rather than a member (e.g.
+ * outgoing-grants listing).
  */
 export interface Drive {
 	id: string;
@@ -216,4 +232,21 @@ export interface Drive {
 	policies: Record<string, unknown>;
 	created_at: string;
 	updated_at: string;
+	caller_role?: DriveRole | null;
+}
+
+/**
+ * One row from `GET /api/drives/{id}/members`. Mirrors `GrantDto` in
+ * `src/application/dtos/grant_dto.rs` — the shape is the same as any
+ * other role-grant; drive membership just constrains `resource.type` to
+ * `"drive"`.
+ */
+export interface DriveMember {
+	id: string;
+	subject: DriveMemberSubject;
+	resource: { type: 'drive'; id: string };
+	role: DriveRole;
+	granted_by: string;
+	granted_at: string;
+	expires_at?: string | null;
 }

--- a/frontend/src/lib/components/DrivePicker.svelte
+++ b/frontend/src/lib/components/DrivePicker.svelte
@@ -62,23 +62,13 @@
 	onMount(() => {
 		void drivesStore.load();
 	});
-
-	// Dev/test override — set `localStorage.setItem('oxi-show-drive-picker', '1')`
-	// from DevTools to force the picker visible even with a single drive (useful
-	// for testing the UI before D3's shared-drive creation lands). Evaluated once
-	// at component mount; reload after toggling to apply.
-	const forceShowPicker = $derived(
-		typeof localStorage !== 'undefined' && localStorage.getItem('oxi-show-drive-picker') === '1'
-	);
 </script>
 
 <!-- Only show the drive switcher when there's an actual choice to make. With a
      single drive (the default personal one) the picker just repeats "Personal"
      under the Files nav row, so hide it; it reappears the moment a second drive
-     (e.g. a shared one) exists.
-
-     `forceShowPicker` is the localStorage-driven dev override (see script). -->
-{#if drivesStore.loaded && (drivesStore.drives.length > 1 || forceShowPicker)}
+     (e.g. a shared one created from the admin Drives tab) exists. -->
+{#if drivesStore.loaded && drivesStore.drives.length > 1}
 	<ul class="drive-picker" aria-label={t('drive.picker', 'Drives')}>
 		{#each sortedDrives as d (d.id)}
 			<li class="drive-picker__row" class:drive-picker__row--active={isActive(d)}>

--- a/frontend/src/lib/components/DrivePicker.svelte
+++ b/frontend/src/lib/components/DrivePicker.svelte
@@ -62,13 +62,23 @@
 	onMount(() => {
 		void drivesStore.load();
 	});
+
+	// Dev/test override — set `localStorage.setItem('oxi-show-drive-picker', '1')`
+	// from DevTools to force the picker visible even with a single drive (useful
+	// for testing the UI before D3's shared-drive creation lands). Evaluated once
+	// at component mount; reload after toggling to apply.
+	const forceShowPicker = $derived(
+		typeof localStorage !== 'undefined' && localStorage.getItem('oxi-show-drive-picker') === '1'
+	);
 </script>
 
 <!-- Only show the drive switcher when there's an actual choice to make. With a
      single drive (the default personal one) the picker just repeats "Personal"
      under the Files nav row, so hide it; it reappears the moment a second drive
-     (e.g. a shared one) exists. -->
-{#if drivesStore.loaded && drivesStore.drives.length > 1}
+     (e.g. a shared one) exists.
+
+     `forceShowPicker` is the localStorage-driven dev override (see script). -->
+{#if drivesStore.loaded && (drivesStore.drives.length > 1 || forceShowPicker)}
 	<ul class="drive-picker" aria-label={t('drive.picker', 'Drives')}>
 		{#each sortedDrives as d (d.id)}
 			<li class="drive-picker__row" class:drive-picker__row--active={isActive(d)}>

--- a/frontend/src/lib/components/OwnerAvatarStack.svelte
+++ b/frontend/src/lib/components/OwnerAvatarStack.svelte
@@ -1,0 +1,207 @@
+<script lang="ts">
+	import Icon from '$lib/icons/Icon.svelte';
+	import { t } from '$lib/i18n/index.svelte';
+	import { resolveRecipient } from '$lib/api/endpoints/recipients';
+	import { resolveUser, type ResolvedUser } from '$lib/api/endpoints/users';
+	import { userInitials, avatarColorIndex } from '$lib/utils/avatar';
+	import type { DriveMember } from '$lib/api/types';
+
+	interface Props {
+		members: DriveMember[];
+		max?: number;
+	}
+	let { members, max = 6 }: Props = $props();
+
+	// Render only Owner-role grants and exclude token subjects (they can't
+	// own a drive per the service contract; defensive filter so a stray
+	// row from a future role doesn't render as an avatar).
+	const owners = $derived(
+		members.filter(
+			(m) => m.role === 'owner' && (m.subject.type === 'user' || m.subject.type === 'group')
+		)
+	);
+
+	const shown = $derived(owners.slice(0, max));
+	const overflow = $derived(Math.max(0, owners.length - shown.length));
+
+	// Per-user profile cache (image + email + real name). The cache itself
+	// lives in `resolveUser`; this state just mirrors what we've fetched so
+	// reactive `$derived` recomputes when a lookup lands.
+	let resolved = $state<Record<string, ResolvedUser | null>>({});
+
+	$effect(() => {
+		// Refresh on every membership change. `resolveUser` dedupes
+		// concurrent calls and caches per id, so this is cheap when the
+		// same id reappears across rows.
+		const users = owners.filter((m) => m.subject.type === 'user');
+		for (const m of users) {
+			if (m.subject.id in resolved) continue;
+			void resolveUser(m.subject.id).then((u) => {
+				resolved = { ...resolved, [m.subject.id]: u };
+			});
+		}
+	});
+
+	function nameFor(m: DriveMember): string {
+		if (m.subject.type === 'group') return resolveRecipient('group', m.subject.id).label;
+		return resolved[m.subject.id]?.name ?? resolveRecipient('user', m.subject.id).label;
+	}
+
+	function imageFor(m: DriveMember): string | null {
+		if (m.subject.type !== 'user') return null;
+		return resolved[m.subject.id]?.image ?? null;
+	}
+
+	function isExternalFor(m: DriveMember): boolean {
+		if (m.subject.type !== 'user') return false;
+		return resolved[m.subject.id]?.isExternal ?? false;
+	}
+
+	// "Name — email" tooltip; group falls back to label only.
+	function titleFor(m: DriveMember): string {
+		const name = nameFor(m);
+		if (m.subject.type === 'group') return name;
+		const email = resolved[m.subject.id]?.email ?? '';
+		return email ? `${name} — ${email}` : name;
+	}
+</script>
+
+{#if owners.length === 0}
+	<span class="owner-stack__empty">{t('admin.drive_no_owners', 'No owners')}</span>
+{:else}
+	<ul class="owner-stack" aria-label={t('admin.drive_owners_aria', 'Drive owners')}>
+		{#each shown as m (`${m.subject.type}-${m.subject.id}`)}
+			{@const title = titleFor(m)}
+			{@const image = imageFor(m)}
+			<li class="owner-stack__chip" {title}>
+				{#if m.subject.type === 'group'}
+					<span class="owner-stack__avatar owner-stack__avatar--group">
+						<Icon name="users" />
+					</span>
+				{:else if image}
+					<img class="owner-stack__photo" src={image} alt="" />
+				{:else}
+					<span class="owner-stack__avatar owner-stack__avatar--c{avatarColorIndex(m.subject.id)}">
+						{userInitials(nameFor(m))}
+					</span>
+				{/if}
+				{#if isExternalFor(m)}
+					<span class="owner-stack__ext-badge" title={t('share.externalUser', 'External user')}>
+						<Icon name="building-circle-xmark" />
+					</span>
+				{/if}
+			</li>
+		{/each}
+		{#if overflow > 0}
+			<li class="owner-stack__chip" title={owners.slice(max).map(titleFor).join('\n')}>
+				<span class="owner-stack__avatar owner-stack__avatar--more">
+					+{overflow}
+				</span>
+			</li>
+		{/if}
+	</ul>
+{/if}
+
+<style>
+	.owner-stack {
+		display: inline-flex;
+		flex-direction: row;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	/* Negative margin = overlap. The chip after this one slides under,
+	   producing the stacked look. First chip keeps full margin so the
+	   leftmost avatar isn't clipped by the container. */
+	.owner-stack__chip {
+		position: relative;
+		margin-left: -0.5rem;
+	}
+
+	.owner-stack__chip:first-child {
+		margin-left: 0;
+	}
+
+	.owner-stack__avatar,
+	.owner-stack__photo {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.75rem;
+		height: 1.75rem;
+		border-radius: 50%;
+		font-size: 0.7rem;
+		font-weight: var(--weight-semibold, 600);
+		color: var(--color-text-light);
+		border: 2px solid var(--color-bg-surface);
+		box-sizing: border-box;
+		user-select: none;
+		object-fit: cover;
+		overflow: hidden;
+	}
+
+	/* Group icon avatar — neutral background, distinct from the coloured
+	   user buckets so a viewer can tell user-vs-group at a glance. */
+	.owner-stack__avatar--group {
+		background: var(--color-bg-muted);
+		color: var(--color-text);
+	}
+
+	/* "+N" overflow chip mirrors the group neutral palette. */
+	.owner-stack__avatar--more {
+		background: var(--color-bg-muted);
+		color: var(--color-text);
+		font-weight: var(--weight-semibold, 600);
+		font-size: 0.65rem;
+	}
+
+	/* Colour buckets mirror UserVignette so the same user gets the same
+	   colour across the app. */
+	.owner-stack__avatar--c0 {
+		background: var(--color-badge-indigo-bg);
+		color: var(--color-badge-indigo-text);
+	}
+
+	.owner-stack__avatar--c1 {
+		background: var(--color-badge-green-bg);
+		color: var(--color-badge-green-text);
+	}
+
+	.owner-stack__avatar--c2 {
+		background: var(--color-badge-orange-bg);
+		color: var(--color-badge-orange-text);
+	}
+
+	.owner-stack__avatar--c3 {
+		background: var(--color-badge-blue-bg);
+		color: var(--color-badge-blue-text);
+	}
+
+	.owner-stack__avatar--c4 {
+		background: var(--color-badge-amber-bg);
+		color: var(--color-badge-amber-text);
+	}
+
+	/* External-user marker — small badge in the bottom-right corner. */
+	.owner-stack__ext-badge {
+		position: absolute;
+		right: -2px;
+		bottom: -2px;
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 0.85rem;
+		height: 0.85rem;
+		border-radius: 50%;
+		background: var(--color-bg-surface);
+		color: var(--color-text-muted);
+		font-size: 0.55rem;
+	}
+
+	.owner-stack__empty {
+		color: var(--color-text-muted);
+		font-style: italic;
+		font-size: 0.8125rem;
+	}
+</style>

--- a/frontend/src/lib/components/ShareDialog.svelte
+++ b/frontend/src/lib/components/ShareDialog.svelte
@@ -28,7 +28,8 @@
 		searchRecipients,
 		type Recipient
 	} from '$lib/api/endpoints/recipients';
-	import type { ItemType, ShareItem } from '$lib/api/types';
+	import type { ShareItem } from '$lib/api/types';
+	import type { GrantResourceType } from '$lib/api/endpoints/grants';
 	import Icon from '$lib/icons/Icon.svelte';
 	import Modal from '$lib/components/Modal.svelte';
 	import UserVignette from '$lib/components/UserVignette.svelte';
@@ -38,7 +39,7 @@
 	interface Target {
 		id: string;
 		name: string;
-		kind: ItemType;
+		kind: GrantResourceType;
 	}
 
 	interface Props {
@@ -46,11 +47,32 @@
 		item: Target | null;
 		/** Fired with the item id when an outgoing share (grant or link) is created. */
 		onshared?: (id: string) => void;
+		/**
+		 * Fired with the item id on **any** membership mutation — create,
+		 * role change, expiry change, removal, or public-link creation.
+		 * Distinct from `onshared` because some callers (file/folder list
+		 * views that toggle a "shared" badge) only care about creation;
+		 * the drive-config view needs to refresh on every change.
+		 */
+		onchange?: (id: string) => void;
+		/**
+		 * Whether the "Public link" (token-grant) tab is exposed. Defaults to
+		 * `true` for file/folder sharing. Drives set this to `false`: a drive
+		 * grant is per-member only, never via a shareable URL — exposing the
+		 * tab would suggest a capability that doesn't exist.
+		 */
+		allowLinks?: boolean;
 	}
 
-	let { open = $bindable(false), item, onshared }: Props = $props();
+	let { open = $bindable(false), item, onshared, onchange, allowLinks = true }: Props = $props();
 
+	// When the public-link tab is hidden, force the People view — otherwise a
+	// caller toggling `allowLinks` between renders could land on the now-hidden
+	// tab with no UI.
 	let tab = $state<'people' | 'link'>('people');
+	$effect(() => {
+		if (!allowLinks) tab = 'people';
+	});
 	let directoryAvailable = $state(true);
 
 	const ROLES: { v: ShareRole; l: string; icon: string }[] = [
@@ -163,6 +185,7 @@
 			results = [];
 			summarizeNotifications(res.notification.outcomes);
 			onshared?.(item.id);
+			onchange?.(item.id);
 			await loadGrants();
 		} catch (e) {
 			errorToast(e);
@@ -178,6 +201,7 @@
 				role,
 				expiryToIso(m.expiry)
 			);
+			onchange?.(item.id);
 			await loadGrants();
 		} catch (e) {
 			errorToast(e);
@@ -193,6 +217,7 @@
 				m.role,
 				expiryToIso(expiry)
 			);
+			onchange?.(item.id);
 			await loadGrants();
 		} catch (e) {
 			errorToast(e);
@@ -202,6 +227,7 @@
 	async function removeMember(m: Member) {
 		try {
 			for (const id of m.grantIds) await revokeGrant(id);
+			if (item) onchange?.(item.id);
 			await loadGrants();
 		} catch (e) {
 			errorToast(e);
@@ -259,7 +285,11 @@
 	let expiresAt = $state<string | null>(null);
 
 	async function loadShares() {
-		if (!item) return;
+		// The share-link API only supports file/folder items; the Link tab
+		// is hidden for drives (`allowLinks=false`) so this path is
+		// unreachable, but narrow the type here so TypeScript doesn't
+		// surface the widened `GrantResourceType` from `item.kind`.
+		if (!item || item.kind === 'drive') return;
 		linkLoading = true;
 		try {
 			shares = await listSharesForItem(item.id, item.kind);
@@ -271,7 +301,7 @@
 	}
 
 	async function createLink() {
-		if (!item) return;
+		if (!item || item.kind === 'drive') return;
 		creating = true;
 		try {
 			await createShare({
@@ -285,6 +315,7 @@
 			password = '';
 			expiresAt = null;
 			onshared?.(item.id);
+			onchange?.(item.id);
 			await loadShares();
 			ui.notify(t('share.created', 'Public link created'), 'success');
 		} catch (e) {
@@ -297,6 +328,7 @@
 	async function editLinkExpiry(share: ShareItem, expiry: string | null) {
 		try {
 			await updateShare(share.id, { expiresAt: expiry });
+			if (item) onchange?.(item.id);
 			await loadShares();
 		} catch (e) {
 			errorToast(e);
@@ -306,6 +338,7 @@
 	async function editLinkPassword(share: ShareItem, pw: string | null) {
 		try {
 			await updateShare(share.id, { password: pw });
+			if (item) onchange?.(item.id);
 			await loadShares();
 			ui.notify(
 				pw
@@ -321,6 +354,7 @@
 	async function removeLink(share: ShareItem) {
 		try {
 			await deleteShare(share.id);
+			if (item) onchange?.(item.id);
 			shares = shares.filter((s) => s.id !== share.id);
 		} catch (e) {
 			errorToast(e);
@@ -378,24 +412,29 @@
 
 <Modal bind:open title={t('share.dialog_title', { name: item?.name ?? '' }, 'Share “{{name}}”')}>
 	<div data-testid="share-dialog">
-		<div class="tabs" role="tablist">
-			<button
-				role="tab"
-				data-testid="share-dialog-people-tab"
-				aria-selected={tab === 'people'}
-				onclick={() => (tab = 'people')}
-			>
-				{t('share.people', 'People')}
-			</button>
-			<button
-				role="tab"
-				data-testid="share-dialog-link-tab"
-				aria-selected={tab === 'link'}
-				onclick={() => (tab = 'link')}
-			>
-				{t('share.public_link', 'Public link')}
-			</button>
-		</div>
+		<!-- People/Link tab switcher. Hidden entirely when `allowLinks=false`
+		     (the drive-members surface) — with only one tab visible the
+		     switcher would be visual noise. -->
+		{#if allowLinks}
+			<div class="tabs" role="tablist">
+				<button
+					role="tab"
+					data-testid="share-dialog-people-tab"
+					aria-selected={tab === 'people'}
+					onclick={() => (tab = 'people')}
+				>
+					{t('share.people', 'People')}
+				</button>
+				<button
+					role="tab"
+					data-testid="share-dialog-link-tab"
+					aria-selected={tab === 'link'}
+					onclick={() => (tab = 'link')}
+				>
+					{t('share.public_link', 'Public link')}
+				</button>
+			</div>
+		{/if}
 
 		{#if tab === 'people'}
 			{#if !directoryAvailable && !grantsLoading}

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -42,16 +42,30 @@
 		type PluginLogEntry,
 		type PluginRetention,
 		type ReextractResult,
+		addDriveMemberAdmin,
+		listAllDrives,
+		listDriveMembersAdmin,
+		removeDriveMemberAdmin,
 		type SmtpInfo,
 		type SmtpTestResult,
 		type StorageSettings,
 		type StorageTestResult
 	} from '$lib/api/endpoints/admin';
-	import type { User } from '$lib/api/types';
+	import { createDrive } from '$lib/api/endpoints/drives';
+	import {
+		ensureResolvers,
+		resolveRecipient,
+		searchRecipients,
+		type Recipient
+	} from '$lib/api/endpoints/recipients';
+	import type { Drive, DriveMember, User } from '$lib/api/types';
 	import Icon from '$lib/icons/Icon.svelte';
 	import Modal from '$lib/components/Modal.svelte';
+	import OwnerAvatarStack from '$lib/components/OwnerAvatarStack.svelte';
+	import UserVignette from '$lib/components/UserVignette.svelte';
 	import { t } from '$lib/i18n/index.svelte';
 	import { session } from '$lib/stores/session.svelte';
+	import { drives as drivesStore } from '$lib/stores/drives.svelte';
 	import { ui } from '$lib/stores/ui.svelte';
 	import { formatBytes } from '$lib/utils/format';
 
@@ -100,7 +114,7 @@
 		confirmState = null;
 	}
 
-	type Tab = 'dashboard' | 'users' | 'plugins' | 'oidc' | 'storage' | 'smtp';
+	type Tab = 'dashboard' | 'users' | 'drives' | 'plugins' | 'oidc' | 'storage' | 'smtp';
 	let tab = $state<Tab>('dashboard');
 
 	// Dashboard
@@ -833,6 +847,259 @@
 		}
 	}
 
+	// ── Drives (D3a admin create-shared-drive) ───────────────────────────────
+	let drivesList = $state<Drive[]>([]);
+	let drivesError = $state<string | null>(null);
+	let driveCreateOpen = $state(false);
+	let driveCreating = $state(false);
+	let driveCreateError = $state<string | null>(null);
+	let driveForm = $state({
+		name: '',
+		ownerQuery: '',
+		ownerPick: null as Recipient | null,
+		quotaValue: 0,
+		quotaUnit: (1024 ** 3) as number
+	});
+	let ownerSuggestions = $state<Recipient[]>([]);
+	let ownerSearching = $state(false);
+	let ownerSearchToken = 0;
+
+	// Members keyed by drive id. The admin Drives table renders an Owner
+	// avatar stack per row; we lazily fetch members for each drive in
+	// parallel after the drives listing comes back. Missing entries mean
+	// "still loading" — the stack treats undefined as no-owners-yet.
+	let driveMembers = $state<Record<string, DriveMember[]>>({});
+
+	async function loadDrivesTab() {
+		drivesError = null;
+		try {
+			// `/api/admin/drives` — system-wide view; an admin who creates
+			// a drive for another user has no `role_grants` row on it and
+			// wouldn't see it via the user-facing `/api/drives` listing.
+			drivesList = await listAllDrives();
+		} catch (e) {
+			drivesError = errorMessage(e);
+			return;
+		}
+		// Seed the contact + group caches so the avatar stack renders real
+		// labels (and stable initials/colours) instead of bare UUIDs.
+		void ensureResolvers();
+		// Fan out one members fetch per drive in parallel. A swallowed
+		// error per drive degrades gracefully — that row's stack shows
+		// "No owners" rather than blocking the whole page.
+		const nextMembers: Record<string, DriveMember[]> = {};
+		await Promise.all(
+			drivesList.map(async (d) => {
+				try {
+					nextMembers[d.id] = await listDriveMembersAdmin(d.id);
+				} catch {
+					nextMembers[d.id] = [];
+				}
+			})
+		);
+		driveMembers = nextMembers;
+	}
+
+	function driveKindLabel(d: Drive): string {
+		if (d.kind === 'shared') return t('admin.drive_kind_shared', 'Shared');
+		return d.default_for_user
+			? t('admin.drive_kind_personal_default', 'Personal (default)')
+			: t('admin.drive_kind_personal', 'Personal');
+	}
+
+	function openDriveCreate() {
+		driveForm = { name: '', ownerQuery: '', ownerPick: null, quotaValue: 0, quotaUnit: 1024 ** 3 };
+		ownerSuggestions = [];
+		driveCreateError = null;
+		driveCreateOpen = true;
+	}
+
+	// Search runs in the background; a monotonically-incrementing `token`
+	// guards against out-of-order results overwriting a newer query — the
+	// network races by query length and keystroke timing.
+	async function searchOwnerCandidates(q: string) {
+		driveForm.ownerPick = null;
+		const trimmed = q.trim();
+		if (!trimmed) {
+			ownerSuggestions = [];
+			return;
+		}
+		const token = ++ownerSearchToken;
+		ownerSearching = true;
+		try {
+			// `includeSelf` — admin creating a drive may legitimately want to
+			// own it themselves; the default share-modal "no self" rule
+			// doesn't apply in the admin context.
+			const results = await searchRecipients(trimmed, { includeSelf: true });
+			if (token !== ownerSearchToken) return; // a newer query is in flight
+			// Filter out the synthetic invite-by-email row — POST /api/drives
+			// refuses email subjects (drive Owner must be a real user or group).
+			ownerSuggestions = results.filter((r) => r.type === 'user' || r.type === 'group');
+		} finally {
+			if (token === ownerSearchToken) ownerSearching = false;
+		}
+	}
+
+	function pickOwner(r: Recipient) {
+		driveForm.ownerPick = r;
+		driveForm.ownerQuery = r.label;
+		ownerSuggestions = [];
+	}
+
+	// ── Manage-owners modal (D3a admin bypass) ──────────────────────────────
+	// State is null when closed; carries the drive being edited otherwise.
+	let manageOwnersDrive = $state<Drive | null>(null);
+	let manageOwnersError = $state<string | null>(null);
+	let manageOwnersBusy = $state(false);
+	// Independent owner-search state so the "manage owners" autocomplete
+	// doesn't fight with the create-drive form's autocomplete.
+	let manageOwnersQuery = $state('');
+	let manageOwnersSuggestions = $state<Recipient[]>([]);
+	let manageOwnersSearchToken = 0;
+	let manageOwnersSearching = $state(false);
+
+	function openManageOwners(d: Drive) {
+		manageOwnersDrive = d;
+		manageOwnersError = null;
+		manageOwnersQuery = '';
+		manageOwnersSuggestions = [];
+		// Members were already fetched on tab load; nothing else to do.
+	}
+
+	function closeManageOwners() {
+		manageOwnersDrive = null;
+		manageOwnersError = null;
+		manageOwnersQuery = '';
+		manageOwnersSuggestions = [];
+	}
+
+	async function searchManageOwnersCandidates(q: string) {
+		const trimmed = q.trim();
+		if (!trimmed) {
+			manageOwnersSuggestions = [];
+			return;
+		}
+		const token = ++manageOwnersSearchToken;
+		manageOwnersSearching = true;
+		try {
+			// Admin adding owners — allow self (the share-modal "no
+			// self" guard doesn't apply to drive-owner management).
+			const results = await searchRecipients(trimmed, { includeSelf: true });
+			if (token !== manageOwnersSearchToken) return;
+			// Filter out emails (POST admin/members refuses them) and any
+			// subject already an Owner of this drive (no point re-adding).
+			const currentOwnerIds = new Set(
+				(driveMembers[manageOwnersDrive?.id ?? ''] ?? [])
+					.filter((m) => m.role === 'owner')
+					.map((m) => `${m.subject.type}-${m.subject.id}`)
+			);
+			manageOwnersSuggestions = results.filter(
+				(r) =>
+					(r.type === 'user' || r.type === 'group') && !currentOwnerIds.has(`${r.type}-${r.id}`)
+			);
+		} finally {
+			if (token === manageOwnersSearchToken) manageOwnersSearching = false;
+		}
+	}
+
+	// Pessimistic refetch after every mutation — the membership list is
+	// small (a handful of owners) and the alternative (mutating local
+	// state) duplicates the server's role-resolution + last-owner logic.
+	async function reloadDriveMembers(driveId: string) {
+		try {
+			driveMembers = {
+				...driveMembers,
+				[driveId]: await listDriveMembersAdmin(driveId)
+			};
+		} catch (e) {
+			manageOwnersError = errorMessage(e);
+		}
+	}
+
+	async function addOwner(r: Recipient) {
+		if (!manageOwnersDrive || (r.type !== 'user' && r.type !== 'group')) return;
+		manageOwnersBusy = true;
+		manageOwnersError = null;
+		try {
+			await addDriveMemberAdmin(manageOwnersDrive.id, { type: r.type, id: r.id }, 'owner');
+			manageOwnersQuery = '';
+			manageOwnersSuggestions = [];
+			await reloadDriveMembers(manageOwnersDrive.id);
+		} catch (e) {
+			manageOwnersError = errorMessage(e);
+		} finally {
+			manageOwnersBusy = false;
+		}
+	}
+
+	async function removeOwner(m: DriveMember) {
+		if (!manageOwnersDrive) return;
+		const confirmMsg = t('admin.drive_owner_remove_confirm', 'Remove this owner from the drive?');
+		if (!(await showConfirm(confirmMsg))) return;
+		manageOwnersBusy = true;
+		manageOwnersError = null;
+		try {
+			await removeDriveMemberAdmin(manageOwnersDrive.id, {
+				type: m.subject.type,
+				id: m.subject.id
+			});
+			await reloadDriveMembers(manageOwnersDrive.id);
+		} catch (e) {
+			manageOwnersError = errorMessage(e);
+		} finally {
+			manageOwnersBusy = false;
+		}
+	}
+
+	// Re-derive the current owners list inside the modal so it reacts to
+	// `driveMembers` changes after add/remove.
+	const manageOwnersList = $derived(
+		manageOwnersDrive
+			? (driveMembers[manageOwnersDrive.id] ?? []).filter(
+					(m) => m.role === 'owner' && (m.subject.type === 'user' || m.subject.type === 'group')
+				)
+			: []
+	);
+
+	async function submitDriveCreate(e: SubmitEvent) {
+		e.preventDefault();
+		const name = driveForm.name.trim();
+		if (name.length === 0) {
+			driveCreateError = t('admin.drive_error_name_required', 'Drive name is required.');
+			return;
+		}
+		const owner = driveForm.ownerPick;
+		if (!owner || (owner.type !== 'user' && owner.type !== 'group')) {
+			driveCreateError = t(
+				'admin.drive_error_owner_required',
+				'Pick a user or group as the drive owner.'
+			);
+			return;
+		}
+		driveCreating = true;
+		driveCreateError = null;
+		try {
+			await createDrive({
+				kind: 'shared',
+				name,
+				owner: { type: owner.type, id: owner.id },
+				quota_bytes:
+					driveForm.quotaValue > 0 ? Math.round(driveForm.quotaValue * driveForm.quotaUnit) : null
+			});
+			driveCreateOpen = false;
+			await loadDrivesTab();
+			// The global drives store backs the sidebar picker; drop its cache
+			// so the new drive shows up for every consumer (picker, breadcrumb,
+			// session bootstrap) without a page reload.
+			drivesStore.invalidate();
+			ui.notify(t('admin.drive_created', 'Drive created.'), 'success');
+		} catch (err) {
+			driveCreateError = errorMessage(err);
+		} finally {
+			driveCreating = false;
+		}
+	}
+
 	async function togglePlugin(p: PluginInfo) {
 		try {
 			await setPluginEnabled(p.id, !p.enabled);
@@ -868,6 +1135,7 @@
 	let loaded = $state<Record<Tab, boolean>>({
 		dashboard: false,
 		users: false,
+		drives: false,
 		plugins: false,
 		oidc: false,
 		storage: false,
@@ -879,6 +1147,7 @@
 		loaded[tab] = true;
 		if (tab === 'dashboard') void loadDashboard();
 		else if (tab === 'users') void loadUsers();
+		else if (tab === 'drives') void loadDrivesTab();
 		else if (tab === 'plugins') void loadPlugins();
 		else if (tab === 'oidc') void loadOidc();
 		else if (tab === 'storage') {
@@ -931,6 +1200,15 @@
 		>
 			<Icon name="users" />
 			{t('admin.users', 'Users')}
+		</button>
+		<button
+			role="tab"
+			data-testid="admin-drives-tab"
+			aria-selected={tab === 'drives'}
+			onclick={() => (tab = 'drives')}
+		>
+			<Icon name="folder" />
+			{t('admin.drives', 'Drives')}
 		</button>
 		<button
 			role="tab"
@@ -1825,6 +2103,102 @@
 				>
 			</div>
 		{/if}
+	{:else if tab === 'drives'}
+		<div class="bar">
+			<button
+				class="btn btn--primary"
+				data-testid="admin-drives-create-btn"
+				onclick={openDriveCreate}
+			>
+				<Icon name="plus" />
+				{t('admin.create_drive', 'Create shared drive')}
+			</button>
+		</div>
+		{#if drivesError}
+			<p class="status status--error">{drivesError}</p>
+		{:else if drivesList.length === 0}
+			<p class="status">{t('admin.no_drives', 'No drives yet.')}</p>
+		{:else}
+			<table class="table">
+				<thead>
+					<tr>
+						<th>{t('admin.drive_name', 'Name')}</th>
+						<th>{t('admin.drive_kind', 'Kind')}</th>
+						<th>{t('admin.drive_owners', 'Owners')}</th>
+						<th>{t('admin.drive_usage', 'Usage')}</th>
+						<th>{t('admin.drive_created_at', 'Created')}</th>
+						<th></th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each drivesList as d (d.id)}
+						{@const pct =
+							d.quota_bytes && d.quota_bytes > 0
+								? Math.min(100, (d.used_bytes / d.quota_bytes) * 100)
+								: null}
+						<tr>
+							<td>
+								<div class="user-cell">
+									<strong>{d.name}</strong>
+									<span class="muted"><code>{d.id}</code></span>
+								</div>
+							</td>
+							<td>
+								<span class="badge badge--{d.kind === 'shared' ? 'admin' : 'user'}">
+									{driveKindLabel(d)}
+								</span>
+							</td>
+							<td>
+								{#if driveMembers[d.id]}
+									<OwnerAvatarStack members={driveMembers[d.id]} />
+								{:else}
+									<span class="muted">{t('common.loading', 'Loading…')}</span>
+								{/if}
+							</td>
+							<td>
+								<div class="quota-cell">
+									{#if pct !== null}
+										<div class="quota-bar">
+											<div
+												class="quota-fill"
+												class:quota-fill--warn={pct > 70}
+												class:quota-fill--danger={pct > 90}
+												style:width="{pct}%"
+											></div>
+										</div>
+									{/if}
+									<span class="muted">
+										{formatBytes(d.used_bytes)} / {d.quota_bytes && d.quota_bytes > 0
+											? formatBytes(d.quota_bytes)
+											: '∞'}
+									</span>
+								</div>
+							</td>
+							<td class="muted">{timeAgo(d.created_at)}</td>
+							<td>
+								<!-- Wrapper div carries the `actions` flex layout; the
+								     <td> stays a plain table cell so its baseline +
+								     bottom-border align with the rest of the row even on
+								     personal-drive rows where the wrapper is empty. -->
+								<div class="actions">
+									{#if d.kind === 'shared'}
+										<button
+											class="icon-btn"
+											data-testid={`admin-drive-manage-owners-${d.id}`}
+											title={t('admin.drive_manage_owners', 'Manage owners')}
+											aria-label={t('admin.drive_manage_owners', 'Manage owners')}
+											onclick={() => openManageOwners(d)}
+										>
+											<Icon name="users-cog" />
+										</button>
+									{/if}
+								</div>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		{/if}
 	{:else if !pluginsAvailable}
 		<p class="status">{t('admin.plugins_disabled', 'The plugin subsystem is disabled.')}</p>
 	{:else if pluginsError}
@@ -2009,6 +2383,221 @@
 			disabled={creating}
 		>
 			{creating ? t('admin.creating', 'Creating…') : t('common.create', 'Create')}
+		</button>
+	{/snippet}
+</Modal>
+
+<!-- Create-drive modal (D3a). Personal-drive creation is omitted because
+     the backend returns 501 for kind=personal today; see DrivePicker for
+     UI flow and drive_handler::create_drive for the wire contract. -->
+<Modal
+	open={driveCreateOpen}
+	title={t('admin.create_drive', 'Create shared drive')}
+	onclose={() => (driveCreateOpen = false)}
+>
+	<form
+		id="create-drive-form"
+		class="form"
+		data-testid="admin-create-drive-form"
+		onsubmit={submitDriveCreate}
+	>
+		<label>
+			<span>{t('admin.drive_name', 'Name')}</span>
+			<input
+				bind:value={driveForm.name}
+				data-testid="admin-create-drive-name-input"
+				required
+				placeholder={t('admin.drive_name_placeholder', 'e.g. Engineering')}
+			/>
+		</label>
+		<label class="drive-owner">
+			<span>{t('admin.drive_owner', 'Owner')}</span>
+			<input
+				type="text"
+				data-testid="admin-create-drive-owner-input"
+				bind:value={driveForm.ownerQuery}
+				oninput={(e) => searchOwnerCandidates(e.currentTarget.value)}
+				placeholder={t('admin.drive_owner_placeholder', 'Search a user or group…')}
+				autocomplete="off"
+				required
+			/>
+			{#if ownerSearching}
+				<span class="muted">{t('common.loading', 'Loading…')}</span>
+			{:else if ownerSuggestions.length > 0}
+				<ul class="owner-suggest" role="listbox">
+					{#each ownerSuggestions as r (`${r.type}-${r.id}`)}
+						<li>
+							<button
+								type="button"
+								class="owner-suggest__row"
+								data-testid={`admin-drive-owner-pick-${r.type}-${r.id}`}
+								onclick={() => pickOwner(r)}
+							>
+								<Icon name={r.type === 'group' ? 'users' : 'user'} />
+								<span class="owner-suggest__label">{r.label}</span>
+								{#if r.sublabel}
+									<span class="muted">{r.sublabel}</span>
+								{/if}
+							</button>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+			{#if driveForm.ownerPick}
+				<span class="muted owner-pick">
+					<Icon name={driveForm.ownerPick.type === 'group' ? 'users' : 'user'} />
+					{t('admin.drive_owner_picked', { name: driveForm.ownerPick.label }, 'Owner: {{name}}')}
+				</span>
+			{/if}
+			<span class="muted">
+				{t(
+					'admin.drive_owner_hint',
+					'Pick a user (sole Owner) or a group (every member becomes Owner via subject expansion).'
+				)}
+			</span>
+		</label>
+		<label>
+			<span>{t('admin.quota', 'Quota')}</span>
+			<div class="quota-input">
+				<input
+					type="number"
+					data-testid="admin-create-drive-quota-input"
+					min="0"
+					step="0.1"
+					bind:value={driveForm.quotaValue}
+				/>
+				<select bind:value={driveForm.quotaUnit} data-testid="admin-create-drive-quota-unit-select">
+					{#each QUOTA_UNITS as unit (unit.label)}
+						<option value={unit.value}>{unit.label}</option>
+					{/each}
+				</select>
+			</div>
+			<span class="muted">{t('admin.quota_unlimited_hint', '0 = unlimited')}</span>
+		</label>
+		{#if driveCreateError}<p class="status--error">{driveCreateError}</p>{/if}
+	</form>
+	{#snippet footer()}
+		<button
+			class="btn"
+			data-testid="admin-create-drive-cancel-btn"
+			onclick={() => (driveCreateOpen = false)}
+		>
+			{t('common.cancel', 'Cancel')}
+		</button>
+		<button
+			class="btn btn--primary"
+			type="submit"
+			form="create-drive-form"
+			data-testid="admin-create-drive-submit-btn"
+			disabled={driveCreating}
+		>
+			{driveCreating ? t('admin.creating', 'Creating…') : t('common.create', 'Create')}
+		</button>
+	{/snippet}
+</Modal>
+
+<!-- Manage-owners modal (D3a admin bypass — calls
+     /api/admin/drives/{id}/members POST/DELETE which skip the per-drive
+     `Manage` check). Last-owner protection still applies server-side. -->
+<Modal
+	open={manageOwnersDrive !== null}
+	title={manageOwnersDrive
+		? t(
+				'admin.drive_manage_owners_for',
+				{ name: manageOwnersDrive.name },
+				'Manage owners — {{name}}'
+			)
+		: t('admin.drive_manage_owners', 'Manage owners')}
+	onclose={closeManageOwners}
+>
+	{#if manageOwnersDrive}
+		<div class="form">
+			<div>
+				<label for="manage-owners-search">
+					<span>{t('admin.drive_add_owner', 'Add owner')}</span>
+				</label>
+				<input
+					id="manage-owners-search"
+					type="text"
+					data-testid="admin-manage-owners-search-input"
+					bind:value={manageOwnersQuery}
+					oninput={(e) => searchManageOwnersCandidates(e.currentTarget.value)}
+					placeholder={t('admin.drive_owner_placeholder', 'Search a user or group…')}
+					autocomplete="off"
+					disabled={manageOwnersBusy}
+				/>
+				{#if manageOwnersSearching}
+					<span class="muted">{t('common.loading', 'Loading…')}</span>
+				{:else if manageOwnersSuggestions.length > 0}
+					<ul class="owner-suggest" role="listbox">
+						{#each manageOwnersSuggestions as r (`${r.type}-${r.id}`)}
+							<li>
+								<button
+									type="button"
+									class="owner-suggest__row"
+									data-testid={`admin-manage-owners-pick-${r.type}-${r.id}`}
+									onclick={() => addOwner(r)}
+									disabled={manageOwnersBusy}
+								>
+									<Icon name={r.type === 'group' ? 'users' : 'user'} />
+									<span class="owner-suggest__label">{r.label}</span>
+									{#if r.sublabel}<span class="muted">{r.sublabel}</span>{/if}
+								</button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</div>
+
+			<div>
+				<h3 class="owners-list__title">
+					{t('admin.drive_current_owners', 'Current owners')}
+					<span class="muted">({manageOwnersList.length})</span>
+				</h3>
+				{#if manageOwnersList.length === 0}
+					<p class="muted">{t('admin.drive_no_owners', 'No owners')}</p>
+				{:else}
+					<ul class="owners-list">
+						{#each manageOwnersList as m (`${m.subject.type}-${m.subject.id}`)}
+							<li class="owners-list__row">
+								{#if m.subject.type === 'user'}
+									<UserVignette userId={m.subject.id} />
+								{:else}
+									<!-- Groups don't resolve via /api/users/{id}; render an
+									     inline equivalent using the cached recipient label
+									     from the share-search resolver. -->
+									<span class="owners-list__group">
+										<span class="owners-list__group-icon"><Icon name="users" /></span>
+										<span class="owners-list__group-name">
+											{resolveRecipient('group', m.subject.id).label}
+										</span>
+									</span>
+								{/if}
+								<button
+									type="button"
+									class="icon-btn icon-btn--danger"
+									data-testid={`admin-manage-owners-remove-${m.subject.type}-${m.subject.id}`}
+									title={t('common.remove', 'Remove')}
+									aria-label={t('common.remove', 'Remove')}
+									onclick={() => removeOwner(m)}
+									disabled={manageOwnersBusy}
+								>
+									<Icon name="trash-alt" />
+								</button>
+							</li>
+						{/each}
+					</ul>
+				{/if}
+			</div>
+
+			{#if manageOwnersError}
+				<p class="status--error">{manageOwnersError}</p>
+			{/if}
+		</div>
+	{/if}
+	{#snippet footer()}
+		<button class="btn" data-testid="admin-manage-owners-close-btn" onclick={closeManageOwners}>
+			{t('common.close', 'Close')}
 		</button>
 	{/snippet}
 </Modal>
@@ -2890,5 +3479,112 @@
 
 	.link-btn--danger {
 		color: var(--color-error-text);
+	}
+
+	/* Drive-owner autocomplete dropdown inside the create-drive modal. */
+	.drive-owner {
+		position: relative;
+	}
+
+	.owner-suggest {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		background: var(--color-bg-surface);
+		max-height: 14rem;
+		overflow-y: auto;
+	}
+
+	.owner-suggest__row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		width: 100%;
+		padding: var(--space-2) var(--space-3);
+		border: none;
+		background: none;
+		text-align: left;
+		font: inherit;
+		color: var(--color-text);
+		cursor: pointer;
+	}
+
+	.owner-suggest__row:hover {
+		background: var(--color-bg-muted);
+	}
+
+	.owner-suggest__label {
+		flex: 1;
+	}
+
+	.owner-pick {
+		display: inline-flex;
+		align-items: center;
+		gap: var(--space-1);
+	}
+
+	/* Manage-owners modal — current-owners list with a remove affordance. */
+	.owners-list__title {
+		margin: var(--space-3) 0 var(--space-2);
+		font-size: 0.95rem;
+	}
+
+	.owners-list {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: var(--space-1);
+	}
+
+	.owners-list__row {
+		display: flex;
+		align-items: center;
+		gap: var(--space-2);
+		padding: var(--space-2);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+	}
+
+	.owners-list__id {
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+		font-size: 0.8125rem;
+	}
+
+	/* Inline group representation in the owners list — mirrors
+	   UserVignette's avatar+text shape so the rows line up visually
+	   even though the data sources differ. */
+	.owners-list__group {
+		display: flex;
+		flex: 1;
+		min-width: 0;
+		align-items: center;
+		gap: var(--space-2);
+	}
+
+	.owners-list__group-icon {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 32px;
+		height: 32px;
+		border-radius: 50%;
+		background: var(--color-bg-muted);
+		color: var(--color-text);
+		flex-shrink: 0;
+	}
+
+	.owners-list__group-name {
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
 	}
 </style>

--- a/frontend/src/routes/config/drive/[uuid]/+page.svelte
+++ b/frontend/src/routes/config/drive/[uuid]/+page.svelte
@@ -4,6 +4,8 @@
 	import { onMount } from 'svelte';
 
 	import { listDriveMembers } from '$lib/api/endpoints/drives';
+	import { renameFolder } from '$lib/api/endpoints/folders';
+	import { errorToast } from '$lib/utils/errors';
 	import type { Drive, DriveMember, DriveRole } from '$lib/api/types';
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import UserVignette from '$lib/components/UserVignette.svelte';
@@ -25,6 +27,55 @@
 	// backend guard refuses), so the UI hides the controls upfront for
 	// honest UX. Shared drives + Owner role → full controls.
 	const canManageMembers = $derived(drive?.kind === 'shared' && drive?.caller_role === 'owner');
+
+	// Rename is allowed for any Owner (both shared and personal), since
+	// the backend requires `Permission::Manage` on the drive's root
+	// folder which only the Owner bundle carries. Personal-drive Owners
+	// are the user themselves (seeded by the lifecycle hook).
+	const canRename = $derived(drive?.caller_role === 'owner');
+
+	// Inline rename state. `renameDraft` shadows `drive.name` while the
+	// input is open; we don't write back to the store until the server
+	// accepts the change. `renameBusy` disables the save/cancel buttons
+	// during the round-trip.
+	let renaming = $state(false);
+	let renameDraft = $state('');
+	let renameBusy = $state(false);
+
+	function startRename() {
+		if (!drive) return;
+		renameDraft = drive.name;
+		renaming = true;
+	}
+
+	function cancelRename() {
+		renaming = false;
+		renameDraft = '';
+	}
+
+	async function saveRename() {
+		if (!drive) return;
+		const next = renameDraft.trim();
+		if (next.length === 0 || next === drive.name) {
+			cancelRename();
+			return;
+		}
+		renameBusy = true;
+		try {
+			// Drive name = root folder name (drive.md §3); rename via the
+			// folder endpoint. Backend promotes the perm to Manage for
+			// parent_id IS NULL, so a non-Owner caller would 404 here
+			// (but the UI also hid this button for non-Owners).
+			await renameFolder(drive.root_folder_id, next);
+			drivesStore.invalidate();
+			await drivesStore.load();
+			renaming = false;
+		} catch (e) {
+			errorToast(e);
+		} finally {
+			renameBusy = false;
+		}
+	}
 
 	function roleLabel(role: DriveRole): string {
 		switch (role) {
@@ -153,10 +204,59 @@
 			<a class="link" href={resolve('/files')}>{t('drive.back_to_files', 'Back to Files')}</a>
 		</div>
 	{:else}
-		<h1>
+		<div class="drive-title">
 			<Icon name={driveIcon(drive)} />
-			{drive.name}
-		</h1>
+			{#if renaming}
+				<input
+					class="drive-title__input"
+					type="text"
+					data-testid="drive-rename-input"
+					bind:value={renameDraft}
+					maxlength="200"
+					disabled={renameBusy}
+					onkeydown={(e) => {
+						if (e.key === 'Enter') void saveRename();
+						else if (e.key === 'Escape') cancelRename();
+					}}
+				/>
+				<button
+					type="button"
+					class="icon-btn"
+					data-testid="drive-rename-save-btn"
+					title={t('common.save', 'Save')}
+					aria-label={t('common.save', 'Save')}
+					onclick={() => void saveRename()}
+					disabled={renameBusy}
+				>
+					<Icon name="check" />
+				</button>
+				<button
+					type="button"
+					class="icon-btn"
+					data-testid="drive-rename-cancel-btn"
+					title={t('common.cancel', 'Cancel')}
+					aria-label={t('common.cancel', 'Cancel')}
+					onclick={cancelRename}
+					disabled={renameBusy}
+				>
+					<Icon name="times" />
+				</button>
+			{:else}
+				<h1 class="drive-title__name">{drive.name}</h1>
+				{#if canRename}
+					<button
+						type="button"
+						class="icon-btn"
+						data-testid="drive-rename-edit-btn"
+						title={t('drive.rename', 'Rename drive')}
+						aria-label={t('drive.rename', 'Rename drive')}
+						onclick={startRename}
+					>
+						<Icon name="pencil-alt" />
+					</button>
+				{/if}
+			{/if}
+		</div>
 
 		<div class="card">
 			<h2><Icon name="info-circle" /> {t('drive.info', 'Drive info')}</h2>
@@ -400,6 +500,54 @@
 
 	.link:hover {
 		text-decoration: underline;
+	}
+
+	/* Drive title row: icon + name (or inline rename input) + edit/save
+	   affordances. Mirrors the visual weight of the previous static
+	   <h1> so the page layout doesn't shift when entering rename mode. */
+	.drive-title {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 1rem;
+	}
+
+	.drive-title__name {
+		margin: 0;
+	}
+
+	.drive-title__input {
+		flex: 1;
+		min-width: 0;
+		max-width: 28rem;
+		padding: 0.4rem 0.6rem;
+		font-size: 1.5rem;
+		font-weight: var(--weight-semibold, 600);
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		background: var(--color-bg-input);
+		color: var(--color-text);
+	}
+
+	/* Compact icon button used in the title row + nowhere else here.
+	   The shared `.icon-btn` style isn't promoted to a global yet, so
+	   we duplicate the minimum that this page needs. */
+	.icon-btn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 2rem;
+		height: 2rem;
+		border: 1px solid var(--color-border);
+		border-radius: var(--radius-md);
+		background: var(--color-bg-surface);
+		color: var(--color-text);
+		cursor: pointer;
+	}
+
+	.icon-btn:disabled {
+		opacity: 0.45;
+		cursor: not-allowed;
 	}
 
 	/* Members card header: title on the left, "Manage members" button on

--- a/frontend/src/routes/config/drive/[uuid]/+page.svelte
+++ b/frontend/src/routes/config/drive/[uuid]/+page.svelte
@@ -3,15 +3,89 @@
 	import { page } from '$app/state';
 	import { onMount } from 'svelte';
 
-	import type { Drive } from '$lib/api/types';
+	import {
+		listDriveMembers,
+		removeDriveMember,
+		updateDriveMember
+	} from '$lib/api/endpoints/drives';
+	import type { Drive, DriveMember, DriveRole } from '$lib/api/types';
+	import UserVignette from '$lib/components/UserVignette.svelte';
 	import Icon from '$lib/icons/Icon.svelte';
 	import { t } from '$lib/i18n/index.svelte';
 	import { drives as drivesStore, driveIcon } from '$lib/stores/drives.svelte';
+	import { errorToast } from '$lib/utils/errors';
 	import { formatDate } from '$lib/utils/display';
 	import { formatBytes } from '$lib/utils/format';
 
 	const uuid = $derived(page.params.uuid ?? '');
 	const drive = $derived<Drive | null>(drivesStore.findById(uuid));
+
+	let members = $state<DriveMember[]>([]);
+	let membersLoaded = $state(false);
+	let membersError = $state<string | null>(null);
+
+	// Mutation controls are gated by *both* caller_role AND drive kind:
+	// even an Owner of a personal drive can't change membership (the
+	// backend guard refuses), so the UI hides the controls upfront for
+	// honest UX. Shared drives + Owner role → full controls.
+	const canManageMembers = $derived(drive?.kind === 'shared' && drive?.caller_role === 'owner');
+
+	// Roles offered in the dropdown. Owner sets the bundle; other roles
+	// match the backend `Role` enum order (owner → viewer = strongest → weakest).
+	const ASSIGNABLE_ROLES: DriveRole[] = ['owner', 'editor', 'viewer'];
+
+	function roleLabel(role: DriveRole): string {
+		switch (role) {
+			case 'owner':
+				return t('drive.role.owner', 'Owner');
+			case 'editor':
+				return t('drive.role.editor', 'Editor');
+			case 'contributor':
+				return t('drive.role.contributor', 'Contributor');
+			case 'commenter':
+				return t('drive.role.commenter', 'Commenter');
+			case 'viewer':
+				return t('drive.role.viewer', 'Viewer');
+		}
+	}
+
+	async function loadMembers() {
+		if (!uuid) return;
+		try {
+			members = await listDriveMembers(uuid);
+		} catch (e) {
+			// 404 here means the caller lacks Read on the drive — which is
+			// also what the parent "Drive not found" card already conveys.
+			// Keep the listing area empty rather than surfacing a noisy toast.
+			membersError = e instanceof Error ? e.message : String(e);
+			members = [];
+		} finally {
+			membersLoaded = true;
+		}
+	}
+
+	async function changeRole(member: DriveMember, role: DriveRole) {
+		if (member.role === role) return;
+		try {
+			const updated = await updateDriveMember(uuid, member.subject, role);
+			members = members.map((m) => (m.id === member.id ? updated : m));
+		} catch (e) {
+			errorToast(e);
+			// Re-fetch so the dropdown reflects the server-side state, not the
+			// optimistic-but-rejected change.
+			await loadMembers();
+		}
+	}
+
+	async function removeMember(member: DriveMember) {
+		try {
+			await removeDriveMember(uuid, member.subject);
+			members = members.filter((m) => m.id !== member.id);
+		} catch (e) {
+			errorToast(e);
+			await loadMembers();
+		}
+	}
 
 	const kindLabel = $derived.by(() => {
 		if (!drive) return '';
@@ -59,6 +133,7 @@
 
 	onMount(() => {
 		void drivesStore.load();
+		void loadMembers();
 	});
 </script>
 
@@ -131,6 +206,73 @@
 				>
 					<div class="bar__fill" style:width="{storagePct}%"></div>
 				</div>
+			{/if}
+		</div>
+
+		<div class="card">
+			<h2><Icon name="users" /> {t('drive.members', 'Members')}</h2>
+			{#if !membersLoaded}
+				<p class="muted">{t('common.loading', 'Loading…')}</p>
+			{:else if members.length === 0}
+				<p class="muted">
+					{membersError ?? t('drive.members_empty', 'No members.')}
+				</p>
+			{:else}
+				<ul class="members">
+					{#each members as m (m.id)}
+						<li class="members__row">
+							{#if m.subject.type === 'user'}
+								<UserVignette userId={m.subject.id} />
+							{:else if m.subject.type === 'group'}
+								<span class="members__group">
+									<Icon name="users" />
+									<span class="mono">{m.subject.id}</span>
+								</span>
+							{:else}
+								<span class="members__token">
+									<Icon name="link" />
+									<span class="mono">{m.subject.id}</span>
+								</span>
+							{/if}
+
+							{#if canManageMembers}
+								<select
+									class="members__role-select"
+									value={m.role}
+									onchange={(e) =>
+										void changeRole(m, (e.currentTarget as HTMLSelectElement).value as DriveRole)}
+									aria-label={t('drive.member.change_role_aria', 'Change role')}
+								>
+									{#each ASSIGNABLE_ROLES as r (r)}
+										<option value={r}>{roleLabel(r)}</option>
+									{/each}
+								</select>
+								<button
+									type="button"
+									class="members__remove"
+									title={t('drive.member.remove', 'Remove member')}
+									aria-label={t('drive.member.remove', 'Remove member')}
+									onclick={() => void removeMember(m)}
+								>
+									<Icon name="times" />
+								</button>
+							{:else}
+								<span class="members__role members__role--{m.role}">
+									{roleLabel(m.role)}
+								</span>
+							{/if}
+						</li>
+					{/each}
+				</ul>
+
+				{#if !canManageMembers && drive.kind === 'personal'}
+					<p class="muted members__personal-note">
+						{t(
+							'drive.members.personal_immutable',
+							'Personal drives have a fixed single-owner membership.'
+						)}
+					</p>
+				{/if}
 			{/if}
 		</div>
 
@@ -247,5 +389,93 @@
 
 	.link:hover {
 		text-decoration: underline;
+	}
+
+	/* Members list */
+	.members {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.members__row {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.5rem 0.75rem;
+		border: 1px solid var(--color-border-faint);
+		border-radius: var(--radius-sm);
+		background: var(--color-bg-page);
+	}
+
+	.members__group,
+	.members__token {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		flex: 1;
+		min-width: 0;
+		color: var(--color-text-secondary);
+	}
+
+	.members__role {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.2rem 0.65rem;
+		border-radius: var(--radius-pill, 999px);
+		font-size: 0.8rem;
+		background: var(--color-bg-muted);
+		color: var(--color-text-secondary);
+		flex: none;
+	}
+
+	.members__role--owner {
+		background: var(--color-accent-tint, var(--color-bg-muted));
+		color: var(--color-accent-text, var(--color-text-secondary));
+		font-weight: var(--weight-semibold);
+	}
+
+	.members__role--editor,
+	.members__role--contributor {
+		background: var(--color-accent-ring, var(--color-bg-muted));
+		color: var(--color-accent-text, var(--color-text-secondary));
+	}
+
+	.members__role-select {
+		flex: none;
+		padding: 0.25rem 0.5rem;
+		border-radius: var(--radius-sm);
+		border: 1px solid var(--color-border);
+		background: var(--color-bg-input);
+		color: var(--color-text);
+		font: inherit;
+		font-size: 0.85rem;
+		cursor: pointer;
+	}
+
+	.members__remove {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 28px;
+		height: 28px;
+		border: none;
+		border-radius: var(--radius-sm);
+		background: transparent;
+		color: var(--color-text-faint);
+		cursor: pointer;
+	}
+
+	.members__remove:hover {
+		background: var(--color-bg-hover);
+		color: var(--color-danger-text, var(--color-text));
+	}
+
+	.members__personal-note {
+		margin-top: 0.75rem;
+		font-size: 0.85rem;
 	}
 </style>

--- a/frontend/src/routes/config/drive/[uuid]/+page.svelte
+++ b/frontend/src/routes/config/drive/[uuid]/+page.svelte
@@ -3,17 +3,13 @@
 	import { page } from '$app/state';
 	import { onMount } from 'svelte';
 
-	import {
-		listDriveMembers,
-		removeDriveMember,
-		updateDriveMember
-	} from '$lib/api/endpoints/drives';
+	import { listDriveMembers } from '$lib/api/endpoints/drives';
 	import type { Drive, DriveMember, DriveRole } from '$lib/api/types';
+	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import UserVignette from '$lib/components/UserVignette.svelte';
 	import Icon from '$lib/icons/Icon.svelte';
 	import { t } from '$lib/i18n/index.svelte';
 	import { drives as drivesStore, driveIcon } from '$lib/stores/drives.svelte';
-	import { errorToast } from '$lib/utils/errors';
 	import { formatDate } from '$lib/utils/display';
 	import { formatBytes } from '$lib/utils/format';
 
@@ -30,10 +26,6 @@
 	// honest UX. Shared drives + Owner role → full controls.
 	const canManageMembers = $derived(drive?.kind === 'shared' && drive?.caller_role === 'owner');
 
-	// Roles offered in the dropdown. Owner sets the bundle; other roles
-	// match the backend `Role` enum order (owner → viewer = strongest → weakest).
-	const ASSIGNABLE_ROLES: DriveRole[] = ['owner', 'editor', 'viewer'];
-
 	function roleLabel(role: DriveRole): string {
 		switch (role) {
 			case 'owner':
@@ -48,6 +40,19 @@
 				return t('drive.role.viewer', 'Viewer');
 		}
 	}
+
+	// `shareDialogOpen` drives the ShareDialog modal — the same dialog
+	// used for file/folder sharing, parameterised with `kind: 'drive'`
+	// + `allowLinks: false`. Add/change-role/remove flow through the
+	// dialog's existing grants plumbing (server-side those routes
+	// dispatch to `DriveManagementService`).
+	let shareDialogOpen = $state(false);
+
+	// `dialogItem` is recomputed from the drive so the dialog title
+	// reflects renames.
+	const dialogItem = $derived(
+		drive ? { id: drive.id, name: drive.name, kind: 'drive' as const } : null
+	);
 
 	async function loadMembers() {
 		if (!uuid) return;
@@ -64,27 +69,12 @@
 		}
 	}
 
-	async function changeRole(member: DriveMember, role: DriveRole) {
-		if (member.role === role) return;
-		try {
-			const updated = await updateDriveMember(uuid, member.subject, role);
-			members = members.map((m) => (m.id === member.id ? updated : m));
-		} catch (e) {
-			errorToast(e);
-			// Re-fetch so the dropdown reflects the server-side state, not the
-			// optimistic-but-rejected change.
-			await loadMembers();
-		}
-	}
-
-	async function removeMember(member: DriveMember) {
-		try {
-			await removeDriveMember(uuid, member.subject);
-			members = members.filter((m) => m.id !== member.id);
-		} catch (e) {
-			errorToast(e);
-			await loadMembers();
-		}
+	// Refresh the on-page member list on every dialog mutation (add,
+	// role change, remove). ShareDialog fires `onchange` for the full
+	// set of grant mutations — `onshared` only covers creation, which
+	// would leave role-change and removal stale here.
+	function onShareDialogChange() {
+		void loadMembers();
 	}
 
 	const kindLabel = $derived.by(() => {
@@ -133,7 +123,21 @@
 
 	onMount(() => {
 		void drivesStore.load();
-		void loadMembers();
+	});
+
+	// SvelteKit reuses this component when navigating between
+	// `/config/drive/<A>` and `/config/drive/<B>` (same route, different
+	// dynamic param), so `onMount` only fires once. Re-run the members
+	// fetch whenever `uuid` changes — without this, the previous drive's
+	// rows linger until a hard refresh. Resetting `members` + the loaded
+	// flag first prevents the brief flash of stale data before the new
+	// fetch returns.
+	$effect(() => {
+		const id = uuid;
+		members = [];
+		membersLoaded = false;
+		membersError = null;
+		if (id) void loadMembers();
 	});
 </script>
 
@@ -210,7 +214,21 @@
 		</div>
 
 		<div class="card">
-			<h2><Icon name="users" /> {t('drive.members', 'Members')}</h2>
+			<div class="members__header">
+				<h2><Icon name="users" /> {t('drive.members', 'Members')}</h2>
+				{#if canManageMembers}
+					<button
+						type="button"
+						class="btn btn-primary"
+						data-testid="drive-manage-members-btn"
+						onclick={() => (shareDialogOpen = true)}
+					>
+						<Icon name="user-plus" />
+						{t('drive.manage_members', 'Manage members')}
+					</button>
+				{/if}
+			</div>
+
 			{#if !membersLoaded}
 				<p class="muted">{t('common.loading', 'Loading…')}</p>
 			{:else if members.length === 0}
@@ -218,6 +236,10 @@
 					{membersError ?? t('drive.members_empty', 'No members.')}
 				</p>
 			{:else}
+				<!-- Read-only summary. Add/change/remove happens inside the
+				     ShareDialog modal opened by the button above; the inline
+				     row controls used to live here have moved into the dialog
+				     so the same flow handles file/folder + drive grants. -->
 				<ul class="members">
 					{#each members as m (m.id)}
 						<li class="members__row">
@@ -234,33 +256,9 @@
 									<span class="mono">{m.subject.id}</span>
 								</span>
 							{/if}
-
-							{#if canManageMembers}
-								<select
-									class="members__role-select"
-									value={m.role}
-									onchange={(e) =>
-										void changeRole(m, (e.currentTarget as HTMLSelectElement).value as DriveRole)}
-									aria-label={t('drive.member.change_role_aria', 'Change role')}
-								>
-									{#each ASSIGNABLE_ROLES as r (r)}
-										<option value={r}>{roleLabel(r)}</option>
-									{/each}
-								</select>
-								<button
-									type="button"
-									class="members__remove"
-									title={t('drive.member.remove', 'Remove member')}
-									aria-label={t('drive.member.remove', 'Remove member')}
-									onclick={() => void removeMember(m)}
-								>
-									<Icon name="times" />
-								</button>
-							{:else}
-								<span class="members__role members__role--{m.role}">
-									{roleLabel(m.role)}
-								</span>
-							{/if}
+							<span class="members__role members__role--{m.role}">
+								{roleLabel(m.role)}
+							</span>
 						</li>
 					{/each}
 				</ul>
@@ -289,6 +287,19 @@
 		{/if}
 	{/if}
 </div>
+
+<!-- Drive members modal — reuses the same ShareDialog as file/folder
+     sharing. `allowLinks={false}` hides the public-link tab because
+     drives don't support shareable URLs (the backend service refuses
+     token subjects on drive resources). -->
+{#if dialogItem}
+	<ShareDialog
+		bind:open={shareDialogOpen}
+		item={dialogItem}
+		allowLinks={false}
+		onchange={onShareDialogChange}
+	/>
+{/if}
 
 <style>
 	.config-drive {
@@ -389,6 +400,20 @@
 
 	.link:hover {
 		text-decoration: underline;
+	}
+
+	/* Members card header: title on the left, "Manage members" button on
+	   the right when the caller can mutate membership. */
+	.members__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-3, 0.75rem);
+		margin-bottom: var(--space-3, 0.75rem);
+	}
+
+	.members__header h2 {
+		margin: 0;
 	}
 
 	/* Members list */

--- a/frontend/src/routes/shared-with-me/+page.svelte
+++ b/frontend/src/routes/shared-with-me/+page.svelte
@@ -26,26 +26,33 @@
 	const byId = $derived(new Map(raw.map((it) => [it.resource.id, it])));
 
 	const entries = $derived(
-		raw.map((it): ResourceEntry => {
-			const isFile = it.resource_type === 'file';
-			return {
-				id: it.resource.id,
-				name: it.resource.name,
-				kind: it.resource_type,
-				iconClass: it.resource.icon_class,
-				// The sharer becomes the "owner" surface — ResourceList renders
-				// `<UserVignette userId>` (avatar / name / external badge),
-				// resolved lazily via `/api/users/{id}`. `path` keeps the
-				// resource's real location so the row still shows where it
-				// lives, not a translated string.
-				ownerId: it.granted_by ?? null,
-				ownerName: sharers.name(it.granted_by),
-				path: it.resource.path,
-				size: isFile ? (it.resource as FileItem).size : null,
-				date: it.granted_at,
-				category: isFile ? it.resource.category : 'Folder'
-			};
-		})
+		// Drive resources also surface in `/api/grants/incoming/resources`
+		// since the role_grants rewrite, but they don't belong in the
+		// file/folder ResourceList — they're reached through the drive
+		// picker / breadcrumb. Filter them out here so the row UI keeps
+		// its file|folder type contract.
+		raw
+			.filter((it) => it.resource_type !== 'drive')
+			.map((it): ResourceEntry => {
+				const isFile = it.resource_type === 'file';
+				return {
+					id: it.resource.id,
+					name: it.resource.name,
+					kind: it.resource_type as 'file' | 'folder',
+					iconClass: it.resource.icon_class,
+					// The sharer becomes the "owner" surface — ResourceList renders
+					// `<UserVignette userId>` (avatar / name / external badge),
+					// resolved lazily via `/api/users/{id}`. `path` keeps the
+					// resource's real location so the row still shows where it
+					// lives, not a translated string.
+					ownerId: it.granted_by ?? null,
+					ownerName: sharers.name(it.granted_by),
+					path: it.resource.path,
+					size: isFile ? (it.resource as FileItem).size : null,
+					date: it.granted_at,
+					category: isFile ? it.resource.category : 'Folder'
+				};
+			})
 	);
 
 	// Server-supported sort_by values (see grant_handler.rs:615):

--- a/frontend/src/routes/shared/+page.svelte
+++ b/frontend/src/routes/shared/+page.svelte
@@ -19,7 +19,8 @@
 	import { copyShareLink, deleteShare, getShareById, updateShare } from '$lib/api/endpoints/shares';
 	import { ensureResolvers, resolveLabel } from '$lib/api/endpoints/recipients';
 	import { fileInlineUrl } from '$lib/api/endpoints/files';
-	import type { FileItem, FolderItem, ItemType } from '$lib/api/types';
+	import type { FileItem, FolderItem } from '$lib/api/types';
+	import type { GrantResourceType } from '$lib/api/endpoints/grants';
 	import Icon from '$lib/icons/Icon.svelte';
 	import ListToolbar from '$lib/components/ListToolbar.svelte';
 	import { lazyComponent } from '$lib/composables/lazyComponent.svelte';
@@ -53,7 +54,7 @@
 
 	// Edit-sharing dialog
 	let dialogOpen = $state(false);
-	let dialogItem = $state<{ id: string; name: string; kind: ItemType } | null>(null);
+	let dialogItem = $state<{ id: string; name: string; kind: GrantResourceType } | null>(null);
 
 	// ShareDialog is heavy and only opens on demand — keep it out of this route's
 	// initial chunk and load it the first time the dialog is opened.
@@ -189,6 +190,13 @@
 	}
 
 	function openResource(item: OutgoingGrantItem) {
+		// Drives don't have a Files-page deep-link the same way folders do
+		// (their id is the drive UUID, not a folder UUID); route to the
+		// per-drive settings page so the user lands somewhere meaningful.
+		if (item.resource_type === 'drive') {
+			goto(resolve(`/config/drive/${item.resource.id}`));
+			return;
+		}
 		if (item.resource_type === 'folder') goto(resolve(`/files/${item.resource.id}`));
 		else window.open(fileInlineUrl(item.resource.id), '_blank', 'noopener');
 	}
@@ -351,6 +359,11 @@
 	}
 
 	function resourceIcon(item: OutgoingGrantItem): string {
+		// Drives use the `hdd` glyph (shared with DrivePicker / breadcrumb)
+		// so a shared drive reads as a distinct kind at a glance — folder
+		// and drive both grant access to a tree, but the scope is very
+		// different.
+		if (item.resource_type === 'drive') return 'hdd';
 		return item.resource_type === 'folder'
 			? 'folder'
 			: iconNameFromClass((item.resource as FileItem | FolderItem).icon_class);
@@ -629,7 +642,10 @@
 
 {#if shareDialog.component}
 	{@const ShareDialog = shareDialog.component}
-	<ShareDialog bind:open={dialogOpen} item={dialogItem} />
+	<!-- Drives don't support shareable URLs — hide the Public-link tab
+	     when the dialog is opened for a drive resource. File/folder
+	     resources keep the default tab set. -->
+	<ShareDialog bind:open={dialogOpen} item={dialogItem} allowLinks={dialogItem?.kind !== 'drive'} />
 {/if}
 
 <style>

--- a/frontend/src/routes/trash/+page.svelte
+++ b/frontend/src/routes/trash/+page.svelte
@@ -10,7 +10,7 @@
 		restoreTrashItem
 	} from '$lib/api/endpoints/trash';
 	import { dateBucket, sizeBucket, typeLabel } from '$lib/api/endpoints/favorites';
-	import type { FileItem, TrashResourceItem } from '$lib/api/types';
+	import type { Drive, FileItem, TrashResourceItem } from '$lib/api/types';
 	import Icon from '$lib/icons/Icon.svelte';
 	import ResourceList, {
 		type GroupByDef,
@@ -18,6 +18,7 @@
 	} from '$lib/components/ResourceList.svelte';
 	import { confirmDialog } from '$lib/stores/dialogs.svelte';
 	import { t } from '$lib/i18n/index.svelte';
+	import { drives as drivesStore } from '$lib/stores/drives.svelte';
 	import { ui } from '$lib/stores/ui.svelte';
 
 	let raw = $state<TrashResourceItem[]>([]);
@@ -41,13 +42,48 @@
 				// `date` carries the deletion date — rendered as an expiry chip.
 				date: it.deletion_date,
 				category: isFile ? it.resource.category : 'Folder',
-				modifiedAt: it.trashed_at
+				modifiedAt: it.trashed_at,
+				// D2b: surface drive_id so the Drive group-by can bucket by it.
+				// Reuses the existing `ownerId` slot on ResourceEntry — both
+				// represent a UUID the listing pivots on; no new field needed.
+				ownerId: it.drive_id
 			};
 		})
 	);
 
+	// "Drive" group rank: default-personal first, then secondary personal, then
+	// shared — matches `DrivePicker.svelte::sortedDrives` so the sidebar and
+	// trash sections agree on ordering. Used as the bucket sort key.
+	function driveRank(d: Drive | null): number {
+		if (!d) return 99;
+		if (d.default_for_user) return 0;
+		return d.kind === 'personal' ? 1 : 2;
+	}
+	function driveLabel(driveId: string): string {
+		const d = drivesStore.findById(driveId);
+		return d?.name ?? driveId;
+	}
+	function driveBucketKey(driveId: string): string {
+		// Bucket key has to be a string but we want ordering; prefix with
+		// rank so the natural lexical sort puts buckets in the picker's order.
+		const d = drivesStore.findById(driveId);
+		const rank = driveRank(d).toString().padStart(2, '0');
+		return `${rank}:${driveId}`;
+	}
+	function driveBucketLabel(key: string): string {
+		const driveId = key.split(':')[1] ?? key;
+		return driveLabel(driveId);
+	}
+
 	const groupBys: GroupByDef[] = [
-		{ key: '', label: t('files.name', 'Name'), orderBy: 'name' },
+		{ key: '', label: t('files.name', 'Name'), orderBy: 'name', icon: 'arrow-up-a-z' },
+		{
+			key: 'drive',
+			label: t('trash.groupby.drive', 'Drive'),
+			orderBy: 'name',
+			bucketOf: (e) => (e.ownerId ? driveBucketKey(e.ownerId) : null),
+			labelOf: driveBucketLabel
+		},
 		{
 			key: 'remainingDays',
 			label: t('trash.groupby.remaining_days', 'Remaining days'),
@@ -148,7 +184,12 @@
 		}
 	}
 
-	onMount(() => load(true));
+	onMount(() => {
+		// Drive names for the "Drive" group-by labels — `drivesStore.load()` is
+		// idempotent (cached on the singleton) so this is essentially free.
+		void drivesStore.load();
+		void load(true);
+	});
 </script>
 
 <svelte:head><title>{t('nav.trash', 'Trash')} · OxiCloud</title></svelte:head>

--- a/migrations/20260804000000_trash_items_drive_id.sql
+++ b/migrations/20260804000000_trash_items_drive_id.sql
@@ -1,0 +1,51 @@
+-- D2b — surface `drive_id` on the unified trash view.
+--
+-- `storage.trash_items` is the read-side projection of soft-deleted files and
+-- folders. D0 added `drive_id` to both `storage.files` and `storage.folders`,
+-- but the view shipped before that and still reflects only `user_id`. D2b's
+-- per-drive trash authorisation needs `drive_id` per row so:
+--
+--   1. Listing can filter to drives the caller can read (the storage
+--      precheck — `pg_acl_engine.caller_role_on_drive_cached` — replaces
+--      the legacy `WHERE user_id = caller_id` scope).
+--   2. The UI can group trash items by drive (per the D2b spec).
+--   3. The trash sweeper / orphan reclamation paths (added later in D2b)
+--      can operate per-drive instead of per-user.
+--
+-- The view is `CREATE OR REPLACE`, so this is a pure schema-shape change —
+-- no data migration needed. The two source columns (`storage.files.drive_id`,
+-- `storage.folders.drive_id`) are both `NOT NULL` after D0's
+-- `20260802100002_drives_not_null.sql`, so the projection inherits NOT NULL
+-- semantics automatically (no `COALESCE` fallback needed).
+
+-- `CREATE OR REPLACE VIEW` is restrictive: it can ADD columns at the END
+-- but never re-order or rename existing ones. `drive_id` goes after every
+-- pre-existing column so PG doesn't read this as renaming `trashed_at` →
+-- `drive_id`. Column ORDER on the view changes; consumers SELECT by name
+-- so they're unaffected.
+
+CREATE OR REPLACE VIEW storage.trash_items AS
+    SELECT f.id, f.name, 'file' AS item_type, f.user_id, f.trashed_at,
+           f.original_folder_id AS original_parent_id, f.created_at,
+           f.drive_id
+    FROM storage.files f
+    WHERE f.is_trashed = TRUE
+      AND (f.folder_id IS NULL
+           OR NOT EXISTS (
+               SELECT 1 FROM storage.folders p
+                WHERE p.id = f.folder_id AND p.is_trashed = TRUE))
+    UNION ALL
+    SELECT fo.id, fo.name, 'folder' AS item_type, fo.user_id, fo.trashed_at,
+           fo.original_parent_id, fo.created_at,
+           fo.drive_id
+    FROM storage.folders fo
+    WHERE fo.is_trashed = TRUE
+      AND (fo.parent_id IS NULL
+           OR NOT EXISTS (
+               SELECT 1 FROM storage.folders p
+                WHERE p.id = fo.parent_id AND p.is_trashed = TRUE));
+
+COMMENT ON VIEW storage.trash_items IS
+    'Unified view of all trashed files and folders. `drive_id` added in D2b '
+    'so callers can scope by accessible drives (the legacy per-user scope '
+    'is being phased out alongside the user_id column in D7).';

--- a/src/application/dtos/drive_dto.rs
+++ b/src/application/dtos/drive_dto.rs
@@ -100,3 +100,4 @@ impl From<DriveWithRootName> for DriveDto {
         }
     }
 }
+

--- a/src/application/dtos/drive_dto.rs
+++ b/src/application/dtos/drive_dto.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+use crate::application::dtos::grant_dto::RoleDto;
 use crate::domain::entities::drive::DriveKind;
 use crate::domain::repositories::drive_repository::DriveWithRootName;
 
@@ -62,6 +63,24 @@ pub struct DriveDto {
     pub policies: serde_json::Value,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub updated_at: chrono::DateTime<chrono::Utc>,
+
+    /// Highest role the **calling** user holds on this drive (direct OR
+    /// group-mediated). Populated by `GET /api/drives` and the drive
+    /// grants in `/api/grants/incoming/resources`. Omitted (`None`) in
+    /// contexts where the caller isn't naturally a member — e.g. the
+    /// outgoing-grants listing where the caller is the granter and may
+    /// not have a current role on the drive themselves.
+    ///
+    /// **UI gating**:
+    /// - `Some(Owner)` → mutation controls (add/edit/remove members, change policies, delete drive)
+    /// - `Some(Editor/Contributor/Commenter)` → mutate drive contents, no membership UI
+    /// - `Some(Viewer)` → read-only
+    /// - `None` → show neither member list nor mutation controls
+    ///
+    /// See `project_caller_role_on_file_folder_dto` memory for the
+    /// pattern extension to FileDto / FolderDto (deferred, perf-sensitive).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub caller_role: Option<RoleDto>,
 }
 
 impl From<DriveWithRootName> for DriveDto {
@@ -77,6 +96,7 @@ impl From<DriveWithRootName> for DriveDto {
             policies: d.drive.policies,
             created_at: d.drive.created_at,
             updated_at: d.drive.updated_at,
+            caller_role: d.caller_role.map(RoleDto::from),
         }
     }
 }

--- a/src/application/dtos/drive_dto.rs
+++ b/src/application/dtos/drive_dto.rs
@@ -100,4 +100,3 @@ impl From<DriveWithRootName> for DriveDto {
         }
     }
 }
-

--- a/src/application/dtos/grant_dto.rs
+++ b/src/application/dtos/grant_dto.rs
@@ -9,6 +9,7 @@ use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use crate::application::dtos::cursor::{CursorListResponse, CursorQuery, PageCursor};
+use crate::application::dtos::drive_dto::DriveDto;
 use crate::application::dtos::file_dto::FileDto;
 use crate::application::dtos::folder_dto::FolderDto;
 use crate::domain::services::authorization::{Grant, Permission, Resource, Role, Subject};
@@ -418,6 +419,7 @@ impl SharedWithMeQuery {
 pub enum ResourceContentDto {
     File(FileDto),
     Folder(FolderDto),
+    Drive(DriveDto),
 }
 
 /// One item in the shared-with-me list.

--- a/src/application/dtos/trash_dto.rs
+++ b/src/application/dtos/trash_dto.rs
@@ -61,6 +61,11 @@ pub struct TrashResourceRow {
     pub resource_created_at: DateTime<Utc>,
     pub modified_at: DateTime<Utc>,
     pub owner_id: Uuid,
+    /// Drive the trashed item belongs to. Surfaced verbatim on the wire
+    /// (`TrashResourceItemDto.drive_id`) so the `/trash` UI can group by
+    /// drive without an extra lookup per row. D2b: filtering by drive is
+    /// done in SQL via `WHERE drive_id = ANY($accessible_drive_ids)`.
+    pub drive_id: Uuid,
     /// Raw BLAKE3 content hash. `Some(_)` for file rows, `None` for
     /// folder rows. Feeds `File::compute_etag` so the trash listing's
     /// `etag` matches what GET/HEAD/PROPFIND would return for the
@@ -162,6 +167,12 @@ pub struct TrashResourceItemDto {
     pub trashed_at: DateTime<Utc>,
     /// When the item will be permanently deleted by the retention sweeper.
     pub deletion_date: DateTime<Utc>,
+    /// The drive the trashed item belongs to. Enables client-side
+    /// group-by-drive in the `/trash` UI (D2b spec — see
+    /// `project_trash_groupbys_d2b` memory). The drive's display name
+    /// resolves through the `/api/drives` listing the client already
+    /// holds in `drives.svelte` — no extra round-trip needed.
+    pub drive_id: Uuid,
     /// Full resource details — shape determined by `resource_type`.
     pub resource: ResourceContentDto,
 }

--- a/src/application/services/drive_management_service.rs
+++ b/src/application/services/drive_management_service.rs
@@ -173,54 +173,105 @@ impl DriveManagementService {
     ///
     /// `set_role` is idempotent — `(subject, resource)` is unique — so the
     /// two HTTP shapes share one service method. Returns the resulting grant.
+    ///
+    /// `caller_is_admin = true` skips the per-drive `Manage` check
+    /// (used by `/api/admin/drives/{id}/members` so an admin who
+    /// created the drive for someone else can still edit owners).
+    /// Personal-drive guard and last-owner protection still apply —
+    /// admin bypass is about *access*, not invariants. The audit log
+    /// flags admin-driven changes via `via_admin = true` so a reader
+    /// can tell what fired the mutation. The caller (HTTP handler) is
+    /// authoritative for `caller_is_admin`; the route gate is the
+    /// source of truth and the service trusts the flag.
     pub async fn set_member_role(
         &self,
         caller_id: Uuid,
+        caller_is_admin: bool,
         drive_id: Uuid,
         subject: Subject,
         role: Role,
         expires_at: Option<chrono::DateTime<chrono::Utc>>,
     ) -> Result<Grant, DomainError> {
         let resource = Resource::Drive(drive_id);
-        self.authz
-            .require(Subject::User(caller_id), Permission::Manage, resource)
-            .await?;
+        if !caller_is_admin {
+            self.authz
+                .require(Subject::User(caller_id), Permission::Manage, resource)
+                .await?;
+        }
 
         self.refuse_if_personal(drive_id, "set_member_role").await?;
 
         // Demotion of the last owner = last-owner protection trips. A fresh
         // owner-role write or any non-owner subject is fine; only the case
         // "this subject is currently the only owner AND the new role is not
-        // owner" is refused.
+        // owner" is refused. Applies to admin-bypass too: orphaning a
+        // shared drive is the same category error regardless of who fires
+        // the request.
         if !matches!(role, Role::Owner) {
             self.refuse_if_last_owner_change(drive_id, subject, caller_id)
                 .await?;
         }
 
-        self.authz
+        let grant = self
+            .authz
             .set_role(caller_id, subject, role, resource, expires_at)
-            .await
+            .await?;
+
+        if caller_is_admin {
+            tracing::info!(
+                target: "audit",
+                event = "drive_membership.set_via_admin",
+                drive_id = %drive_id,
+                subject_type = subject.type_str(),
+                subject_id = %subject.id(),
+                role = role.as_str(),
+                by = %caller_id,
+                "👮🏻‍♂️ admin set drive member role bypassing Manage check",
+            );
+        }
+        Ok(grant)
     }
 
     /// `DELETE /api/drives/{id}/members/{subject_id}`. Idempotent — removing
     /// a subject with no current grant succeeds (matches `clear_role`).
+    ///
+    /// `caller_is_admin` mirrors `set_member_role`: skips the per-drive
+    /// `Manage` check but keeps personal-drive guard + last-owner
+    /// protection. Audit emits `drive_membership.removed_via_admin`
+    /// when the bypass fires.
     pub async fn remove_member(
         &self,
         caller_id: Uuid,
+        caller_is_admin: bool,
         drive_id: Uuid,
         subject: Subject,
     ) -> Result<(), DomainError> {
         let resource = Resource::Drive(drive_id);
-        self.authz
-            .require(Subject::User(caller_id), Permission::Manage, resource)
-            .await?;
+        if !caller_is_admin {
+            self.authz
+                .require(Subject::User(caller_id), Permission::Manage, resource)
+                .await?;
+        }
 
         self.refuse_if_personal(drive_id, "remove_member").await?;
 
         self.refuse_if_last_owner_change(drive_id, subject, caller_id)
             .await?;
 
-        self.authz.clear_role(subject, resource).await
+        self.authz.clear_role(subject, resource).await?;
+
+        if caller_is_admin {
+            tracing::info!(
+                target: "audit",
+                event = "drive_membership.removed_via_admin",
+                drive_id = %drive_id,
+                subject_type = subject.type_str(),
+                subject_id = %subject.id(),
+                by = %caller_id,
+                "👮🏻‍♂️ admin removed drive member bypassing Manage check",
+            );
+        }
+        Ok(())
     }
 
     // ── Business rules ──────────────────────────────────────────────────────

--- a/src/application/services/drive_management_service.rs
+++ b/src/application/services/drive_management_service.rs
@@ -1,0 +1,178 @@
+//! D2 — drive membership management service.
+//!
+//! Translates `POST/PATCH/DELETE /api/drives/{id}/members` into role-grant
+//! writes on `resource_type='drive'`, layering D2's business rules on top:
+//!
+//! - **Personal-drive guard** (§2): drives with `kind='personal'` are
+//!   single-user single-owner by invariant; any member mutation is refused
+//!   at the service edge with `403`. Listing a personal drive's members is
+//!   still allowed (returns exactly the owner row) so the UI can render the
+//!   same shape across drive kinds without per-kind branching.
+//!
+//! - **Last-owner protection** (shared drives): removing or demoting the
+//!   final `Role::Owner` would leave the drive unmanageable. Refused at the
+//!   service edge — the caller has to promote someone else to Owner first,
+//!   or delete the drive.
+//!
+//! - **Authorization**: caller must hold `Permission::Manage` on the drive
+//!   to mutate; `Permission::Read` to list. `AuthorizationEngine::require`
+//!   emits the canonical `authz.denied` audit line on rejection.
+
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::application::ports::authorization_ports::AuthorizationEngine;
+use crate::common::errors::DomainError;
+use crate::domain::repositories::drive_repository::DriveRepository;
+use crate::domain::services::authorization::{Grant, Permission, Resource, Role, Subject};
+use crate::infrastructure::repositories::pg::DrivePgRepository;
+use crate::infrastructure::services::pg_acl_engine::PgAclEngine;
+
+pub struct DriveManagementService {
+    drive_repo: Arc<DrivePgRepository>,
+    authz: Arc<PgAclEngine>,
+}
+
+impl DriveManagementService {
+    pub fn new(drive_repo: Arc<DrivePgRepository>, authz: Arc<PgAclEngine>) -> Self {
+        Self { drive_repo, authz }
+    }
+
+    /// `GET /api/drives/{id}/members` — every role grant on the drive.
+    pub async fn list_members(
+        &self,
+        caller_id: Uuid,
+        drive_id: Uuid,
+    ) -> Result<Vec<Grant>, DomainError> {
+        let resource = Resource::Drive(drive_id);
+        self.authz
+            .require(Subject::User(caller_id), Permission::Read, resource)
+            .await?;
+        self.authz.list_grants_on_resource(resource).await
+    }
+
+    /// `POST /api/drives/{id}/members` (create) or
+    /// `PATCH /api/drives/{id}/members/{subject_id}` (role change).
+    ///
+    /// `set_role` is idempotent — `(subject, resource)` is unique — so the
+    /// two HTTP shapes share one service method. Returns the resulting grant.
+    pub async fn set_member_role(
+        &self,
+        caller_id: Uuid,
+        drive_id: Uuid,
+        subject: Subject,
+        role: Role,
+        expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<Grant, DomainError> {
+        let resource = Resource::Drive(drive_id);
+        self.authz
+            .require(Subject::User(caller_id), Permission::Manage, resource)
+            .await?;
+
+        self.refuse_if_personal(drive_id, "set_member_role").await?;
+
+        // Demotion of the last owner = last-owner protection trips. A fresh
+        // owner-role write or any non-owner subject is fine; only the case
+        // "this subject is currently the only owner AND the new role is not
+        // owner" is refused.
+        if !matches!(role, Role::Owner) {
+            self.refuse_if_last_owner_change(drive_id, subject, caller_id)
+                .await?;
+        }
+
+        self.authz
+            .set_role(caller_id, subject, role, resource, expires_at)
+            .await
+    }
+
+    /// `DELETE /api/drives/{id}/members/{subject_id}`. Idempotent — removing
+    /// a subject with no current grant succeeds (matches `clear_role`).
+    pub async fn remove_member(
+        &self,
+        caller_id: Uuid,
+        drive_id: Uuid,
+        subject: Subject,
+    ) -> Result<(), DomainError> {
+        let resource = Resource::Drive(drive_id);
+        self.authz
+            .require(Subject::User(caller_id), Permission::Manage, resource)
+            .await?;
+
+        self.refuse_if_personal(drive_id, "remove_member").await?;
+
+        self.refuse_if_last_owner_change(drive_id, subject, caller_id)
+            .await?;
+
+        self.authz.clear_role(subject, resource).await
+    }
+
+    // ── Business rules ──────────────────────────────────────────────────────
+
+    /// Personal drives are single-user single-owner; any member mutation is
+    /// a category error (§2). Returns `Forbidden` with an audit line.
+    async fn refuse_if_personal(&self, drive_id: Uuid, op: &str) -> Result<(), DomainError> {
+        let drive = self.drive_repo.get_by_id(drive_id).await.map_err(|e| {
+            DomainError::internal_error("Drive", format!("Failed to fetch drive: {e:?}"))
+        })?;
+        if drive.drive.is_personal() {
+            tracing::info!(
+                target: "audit",
+                event = "drive_membership.rejected",
+                reason = "personal_drive_immutable",
+                operation = %op,
+                drive_id = %drive_id,
+                "👮🏻‍♂️ refused {op} on personal drive {drive_id}",
+            );
+            return Err(DomainError::operation_not_supported(
+                "Drive",
+                "Personal drives have a fixed single-owner membership and cannot be modified.",
+            ));
+        }
+        Ok(())
+    }
+
+    /// Refuse the change if `subject` is currently the sole `Owner` on the
+    /// drive and the operation would remove or demote them. A shared drive
+    /// must always have at least one Owner — otherwise it becomes orphaned
+    /// (no one can ever grant permissions again).
+    async fn refuse_if_last_owner_change(
+        &self,
+        drive_id: Uuid,
+        subject: Subject,
+        caller_id: Uuid,
+    ) -> Result<(), DomainError> {
+        let resource = Resource::Drive(drive_id);
+        let grants = self.authz.list_grants_on_resource(resource).await?;
+
+        // `subject` must currently BE an owner — otherwise no demotion risk.
+        let subject_is_owner = grants
+            .iter()
+            .any(|g| g.subject == subject && matches!(g.role, Role::Owner));
+        if !subject_is_owner {
+            return Ok(());
+        }
+
+        let owner_count = grants
+            .iter()
+            .filter(|g| matches!(g.role, Role::Owner))
+            .count();
+        if owner_count <= 1 {
+            tracing::info!(
+                target: "audit",
+                event = "drive_membership.rejected",
+                reason = "last_owner",
+                drive_id = %drive_id,
+                caller_id = %caller_id,
+                subject_type = subject.type_str(),
+                subject_id = %subject.id(),
+                "👮🏻‍♂️ refused last-owner removal on drive {drive_id}",
+            );
+            return Err(DomainError::validation_error(
+                "A shared drive must keep at least one Owner — promote another \
+                 member to Owner first, or delete the drive.",
+            ));
+        }
+        Ok(())
+    }
+}

--- a/src/application/services/drive_management_service.rs
+++ b/src/application/services/drive_management_service.rs
@@ -25,18 +25,134 @@ use uuid::Uuid;
 use crate::application::ports::authorization_ports::AuthorizationEngine;
 use crate::common::errors::DomainError;
 use crate::domain::repositories::drive_repository::DriveRepository;
+use crate::domain::repositories::subject_group_repository::SubjectGroupRepository;
 use crate::domain::services::authorization::{Grant, Permission, Resource, Role, Subject};
 use crate::infrastructure::repositories::pg::DrivePgRepository;
+use crate::infrastructure::repositories::pg::SubjectGroupPgRepository;
 use crate::infrastructure::services::pg_acl_engine::PgAclEngine;
 
 pub struct DriveManagementService {
     drive_repo: Arc<DrivePgRepository>,
     authz: Arc<PgAclEngine>,
+    /// Needed to validate that a Group owner subject is non-empty at
+    /// create-drive time — refusing creation with an empty group avoids
+    /// constructing an orphan-owned drive (the "drive must always have
+    /// ≥1 effective Owner-user" invariant from day one).
+    group_repo: Arc<SubjectGroupPgRepository>,
 }
 
 impl DriveManagementService {
-    pub fn new(drive_repo: Arc<DrivePgRepository>, authz: Arc<PgAclEngine>) -> Self {
-        Self { drive_repo, authz }
+    pub fn new(
+        drive_repo: Arc<DrivePgRepository>,
+        authz: Arc<PgAclEngine>,
+        group_repo: Arc<SubjectGroupPgRepository>,
+    ) -> Self {
+        Self {
+            drive_repo,
+            authz,
+            group_repo,
+        }
+    }
+
+    /// `POST /api/drives` — create a shared drive owned by a group.
+    ///
+    /// **AuthZ (D3a)**: OxiCloud-admin only. The plan (`drive.md §6`)
+    /// reads "admin or group owner triggers" — D3a starts with the
+    /// admin-only path; group-owner triggering can extend the gate
+    /// later without changing the wire shape or the service method
+    /// signature. `caller_is_admin` is resolved by the HTTP handler
+    /// from `CurrentUser.role` and passed in; the service trusts it
+    /// (defense-in-depth check stays at the route layer).
+    ///
+    /// Audit log: `drive.created` with the drive id, the owner group,
+    /// and the granted_by (the admin caller).
+    pub async fn create_shared_drive(
+        &self,
+        caller_id: Uuid,
+        caller_is_admin: bool,
+        name: &str,
+        owner_subject: Subject,
+        quota_bytes: Option<i64>,
+    ) -> Result<crate::domain::repositories::drive_repository::DriveWithRootName, DomainError> {
+        if !caller_is_admin {
+            tracing::info!(
+                target: "audit",
+                event = "drive_create.rejected",
+                reason = "not_admin",
+                caller_id = %caller_id,
+                owner_type = owner_subject.type_str(),
+                owner_id = %owner_subject.id(),
+                "👮🏻‍♂️ refused shared-drive create: caller is not an OxiCloud admin",
+            );
+            return Err(DomainError::access_denied(
+                "Drive",
+                "Only OxiCloud administrators can create shared drives.",
+            ));
+        }
+
+        // Token subjects are share-link identities, not entities that can
+        // own things. Refuse at the service edge.
+        if matches!(owner_subject, Subject::Token(_)) {
+            tracing::info!(
+                target: "audit",
+                event = "drive_create.rejected",
+                reason = "invalid_owner_kind",
+                caller_id = %caller_id,
+                owner_type = "token",
+                "👮🏻‍♂️ refused shared-drive create: owner cannot be a Token subject",
+            );
+            return Err(DomainError::validation_error(
+                "Drive owner must be a user or a group, not a token.",
+            ));
+        }
+
+        // Group owners must be non-empty — otherwise the drive is created
+        // with no transitive Owner-user from day one. Per Ed's invariant:
+        // "a drive must always remain with at least one Owner-user". User
+        // owners trivially satisfy this.
+        if let Subject::Group(gid) = owner_subject {
+            let n = self.group_repo.count_members(gid).await.map_err(|e| {
+                DomainError::internal_error("Drive", format!("group lookup failed: {e:?}"))
+            })?;
+            if n < 1 {
+                tracing::info!(
+                    target: "audit",
+                    event = "drive_create.rejected",
+                    reason = "owner_group_empty",
+                    caller_id = %caller_id,
+                    owner_group_id = %gid,
+                    "👮🏻‍♂️ refused shared-drive create: owner group has no members",
+                );
+                return Err(DomainError::validation_error(
+                    "Owner group has no members — the drive would have no effective Owner.",
+                ));
+            }
+        }
+
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return Err(DomainError::validation_error("Drive name is required."));
+        }
+
+        let drive = self
+            .drive_repo
+            .create_shared_drive_atomic(trimmed, owner_subject, quota_bytes, caller_id)
+            .await
+            .map_err(|e| DomainError::internal_error("Drive", format!("create failed: {e:?}")))?;
+
+        tracing::info!(
+            target: "audit",
+            event = "drive.created",
+            kind = "shared",
+            drive_id = %drive.drive.id,
+            owner_type = owner_subject.type_str(),
+            owner_id = %owner_subject.id(),
+            granted_by = %caller_id,
+            "🆕 shared drive created '{}' owned by {} {}",
+            trimmed, owner_subject.type_str(), owner_subject.id(),
+        );
+
+        Ok(drive)
     }
 
     /// `GET /api/drives/{id}/members` — every role grant on the drive.

--- a/src/application/services/folder_service.rs
+++ b/src/application/services/folder_service.rs
@@ -446,10 +446,32 @@ impl FolderUseCase for FolderService {
             )));
         }
 
+        // Drive roots double as the drive's display name (per drive.md §3,
+        // `drives.name` is sourced from `storage.folders.name` of the row
+        // pointed at by `root_folder_id`). Per drive.md §6 the rename is
+        // Owner-only — but with `Permission::Update` that's leaky because
+        // every Editor of the drive has Update on every folder in the
+        // drive, including the root. So we promote the requirement to
+        // `Manage` for root folders. A root is identified by
+        // `parent_id IS NULL`; that's the same property the drive seeder
+        // and the drive-of-resource resolver rely on, so no schema-level
+        // assumption shifts here.
+        let folder = self.folder_storage.get_folder(id).await.map_err(|e| {
+            DomainError::internal_error(
+                "FolderStorage",
+                format!("Failed to look up folder before rename: {id}: {e}"),
+            )
+        })?;
+        let required_perm = if folder.parent_id().is_none() {
+            Permission::Manage
+        } else {
+            Permission::Update
+        };
+
         self.authz
             .require(
                 Subject::User(caller_id),
-                Permission::Update,
+                required_perm,
                 Self::folder_resource(id)?,
             )
             .await?;

--- a/src/application/services/mod.rs
+++ b/src/application/services/mod.rs
@@ -7,6 +7,7 @@ pub mod calendar_service;
 pub mod contact_service;
 pub mod delta_upload_service;
 pub mod device_auth_service;
+pub mod drive_management_service;
 pub mod external_identity_service;
 pub mod favorites_service;
 pub mod file_lifecycle_service;

--- a/src/application/services/subject_group_service.rs
+++ b/src/application/services/subject_group_service.rs
@@ -563,7 +563,15 @@ mod integration_tests {
         let pool = Arc::new(pool);
         let repo = Arc::new(SubjectGroupPgRepository::new(pool.clone()));
         let user_storage = Arc::new(UserPgRepository::new(pool.clone()));
-        SubjectGroupService::new(repo, pool, user_storage)
+        // The engine is wired so `add_member` / `remove_member` can invalidate
+        // their stale `user_groups_cache` entries (the production path).
+        // A stub engine is enough — these tests never trigger an authz SQL
+        // round-trip, only the in-memory cache invalidation calls. The stub's
+        // lazy invalid pool would panic if reached, surfacing any drift if a
+        // future test starts exercising real authz lookups.
+        let engine =
+            Arc::new(crate::infrastructure::services::pg_acl_engine::PgAclEngine::new_stub());
+        SubjectGroupService::new(repo, pool, user_storage, engine)
     }
 
     async fn first_admin(pool: &sqlx::PgPool) -> Uuid {

--- a/src/application/services/subject_group_service.rs
+++ b/src/application/services/subject_group_service.rs
@@ -37,6 +37,13 @@ pub struct SubjectGroupService {
     /// make it not dyn-compatible (matches the convention used by other
     /// services in this layer).
     user_storage: Arc<UserPgRepository>,
+    /// Used by `add_member` / `remove_member` to drop stale
+    /// `user_groups_cache` entries for affected users so newly-added
+    /// (or newly-removed) group memberships surface in the next
+    /// `expand_subject_for_listing` call instead of waiting out the
+    /// 30 s TTL. Without this, fresh group-mediated drive grants
+    /// don't appear in `/api/drives` for up to 30 s after `add_member`.
+    engine: Arc<crate::infrastructure::services::pg_acl_engine::PgAclEngine>,
 }
 
 impl SubjectGroupService {
@@ -44,11 +51,29 @@ impl SubjectGroupService {
         repo: Arc<SubjectGroupPgRepository>,
         pool: Arc<PgPool>,
         user_storage: Arc<UserPgRepository>,
+        engine: Arc<crate::infrastructure::services::pg_acl_engine::PgAclEngine>,
     ) -> Self {
         Self {
             repo,
             pool,
             user_storage,
+            engine,
+        }
+    }
+
+    /// Returns the user IDs whose `user_groups_cache` entries need to
+    /// drop after a membership change on `member`. For `User` members
+    /// it's just that user; for nested `Group` members, every
+    /// transitive user under that child group inherits/loses the
+    /// parent-group ancestor, so all of them need invalidation.
+    async fn invalidation_targets(&self, member: GroupMember) -> Result<Vec<Uuid>, DomainError> {
+        match member {
+            GroupMember::User(uid) => Ok(vec![uid]),
+            GroupMember::Group(child_id) => self
+                .repo
+                .list_transitive_users(child_id)
+                .await
+                .map_err(map_repo_err),
         }
     }
 
@@ -331,6 +356,15 @@ impl SubjectGroupService {
                 map_repo_err(e)
             })?;
 
+        // Drop stale cached subject expansions for every user who just
+        // inherited the new group as a transitive ancestor — otherwise
+        // group-mediated grants (e.g. shared-drive Owner via this
+        // group) wouldn't surface in the next `expand_subject_for_listing`
+        // call for up to 30 s.
+        for uid in self.invalidation_targets(member).await? {
+            self.engine.invalidate_user_groups_cache(uid).await;
+        }
+
         tracing::info!(
             target: "audit",
             event = "group.member_added",
@@ -356,10 +390,79 @@ impl SubjectGroupService {
             ));
         }
 
+        // Self-defense (D3a follow-up): a group can never drop to 0
+        // transitive users once seeded. Without this, an admin could
+        // empty a group that's the Owner of a shared drive, leaving the
+        // drive with no effective Owner (orphan-owned). Per Ed's
+        // conservative-by-default stance: enforce the invariant
+        // globally — not just for drive-owning groups — so anything
+        // else that grants groups semantic power (delegated permissions,
+        // mention targets, ...) is automatically protected.
+        //
+        // Pre-check is conservative: it computes the transitive user
+        // set BEFORE the remove and refuses when the removal would
+        // collapse it to 0. The edge case "user reachable via a nested
+        // group" is handled by `list_transitive_users` itself — if the
+        // user is still reachable via another path after this remove,
+        // they stay in the set on the post-state, so the check would
+        // pass on the next remove instead.
+        let users_before = self
+            .repo
+            .list_transitive_users(group_id)
+            .await
+            .map_err(map_repo_err)?;
+        if !users_before.is_empty() {
+            let would_be_empty = match member {
+                GroupMember::User(uid) => users_before.len() == 1 && users_before.contains(&uid),
+                GroupMember::Group(child_id) => {
+                    // For child-group removal: would this drop the
+                    // parent's transitive user set to 0? Look up the
+                    // child's transitive users — if every user in the
+                    // parent's set comes through the child, removing the
+                    // child empties the parent.
+                    let child_users = self
+                        .repo
+                        .list_transitive_users(child_id)
+                        .await
+                        .map_err(map_repo_err)?;
+                    !child_users.is_empty() && users_before.iter().all(|u| child_users.contains(u))
+                }
+            };
+            if would_be_empty {
+                tracing::info!(
+                    target: "audit",
+                    event = "group.member_removed_rejected",
+                    reason = "would_empty_seeded_group",
+                    group_id = %group_id,
+                    member = ?member,
+                    by = %caller_id,
+                    "👮🏻‍♂️ refused last-user removal from group {group_id} \
+                     (groups must never drop to 0 transitive users once seeded — \
+                     a drive-owning group going empty would orphan the drive)",
+                );
+                return Err(DomainError::new(
+                    ErrorKind::InvalidInput,
+                    "SubjectGroup",
+                    "A group cannot have less than 1 user once seeded. \
+                     Add another user before removing this one."
+                        .to_string(),
+                ));
+            }
+        }
+
         self.repo
             .remove_member(group_id, member)
             .await
             .map_err(map_repo_err)?;
+
+        // Symmetric to add_member: drop the cache for users whose
+        // expanded subject set just lost the parent group as an
+        // ancestor. Without this, a removed-from-group user keeps
+        // appearing as a transitive member in `expand_subject_for_listing`
+        // for up to 30 s, surfacing grants they no longer have.
+        for uid in self.invalidation_targets(member).await? {
+            self.engine.invalidate_user_groups_cache(uid).await;
+        }
 
         tracing::info!(
             target: "audit",

--- a/src/application/services/trash_service.rs
+++ b/src/application/services/trash_service.rs
@@ -19,6 +19,7 @@ use crate::application::ports::trash_ports::TrashUseCase;
 use crate::common::errors::{DomainError, ErrorKind, Result};
 use crate::domain::entities::file::File;
 use crate::domain::entities::trashed_item::{TrashedItem, TrashedItemType};
+use crate::domain::repositories::drive_repository::DriveRepository;
 use crate::domain::repositories::folder_repository::FolderRepository;
 use crate::domain::repositories::trash_repository::TrashRepository;
 use crate::domain::services::authorization::ResourceKind;
@@ -70,6 +71,11 @@ pub struct TrashService {
     /// Authz engine
     authz: Arc<PgAclEngine>,
 
+    /// Drive repository — D2b uses it to resolve "drives the caller can read"
+    /// so trash listings filter by drive membership instead of the legacy
+    /// per-user scope.
+    drive_repo: Arc<crate::infrastructure::repositories::pg::DrivePgRepository>,
+
     /// Number of days items should be kept in trash before automatic cleanup
     retention_days: u32,
 }
@@ -85,6 +91,7 @@ impl TrashService {
         dedup_service: Arc<DedupService>,
         content_cache: Option<Arc<FileContentCache>>,
         authz: Arc<PgAclEngine>,
+        drive_repo: Arc<crate::infrastructure::repositories::pg::DrivePgRepository>,
     ) -> Self {
         Self {
             trash_repository,
@@ -95,6 +102,7 @@ impl TrashService {
             file_deleted_hook: None,
             content_cache,
             authz,
+            drive_repo,
             retention_days,
         }
     }
@@ -366,10 +374,7 @@ impl TrashUseCase for TrashService {
 
         // Get the trash item
         info!("Retrieving trash item from repository: ID={}", trash_id);
-        let item_result = self
-            .trash_repository
-            .get_trash_item(&trash_uuid, &user_uuid)
-            .await;
+        let item_result = self.trash_repository.get_trash_item(&trash_uuid).await;
 
         match item_result {
             Ok(Some(item)) => {
@@ -379,6 +384,21 @@ impl TrashUseCase for TrashService {
                     item.item_type(),
                     item.original_id()
                 );
+
+                // D2b stage 3: gate the restore on Delete permission against
+                // the item's original resource. The drive precheck in
+                // `pg_acl_engine` resolves Owner-on-drive → Delete-permission,
+                // so a drive Owner can restore items they didn't originally
+                // trash (per `drive.md §12`). 404-on-deny via `authz.require`
+                // matches the lookup-NotFound shape.
+                let original = item.original_id();
+                let resource = match item.item_type() {
+                    TrashedItemType::File => Resource::File(original),
+                    TrashedItemType::Folder => Resource::Folder(original),
+                };
+                self.authz
+                    .require(Subject::User(user_id), Permission::Delete, resource)
+                    .await?;
 
                 // Restore based on type
                 match item.item_type() {
@@ -540,10 +560,7 @@ impl TrashUseCase for TrashService {
 
         // Get the trash item
         info!("Retrieving trash item from repository: ID={}", trash_id);
-        let item_result = self
-            .trash_repository
-            .get_trash_item(&trash_uuid, &user_uuid)
-            .await;
+        let item_result = self.trash_repository.get_trash_item(&trash_uuid).await;
 
         match item_result {
             Ok(Some(item)) => {
@@ -553,6 +570,19 @@ impl TrashUseCase for TrashService {
                     item.item_type(),
                     item.original_id()
                 );
+
+                // D2b stage 3: gate the permanent-delete on Delete permission
+                // against the item's original resource (mirrors `restore_item`
+                // above). Drive Owners can hard-delete shared-drive items
+                // they didn't trash.
+                let original = item.original_id();
+                let resource = match item.item_type() {
+                    TrashedItemType::File => Resource::File(original),
+                    TrashedItemType::Folder => Resource::Folder(original),
+                };
+                self.authz
+                    .require(Subject::User(user_id), Permission::Delete, resource)
+                    .await?;
 
                 // Permanently delete based on type
                 match item.item_type() {
@@ -688,6 +718,41 @@ impl TrashUseCase for TrashService {
     async fn empty_trash(&self, user_id: Uuid) -> Result<()> {
         info!("Emptying trash for user {}", user_id);
 
+        // D2b stage 3: resolve the set of drives the caller can permanently
+        // delete content in. "Empty trash" means "drop every trashed item
+        // I have Delete on" — Owner role's bundle includes Delete; Editor /
+        // Viewer / Contributor / Commenter do not. So this filter picks out
+        // the drives where the caller is effectively Owner (direct or via a
+        // group). Single-drive users: this resolves to just their personal
+        // drive, identical to the legacy `WHERE user_id = $1` scope.
+        let (subject_types, subject_ids) = self
+            .authz
+            .expand_subject_for_listing(Subject::User(user_id))
+            .await?;
+        let drives = self
+            .drive_repo
+            .list_for_subjects(&subject_types, &subject_ids)
+            .await
+            .map_err(|e| {
+                DomainError::internal_error(
+                    "Trash",
+                    format!("Failed to resolve accessible drives: {e:?}"),
+                )
+            })?;
+        let drive_ids: Vec<Uuid> = drives
+            .iter()
+            .filter(|d| {
+                d.caller_role
+                    .is_some_and(|r| r.expand().contains(&Permission::Delete))
+            })
+            .map(|d| d.drive.id)
+            .collect();
+
+        if drive_ids.is_empty() {
+            info!("empty_trash: caller has Delete on no drive — nothing to do");
+            return Ok(());
+        }
+
         // Collect ALL trashed file IDs BEFORE bulk-deleting so hooks (thumbnail
         // cleanup, etc.) can run afterward.  We use get_all_trashed_file_ids (not
         // get_trash_items) because the trash_items view excludes files inside a
@@ -696,7 +761,7 @@ impl TrashUseCase for TrashService {
         let trashed_file_ids: Vec<String> = if self.file_deleted_hook.is_some() {
             match self
                 .trash_repository
-                .get_all_trashed_file_ids(&user_id)
+                .get_all_trashed_file_ids(&drive_ids)
                 .await
             {
                 Ok(ids) => ids,
@@ -709,16 +774,14 @@ impl TrashUseCase for TrashService {
             Vec::new()
         };
 
-        // clear_trash() performs bulk SQL DELETEs in 2 queries:
-        //   1. DELETE FROM storage.files  WHERE user_id = $1 AND is_trashed = TRUE
-        //   2. DELETE FROM storage.folders WHERE user_id = $1 AND is_trashed = TRUE
+        // clear_trash() performs bulk SQL DELETEs in 2 queries (post D2b stage 3):
+        //   1. DELETE FROM storage.files  WHERE drive_id = ANY($1) AND is_trashed = TRUE
+        //   2. DELETE FROM storage.folders WHERE drive_id = ANY($1) AND is_trashed = TRUE
         //
         // Folder deletion cascades (FK ON DELETE CASCADE) to child folders and
         // their files. The PG trigger `trg_files_decrement_blob_ref` automatically
         // decrements blob ref_counts for every deleted file row.
-        //
-        // Finally it clears the trash_items index for the user.
-        self.trash_repository.clear_trash(&user_id).await?;
+        self.trash_repository.clear_trash(&drive_ids).await?;
 
         // The PG trigger decremented ref_counts but cannot delete disk files or
         // thumbnails.  Run garbage_collect() to remove any blobs whose ref_count
@@ -766,11 +829,32 @@ impl TrashService {
         kinds: Option<&[ResourceKind]>,
         reverse: bool,
     ) -> Result<(Vec<TrashResourceItemDto>, Option<String>)> {
+        // D2b: scope by drives the caller can read (resolved through
+        // role_grants on resource_type='drive', including group-mediated
+        // grants). Empty set → empty page without a SQL round-trip.
+        let (subject_types, subject_ids) = self
+            .authz
+            .expand_subject_for_listing(Subject::User(user_id))
+            .await?;
+        let drive_ids: Vec<Uuid> = match self
+            .drive_repo
+            .list_for_subjects(&subject_types, &subject_ids)
+            .await
+        {
+            Ok(drives) => drives.into_iter().map(|d| d.drive.id).collect(),
+            Err(e) => {
+                return Err(DomainError::internal_error(
+                    "Trash",
+                    format!("Failed to resolve accessible drives: {e:?}"),
+                ));
+            }
+        };
+
         // Fetch one extra row to detect whether a next page exists.
         let mut rows = self
             .trash_repository
             .list_resources_paged(
-                user_id,
+                &drive_ids,
                 limit + 1,
                 cursor.as_ref(),
                 order_by,
@@ -823,10 +907,10 @@ fn row_to_item_dto(row: TrashResourceRow) -> TrashResourceItemDto {
             path,
             parent_id: row.parent_id.map(|u| u.to_string()),
             owner_id: Some(row.owner_id.to_string()),
-            // Trash listing — drive_id is informational and the trash
-            // row doesn't currently SELECT it. Path-based lookups
-            // never enter this code path.
-            drive_id: uuid::Uuid::nil(),
+            // D2b: the trash listing query now SELECTs `drive_id` (the
+            // unified view exposes it). Surfaced so per-drive grouping
+            // in the `/trash` UI doesn't need an extra lookup per row.
+            drive_id: row.drive_id,
             created_at: row.resource_created_at.timestamp() as u64,
             modified_at: row.modified_at.timestamp() as u64,
             is_root: false,
@@ -841,6 +925,7 @@ fn row_to_item_dto(row: TrashResourceRow) -> TrashResourceItemDto {
             resource_type: ResourceTypeDto::Folder,
             trashed_at: row.trashed_at,
             deletion_date: row.deletion_date,
+            drive_id: row.drive_id,
             resource: ResourceContentDto::Folder(dto),
         }
     } else {
@@ -884,6 +969,7 @@ fn row_to_item_dto(row: TrashResourceRow) -> TrashResourceItemDto {
             resource_type: ResourceTypeDto::File,
             trashed_at: row.trashed_at,
             deletion_date: row.deletion_date,
+            drive_id: row.drive_id,
             resource: ResourceContentDto::File(dto),
         }
     }

--- a/src/application/services/trash_service_test.rs
+++ b/src/application/services/trash_service_test.rs
@@ -203,10 +203,7 @@ where
         let trash_uuid = Uuid::parse_str(trash_id)
             .map_err(|e| DomainError::validation_error(format!("Invalid trash ID: {}", e)))?;
 
-        let item = self
-            .trash_repository
-            .get_trash_item(&trash_uuid, &user_id)
-            .await?;
+        let item = self.trash_repository.get_trash_item(&trash_uuid).await?;
         match item {
             Some(item) => {
                 match item.item_type() {
@@ -265,10 +262,7 @@ where
         let trash_uuid = Uuid::parse_str(trash_id)
             .map_err(|e| DomainError::validation_error(format!("Invalid trash ID: {}", e)))?;
 
-        let item = self
-            .trash_repository
-            .get_trash_item(&trash_uuid, &user_id)
-            .await?;
+        let item = self.trash_repository.get_trash_item(&trash_uuid).await?;
         match item {
             Some(item) => {
                 match item.item_type() {
@@ -319,7 +313,11 @@ where
     }
 
     async fn empty_trash(&self, user_id: Uuid) -> Result<()> {
-        self.trash_repository.clear_trash(&user_id).await
+        // Test mock — treats `user_id` as a stand-in for the single accessible
+        // drive (the mock storage is single-user / single-drive). The
+        // production `TrashService::empty_trash` resolves the real drive set
+        // via `drive_repo.list_for_subjects` + role-bundle filter.
+        self.trash_repository.clear_trash(&[user_id]).await
     }
 }
 
@@ -364,13 +362,11 @@ impl TrashRepository for MockTrashRepository {
         Ok(user_items)
     }
 
-    async fn get_trash_item(&self, id: &Uuid, user_id: &Uuid) -> Result<Option<TrashedItem>> {
+    async fn get_trash_item(&self, id: &Uuid) -> Result<Option<TrashedItem>> {
+        // Mock mirrors the production repo's no-filter lookup — the
+        // user-scoped check has moved into the service's `authz.require`.
         let items = self.trash_items.lock().unwrap();
-        let item = items
-            .get(id)
-            .filter(|item| item.user_id() == *user_id)
-            .cloned();
-        Ok(item)
+        Ok(items.get(id).cloned())
     }
 
     async fn restore_from_trash(&self, id: &Uuid, user_id: &Uuid) -> Result<()> {
@@ -393,16 +389,19 @@ impl TrashRepository for MockTrashRepository {
         Ok(())
     }
 
-    async fn clear_trash(&self, user_id: &Uuid) -> Result<()> {
+    async fn clear_trash(&self, drive_ids: &[Uuid]) -> Result<()> {
+        // Test mock: the single-user/single-drive mock uses `user_id` as
+        // the drive proxy (see `empty_trash` in the service mock). Filter
+        // trash items whose owner is in the passed-in set.
         let mut items = self.trash_items.lock().unwrap();
-        items.retain(|_, item| item.user_id() != *user_id);
+        items.retain(|_, item| !drive_ids.contains(&item.user_id()));
         // Simulate PG CASCADE: clear trashed file/folder storage too
         self.trashed_files.lock().unwrap().clear();
         self.trashed_folders.lock().unwrap().clear();
         Ok(())
     }
 
-    async fn get_all_trashed_file_ids(&self, _user_id: &Uuid) -> Result<Vec<String>> {
+    async fn get_all_trashed_file_ids(&self, _drive_ids: &[Uuid]) -> Result<Vec<String>> {
         let files = self.trashed_files.lock().unwrap();
         Ok(files.keys().cloned().collect())
     }

--- a/src/common/di.rs
+++ b/src/common/di.rs
@@ -768,6 +768,7 @@ impl AppServiceFactory {
         repos: &RepositoryServices,
         core: &CoreServices,
         authz: &Arc<PgAclEngine>,
+        drive_repo: &Arc<crate::infrastructure::repositories::pg::DrivePgRepository>,
     ) -> Option<Arc<TrashService>> {
         if !self.config.features.enable_trash {
             tracing::info!("Trash service is disabled in configuration");
@@ -787,6 +788,7 @@ impl AppServiceFactory {
                 core.dedup_service.clone(),
                 Some(core.file_content_cache.clone()),
                 authz.clone(),
+                drive_repo.clone(),
             )
             .with_file_deleted_hook(core.file_lifecycle.clone()),
         );
@@ -1137,7 +1139,7 @@ impl AppServiceFactory {
 
         // 3b. Trash service (needed before application services)
         let trash_service = self
-            .create_trash_service(&repos, &core, &authorization)
+            .create_trash_service(&repos, &core, &authorization, &drive_repo)
             .await;
 
         // 3c. Storage usage / quota service (needed by the instant-upload

--- a/src/common/di.rs
+++ b/src/common/di.rs
@@ -1467,8 +1467,14 @@ impl AppServiceFactory {
             path_resolver: None,
             webdav_lock_store:
                 crate::infrastructure::services::webdav_lock_service::create_webdav_lock_store(),
-            authorization,
+            authorization: authorization.clone(),
             drive_repo: drive_repo.clone(),
+            drive_management_service: Arc::new(
+                crate::application::services::drive_management_service::DriveManagementService::new(
+                    drive_repo.clone(),
+                    authorization.clone(),
+                ),
+            ),
             subject_group_service: Some(Arc::new(
                 crate::application::services::subject_group_service::SubjectGroupService::new(
                     subject_group_repo.clone(),
@@ -1935,6 +1941,13 @@ pub struct AppState {
     /// resolved through `role_grants` not a separate `drive_members`
     /// table (see `docs/plan/drive.md` §3).
     pub drive_repo: Arc<crate::infrastructure::repositories::pg::DrivePgRepository>,
+    /// D2 — drive membership management service. Translates the membership
+    /// API (`POST/PATCH/DELETE /api/drives/{id}/members`) into role-grant
+    /// writes on `resource_type='drive'`, with the personal-drive guard
+    /// and shared-drive last-owner protection layered in.
+    pub drive_management_service: Arc<
+        crate::application::services::drive_management_service::DriveManagementService,
+    >,
     /// ReBAC subject-group management (CRUD + membership). `None` when the
     /// auth subsystem is not configured.
     pub subject_group_service:

--- a/src/common/di.rs
+++ b/src/common/di.rs
@@ -1475,6 +1475,7 @@ impl AppServiceFactory {
                 crate::application::services::drive_management_service::DriveManagementService::new(
                     drive_repo.clone(),
                     authorization.clone(),
+                    subject_group_repo.clone(),
                 ),
             ),
             subject_group_service: Some(Arc::new(
@@ -1486,6 +1487,7 @@ impl AppServiceFactory {
                             pool.clone(),
                         ),
                     ),
+                    authorization.clone(),
                 ),
             )),
             email_sender: None,                   // populated below

--- a/src/domain/repositories/drive_repository.rs
+++ b/src/domain/repositories/drive_repository.rs
@@ -176,6 +176,21 @@ pub trait DriveRepository: Send + Sync + 'static {
         subject_types: &[&str],
         subject_ids: &[Uuid],
     ) -> Result<Vec<DriveWithRootName>, DriveRepositoryError>;
+
+    /// List every drive on the system, regardless of caller membership.
+    ///
+    /// Used by the admin panel's `GET /api/admin/drives`. Distinct from
+    /// `list_for_subjects` (which filters by `role_grants`) because an
+    /// admin who creates a shared drive for someone else has no grant
+    /// on it — but still needs to see, audit, and manage it. The HTTP
+    /// gate (admin-only middleware) is what makes the unrestricted
+    /// listing safe; no role-based filtering happens here.
+    ///
+    /// Returns rows ordered by display name. `caller_role` is left
+    /// unset on the returned `DriveWithRootName` — the admin is not
+    /// necessarily a member, so the per-drive role would be misleading
+    /// here.
+    async fn list_all(&self) -> Result<Vec<DriveWithRootName>, DriveRepositoryError>;
 }
 
 /// Convenience: convert the canonical kind discriminator from its SQL

--- a/src/domain/repositories/drive_repository.rs
+++ b/src/domain/repositories/drive_repository.rs
@@ -78,6 +78,16 @@ pub trait DriveRepository: Send + Sync + 'static {
     /// when no row matches.
     async fn get_by_id(&self, id: Uuid) -> Result<DriveWithRootName, DriveRepositoryError>;
 
+    /// Batch fetch — returns one row per existing id. Missing ids are
+    /// silently dropped (matches the `get_files_by_ids` / `get_folders_by_ids`
+    /// shape used by `list_shared_with_me`). Caller-side `HashMap<Uuid, _>`
+    /// lookup gives `Option<Drive>` semantics for stale grants whose drive
+    /// was deleted between listing and resolution.
+    async fn get_by_ids(
+        &self,
+        ids: &[Uuid],
+    ) -> Result<Vec<DriveWithRootName>, DriveRepositoryError>;
+
     /// Return the caller's default personal drive paired with its
     /// display name, or `NotFound` if they don't have one (e.g.
     /// external users; users created before the lifecycle hook fired).

--- a/src/domain/repositories/drive_repository.rs
+++ b/src/domain/repositories/drive_repository.rs
@@ -51,6 +51,17 @@ pub struct DriveWithRootName {
     /// The drive's display name. Sourced from `storage.folders.name`
     /// of the root folder via JOIN at read time.
     pub root_folder_name: String,
+    /// Highest role the calling user holds on this drive (direct OR
+    /// group-mediated). Populated by `list_for_subjects` (which already
+    /// JOINs `role_grants` for accessibility, so the role is in scope at
+    /// query time). `None` for repo methods called without a caller
+    /// context (`get_by_id`, `get_by_ids`, `find_default_for_user`,
+    /// `create_personal_drive_atomic`) — the DTO layer omits the field
+    /// via `#[serde(skip_serializing_if = "Option::is_none")]`.
+    ///
+    /// See [[project-caller-role-on-file-folder-dto]] for the pattern
+    /// extension to FileDto/FolderDto with a perf warning.
+    pub caller_role: Option<crate::domain::services::authorization::Role>,
 }
 
 #[async_trait::async_trait]

--- a/src/domain/repositories/drive_repository.rs
+++ b/src/domain/repositories/drive_repository.rs
@@ -85,6 +85,36 @@ pub trait DriveRepository: Send + Sync + 'static {
         quota_bytes: Option<i64>,
     ) -> Result<DriveWithRootName, DriveRepositoryError>;
 
+    /// Atomically create a **shared** drive together with its root folder
+    /// and the initial Owner-role grant. Mirrors
+    /// `create_personal_drive_atomic` but with three differences:
+    ///   - `kind='shared'`, `default_for_user=NULL`
+    ///   - root folder name is caller-supplied (validated upstream)
+    ///   - Owner role_grant subject is caller-supplied — either a
+    ///     single `User` (becomes the sole drive Owner) or a `Group`
+    ///     (the group's transitive user members all gain the Owner
+    ///     role via subject expansion). Token subjects are refused at
+    ///     the service edge.
+    ///
+    /// `granted_by` is recorded on the role_grant row + on the root
+    /// folder's `created_by` / `updated_by` columns for audit
+    /// traceability — the OxiCloud admin who provisioned the drive.
+    ///
+    /// **AuthZ contract**: this method performs no authorization. The
+    /// service layer MUST verify the caller has the OxiCloud `admin`
+    /// system role (D3a). If `owner_subject` is `Group`, the service
+    /// MUST also have verified the group has ≥1 user member —
+    /// otherwise the drive is created with no effective Owner-user
+    /// and would breach the "drive must always have ≥1 effective
+    /// Owner" invariant from day one.
+    async fn create_shared_drive_atomic(
+        &self,
+        name: &str,
+        owner_subject: crate::domain::services::authorization::Subject,
+        quota_bytes: Option<i64>,
+        granted_by: Uuid,
+    ) -> Result<DriveWithRootName, DriveRepositoryError>;
+
     /// Fetch a drive by id together with its display name. `NotFound`
     /// when no row matches.
     async fn get_by_id(&self, id: Uuid) -> Result<DriveWithRootName, DriveRepositoryError>;

--- a/src/domain/repositories/trash_repository.rs
+++ b/src/domain/repositories/trash_repository.rs
@@ -6,15 +6,37 @@ use crate::domain::entities::trashed_item::TrashedItem;
 pub trait TrashRepository: Send + Sync {
     async fn add_to_trash(&self, item: &TrashedItem) -> Result<()>;
     async fn get_trash_items(&self, user_id: &Uuid) -> Result<Vec<TrashedItem>>;
-    async fn get_trash_item(&self, id: &Uuid, user_id: &Uuid) -> Result<Option<TrashedItem>>;
+    /// Fetch a trashed item by its trash-row id.
+    ///
+    /// **Caller contract**: this method does NO authorization check. Callers
+    /// MUST follow with
+    /// `authz.require(Permission::Delete, Resource::File|Folder(item.original_id()))`
+    /// before acting on the result. The trash service's `restore_item` and
+    /// `delete_permanently` are the canonical examples.
+    ///
+    /// **Implementor contract**: do NOT re-introduce a `user_id` (or
+    /// `drive_id`) scope filter at the SQL layer. Authorization is the
+    /// service's job, not the repository's — adding a scope here would
+    /// silently break drive-Owner-restores-another-user's-trashed-item
+    /// (the canonical D2 use case). A direct-by-id lookup is the
+    /// intended shape.
+    async fn get_trash_item(&self, id: &Uuid) -> Result<Option<TrashedItem>>;
     async fn restore_from_trash(&self, id: &Uuid, user_id: &Uuid) -> Result<()>;
     async fn delete_permanently(&self, id: &Uuid, user_id: &Uuid) -> Result<()>;
-    async fn clear_trash(&self, user_id: &Uuid) -> Result<()>;
+    /// Bulk-delete all trashed files and folders in the given drives.
+    ///
+    /// **Caller contract**: pass only drive UUIDs the caller has
+    /// `Permission::Delete` on (resolved by the service via
+    /// `DriveRepository::list_for_subjects` + role-bundle filter). This
+    /// repository performs no authorization — see
+    /// `TrashService::empty_trash` for the canonical call site.
+    async fn clear_trash(&self, drive_ids: &[Uuid]) -> Result<()>;
 
-    /// All trashed file IDs for this user, regardless of parent folder trash status.
-    /// Used by empty_trash for thumbnail cleanup — the view used by get_trash_items
-    /// excludes files inside trashed folders, which would miss their ext thumbnails.
-    async fn get_all_trashed_file_ids(&self, user_id: &Uuid) -> Result<Vec<String>>;
+    /// All trashed file IDs across the given drives, regardless of parent
+    /// folder trash status. Used by `empty_trash` for thumbnail cleanup —
+    /// the trash_items view excludes files inside trashed folders, which
+    /// would miss their thumbnails. Same caller contract as `clear_trash`.
+    async fn get_all_trashed_file_ids(&self, drive_ids: &[Uuid]) -> Result<Vec<String>>;
 
     /// Bulk-delete all expired trash items (files + folders) in a single
     /// transaction.  Returns `(files_deleted, folders_deleted)`.

--- a/src/infrastructure/repositories/pg/drive_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/drive_pg_repository.rs
@@ -431,4 +431,28 @@ impl DriveRepository for DrivePgRepository {
             .map(Self::row_to_drive_with_name_and_role)
             .collect()
     }
+
+    async fn list_all(&self) -> Result<Vec<DriveWithRootName>, DriveRepositoryError> {
+        // No subject filter: every drive on the system. The HTTP layer
+        // (admin guard on `/api/admin/drives`) is the access control —
+        // adding a role filter here would defeat the point of the
+        // endpoint (an admin without explicit membership wouldn't see
+        // the drives they created for other users).
+        let rows = sqlx::query(
+            r#"
+            SELECT d.id, d.kind, d.default_for_user, d.root_folder_id,
+                   d.quota_bytes, d.used_bytes, d.policies,
+                   d.created_at, d.updated_at,
+                   f.name AS root_folder_name
+              FROM storage.drives d
+              JOIN storage.folders f ON f.id = d.root_folder_id
+             ORDER BY LOWER(f.name) ASC
+            "#,
+        )
+        .fetch_all(self.pool.as_ref())
+        .await
+        .map_err(|e| Self::map_sqlx_err("list_all", e))?;
+
+        rows.iter().map(Self::row_to_drive_with_name).collect()
+    }
 }

--- a/src/infrastructure/repositories/pg/drive_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/drive_pg_repository.rs
@@ -197,6 +197,32 @@ impl DriveRepository for DrivePgRepository {
         Self::row_to_drive_with_name(&row)
     }
 
+    async fn get_by_ids(
+        &self,
+        ids: &[Uuid],
+    ) -> Result<Vec<DriveWithRootName>, DriveRepositoryError> {
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let rows = sqlx::query(
+            r#"
+            SELECT d.id, d.kind, d.default_for_user, d.root_folder_id,
+                   d.quota_bytes, d.used_bytes, d.policies,
+                   d.created_at, d.updated_at,
+                   f.name AS root_folder_name
+              FROM storage.drives d
+              JOIN storage.folders f ON f.id = d.root_folder_id
+             WHERE d.id = ANY($1)
+            "#,
+        )
+        .bind(ids)
+        .fetch_all(self.pool.as_ref())
+        .await
+        .map_err(|e| Self::map_sqlx_err("get_by_ids", e))?;
+
+        rows.iter().map(Self::row_to_drive_with_name).collect()
+    }
+
     async fn find_default_for_user(
         &self,
         user_id: Uuid,

--- a/src/infrastructure/repositories/pg/drive_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/drive_pg_repository.rs
@@ -44,6 +44,9 @@ impl DrivePgRepository {
 
     /// Map a row carrying both the drive's columns AND a `root_folder_name`
     /// column (sourced via JOIN with `storage.folders`) into the view-model.
+    /// `caller_role` is left `None` — only the listing path (which
+    /// JOINs `role_grants` for accessibility) has it in scope; see
+    /// `row_to_drive_with_name_and_role`.
     fn row_to_drive_with_name(
         row: &sqlx::postgres::PgRow,
     ) -> Result<DriveWithRootName, DriveRepositoryError> {
@@ -63,7 +66,24 @@ impl DrivePgRepository {
         Ok(DriveWithRootName {
             drive,
             root_folder_name: row.get("root_folder_name"),
+            caller_role: None,
         })
+    }
+
+    /// Same as `row_to_drive_with_name` but reads `caller_role` from the
+    /// listing query — `MIN(g.role)::text`. The `storage.grant_role` ENUM
+    /// is declared owner→viewer (strongest→weakest), so `MIN` picks the
+    /// strongest of the caller's grants on the drive (direct +
+    /// group-mediated collapsed by GROUP BY). Used only by
+    /// `list_for_subjects`.
+    fn row_to_drive_with_name_and_role(
+        row: &sqlx::postgres::PgRow,
+    ) -> Result<DriveWithRootName, DriveRepositoryError> {
+        use crate::domain::services::authorization::Role;
+        let mut dwr = Self::row_to_drive_with_name(row)?;
+        let role_str: Option<String> = row.try_get("caller_role").ok();
+        dwr.caller_role = role_str.as_deref().and_then(Role::parse);
+        Ok(dwr)
     }
 }
 
@@ -260,12 +280,20 @@ impl DriveRepository for DrivePgRepository {
         // group-mediated) and sidesteps PostgreSQL's "ORDER BY
         // expression must appear in select list" rule that SELECT
         // DISTINCT imposes.
+        // `MIN(g.role)` picks the caller's strongest role on each drive:
+        // `storage.grant_role` is declared `owner → viewer` (strongest →
+        // weakest), so MIN returns the strongest. Cast `::text` matches
+        // the codebase convention for reading enum columns into Rust
+        // (see `pg_acl_engine.rs`); `Role::parse` handles the trip back.
+        // Collapses direct + group-mediated grants on the same drive
+        // into one row alongside the existing GROUP BY.
         let rows = sqlx::query(
             r#"
             SELECT d.id, d.kind, d.default_for_user, d.root_folder_id,
                    d.quota_bytes, d.used_bytes, d.policies,
                    d.created_at, d.updated_at,
-                   f.name AS root_folder_name
+                   f.name AS root_folder_name,
+                   MIN(g.role)::text AS caller_role
               FROM storage.drives d
               JOIN storage.folders f ON f.id = d.root_folder_id
               JOIN storage.role_grants g
@@ -292,6 +320,8 @@ impl DriveRepository for DrivePgRepository {
         .await
         .map_err(|e| Self::map_sqlx_err("list_for_subjects", e))?;
 
-        rows.iter().map(Self::row_to_drive_with_name).collect()
+        rows.iter()
+            .map(Self::row_to_drive_with_name_and_role)
+            .collect()
     }
 }

--- a/src/infrastructure/repositories/pg/drive_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/drive_pg_repository.rs
@@ -196,6 +196,113 @@ impl DriveRepository for DrivePgRepository {
         Self::row_to_drive_with_name(&row)
     }
 
+    async fn create_shared_drive_atomic(
+        &self,
+        name: &str,
+        owner_subject: crate::domain::services::authorization::Subject,
+        quota_bytes: Option<i64>,
+        granted_by: Uuid,
+    ) -> Result<DriveWithRootName, DriveRepositoryError> {
+        // Same four-write transaction shape as `create_personal_drive_atomic`
+        // (see that method for the why-not-CTE explanation). Differences:
+        //   - `kind='shared'`, `default_for_user=NULL`.
+        //   - Root folder name is caller-supplied.
+        //   - Owner grant subject is caller-supplied — either a single
+        //     User (becomes the sole drive Owner) or a Group (transitive
+        //     members inherit Owner via subject expansion).
+        //   - `granted_by` is the OxiCloud admin who provisioned the drive;
+        //     same value goes onto the folder's `created_by`/`updated_by`
+        //     for §14 provenance.
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| Self::map_sqlx_err("create_shared_drive_atomic.begin", e))?;
+
+        // 1. Drive row (root_folder_id NULL — populated in step 3).
+        let drive_id: Uuid = sqlx::query_scalar(
+            r#"
+            INSERT INTO storage.drives
+                (kind, default_for_user, quota_bytes, policies)
+            VALUES ('shared', NULL, $1, '{}'::jsonb)
+            RETURNING id
+            "#,
+        )
+        .bind(quota_bytes)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| Self::map_sqlx_err("create_shared_drive_atomic.drive", e))?;
+
+        // 2. Root folder. The folder's `user_id` carries the admin (legacy
+        //    column still NOT NULL during the dual-write window — D7
+        //    drops it once `drive_id` is the canonical ownership signal).
+        let folder_id: Uuid = sqlx::query_scalar(
+            r#"
+            INSERT INTO storage.folders
+                (name, parent_id, user_id, drive_id, created_by, updated_by)
+            VALUES ($1, NULL, $2, $3, $2, $2)
+            RETURNING id
+            "#,
+        )
+        .bind(name)
+        .bind(granted_by)
+        .bind(drive_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| Self::map_sqlx_err("create_shared_drive_atomic.folder", e))?;
+
+        // 3. Close the circular reference (drive ↔ root folder).
+        sqlx::query(r#"UPDATE storage.drives SET root_folder_id = $1 WHERE id = $2"#)
+            .bind(folder_id)
+            .bind(drive_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| Self::map_sqlx_err("create_shared_drive_atomic.wire", e))?;
+
+        // 4. Owner role_grant — subject_type chosen from the caller's input.
+        //    Group subjects expand transitively via `subject_match_set` so
+        //    every member inherits Owner; User subjects are the single
+        //    admin case.
+        sqlx::query(
+            r#"
+            INSERT INTO storage.role_grants
+                (subject_type, subject_id, resource_type, resource_id,
+                 role, granted_by)
+            VALUES ($1, $2, 'drive', $3, 'owner', $4)
+            "#,
+        )
+        .bind(owner_subject.type_str())
+        .bind(owner_subject.id())
+        .bind(drive_id)
+        .bind(granted_by)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| Self::map_sqlx_err("create_shared_drive_atomic.grant", e))?;
+
+        // Fetch final state so the caller sees DB-computed defaults.
+        let row = sqlx::query(
+            r#"
+            SELECT d.id, d.kind, d.default_for_user, d.root_folder_id,
+                   d.quota_bytes, d.used_bytes, d.policies,
+                   d.created_at, d.updated_at,
+                   f.name AS root_folder_name
+              FROM storage.drives d
+              JOIN storage.folders f ON f.id = d.root_folder_id
+             WHERE d.id = $1
+            "#,
+        )
+        .bind(drive_id)
+        .fetch_one(&mut *tx)
+        .await
+        .map_err(|e| Self::map_sqlx_err("create_shared_drive_atomic.read", e))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| Self::map_sqlx_err("create_shared_drive_atomic.commit", e))?;
+
+        Self::row_to_drive_with_name(&row)
+    }
+
     async fn get_by_id(&self, id: Uuid) -> Result<DriveWithRootName, DriveRepositoryError> {
         let row = sqlx::query(
             r#"

--- a/src/infrastructure/repositories/pg/file_blob_read_repository.rs
+++ b/src/infrastructure/repositories/pg/file_blob_read_repository.rs
@@ -330,6 +330,20 @@ impl FileBlobReadRepository {
             .ok_or_else(|| DomainError::not_found("File", file_id))
     }
 
+    /// Returns `drive_id` for a given file. Drives the permission-floor
+    /// short-circuit in `PgAclEngine::check_inner` — drive membership is
+    /// the baseline floor per `drive.md §5`.
+    pub async fn get_file_drive_id(&self, file_id: &str) -> Result<uuid::Uuid, DomainError> {
+        sqlx::query_scalar::<_, uuid::Uuid>(
+            "SELECT drive_id FROM storage.files WHERE id = $1::uuid",
+        )
+        .bind(file_id)
+        .fetch_optional(self.pool.as_ref())
+        .await
+        .map_err(|e| DomainError::internal_error("FileBlobRead", format!("drive_id lookup: {e}")))?
+        .ok_or_else(|| DomainError::not_found("File", file_id))
+    }
+
     /// Creates a stub instance for testing — never hits PG.
     #[cfg(test)]
     pub fn new_stub() -> Self {

--- a/src/infrastructure/repositories/pg/file_blob_read_repository.rs
+++ b/src/infrastructure/repositories/pg/file_blob_read_repository.rs
@@ -345,7 +345,11 @@ impl FileBlobReadRepository {
     }
 
     /// Creates a stub instance for testing — never hits PG.
-    #[cfg(test)]
+    /// Available in both standard unit-test (`cfg(test)`) and integration
+    /// (`cfg(integration_tests)`) builds; `PgAclEngine::new_stub` chains
+    /// into this stub and is needed from the integration-test module of
+    /// `subject_group_service`.
+    #[cfg(any(test, integration_tests))]
     pub fn new_stub() -> Self {
         use crate::infrastructure::services::dedup_service::DedupService;
         Self {

--- a/src/infrastructure/repositories/pg/folder_db_repository.rs
+++ b/src/infrastructure/repositories/pg/folder_db_repository.rs
@@ -1335,6 +1335,19 @@ impl FolderDbRepository {
             .ok_or_else(|| DomainError::not_found("Folder", folder_id))
     }
 
+    /// Returns `drive_id` for a given folder. Drives the new permission-floor
+    /// short-circuit in `PgAclEngine::check_inner` (a caller with any role
+    /// on the folder's drive automatically passes the check — drive
+    /// membership is the baseline floor per `drive.md §5`).
+    pub async fn get_folder_drive_id(&self, folder_id: &str) -> Result<Uuid, DomainError> {
+        sqlx::query_scalar::<_, Uuid>("SELECT drive_id FROM storage.folders WHERE id = $1::uuid")
+            .bind(folder_id)
+            .fetch_optional(self.pool())
+            .await
+            .map_err(|e| DomainError::internal_error("FolderDb", format!("drive_id lookup: {e}")))?
+            .ok_or_else(|| DomainError::not_found("Folder", folder_id))
+    }
+
     /// Verifies that `folder_id` is owned by `owner_id`.
     ///
     /// Returns `DomainError::not_found(...)` for both "folder missing" and

--- a/src/infrastructure/repositories/pg/trash_db_repository.rs
+++ b/src/infrastructure/repositories/pg/trash_db_repository.rs
@@ -147,18 +147,22 @@ impl TrashRepository for TrashDbRepository {
             .collect())
     }
 
-    async fn get_trash_item(&self, id: &Uuid, user_id: &Uuid) -> Result<Option<TrashedItem>> {
+    async fn get_trash_item(&self, id: &Uuid) -> Result<Option<TrashedItem>> {
+        // D2b stage 3: lookup by id only — the `user_id` filter that used to
+        // gate this query is replaced by an explicit `authz.require(Delete,
+        // …)` in the service callers (`restore_item`, `delete_permanently`).
+        // The drive precheck in `pg_acl_engine` then resolves Owner-on-drive
+        // → Delete-permission for items in shared drives.
         let row = sqlx::query_as::<_, (Uuid, String, String, Uuid, Option<DateTime<Utc>>, String)>(
             r#"
             SELECT t.id, t.name, t.item_type, t.user_id, t.trashed_at,
                    COALESCE(p.path || '/' || t.name, t.name) AS original_path
               FROM storage.trash_items t
               LEFT JOIN storage.folders p ON p.id = t.original_parent_id
-             WHERE t.id = $1 AND t.user_id = $2
+             WHERE t.id = $1
             "#,
         )
         .bind(id)
-        .bind(user_id)
         .fetch_optional(self.pool.as_ref())
         .await
         .map_err(|e| DomainError::internal_error("TrashDb", format!("get: {e}")))?;
@@ -182,17 +186,22 @@ impl TrashRepository for TrashDbRepository {
         Ok(())
     }
 
-    async fn clear_trash(&self, user_id: &Uuid) -> Result<()> {
-        // Delete all trashed files for this user
-        sqlx::query("DELETE FROM storage.files WHERE user_id = $1 AND is_trashed = TRUE")
-            .bind(user_id)
+    async fn clear_trash(&self, drive_ids: &[Uuid]) -> Result<()> {
+        if drive_ids.is_empty() {
+            return Ok(());
+        }
+        // Delete all trashed files in the given drives.
+        sqlx::query("DELETE FROM storage.files WHERE drive_id = ANY($1) AND is_trashed = TRUE")
+            .bind(drive_ids)
             .execute(self.pool.as_ref())
             .await
             .map_err(|e| DomainError::internal_error("TrashDb", format!("clear files: {e}")))?;
 
-        // Delete all trashed folders for this user
-        sqlx::query("DELETE FROM storage.folders WHERE user_id = $1 AND is_trashed = TRUE")
-            .bind(user_id)
+        // Delete all trashed folders in the given drives. FK ON DELETE CASCADE
+        // sweeps descendant rows; the `trg_files_decrement_blob_ref` trigger
+        // handles blob refcount drops automatically.
+        sqlx::query("DELETE FROM storage.folders WHERE drive_id = ANY($1) AND is_trashed = TRUE")
+            .bind(drive_ids)
             .execute(self.pool.as_ref())
             .await
             .map_err(|e| DomainError::internal_error("TrashDb", format!("clear folders: {e}")))?;
@@ -200,11 +209,14 @@ impl TrashRepository for TrashDbRepository {
         Ok(())
     }
 
-    async fn get_all_trashed_file_ids(&self, user_id: &Uuid) -> Result<Vec<String>> {
+    async fn get_all_trashed_file_ids(&self, drive_ids: &[Uuid]) -> Result<Vec<String>> {
+        if drive_ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let rows = sqlx::query_scalar::<_, String>(
-            "SELECT id::text FROM storage.files WHERE user_id = $1 AND is_trashed = TRUE",
+            "SELECT id::text FROM storage.files WHERE drive_id = ANY($1) AND is_trashed = TRUE",
         )
-        .bind(user_id)
+        .bind(drive_ids)
         .fetch_all(self.pool.as_ref())
         .await
         .map_err(|e| DomainError::internal_error("TrashDb", format!("all_trashed_files: {e}")))?;
@@ -253,23 +265,34 @@ impl TrashRepository for TrashDbRepository {
 // Cursor-paginated trash listing  (used by GET /api/trash/resources)
 // ════════════════════════════════════════════════════════════════════════════
 impl TrashDbRepository {
-    /// Cursor-paginated list of the user's trashed resources.
+    /// Cursor-paginated list of trashed resources the caller can read.
+    ///
+    /// D2b: scope is drive-membership-based — pass the set of drive UUIDs
+    /// the caller can read (resolved upstream by `DriveRepository::list_for_subjects`
+    /// or equivalent). Items in drives outside this set drop out at the
+    /// WHERE clause. The legacy `WHERE user_id = $1::uuid` filter is gone;
+    /// for single-drive users this returns exactly the same items as before
+    /// because the caller's own personal drive is always in `drive_ids`.
     ///
     /// Mirrors the favorites/grants pattern: a UNION-ALL CTE over folder and
     /// file branches (each pre-computing sort columns), then a per-dimension
     /// keyset WHERE + ORDER BY.
     ///
     /// Returns rows in caller-requested sort order. The caller is expected to
-    /// fetch `limit + 1` to detect end-of-results.
+    /// fetch `limit + 1` to detect end-of-results. Empty `drive_ids` returns
+    /// an empty page without hitting PG.
     pub async fn list_resources_paged(
         &self,
-        user_id: Uuid,
+        drive_ids: &[Uuid],
         limit: usize,
         cursor: Option<&TrashCursor>,
         order_by: &str,
         kinds: Option<&[ResourceKind]>,
         reverse: bool,
     ) -> Result<Vec<TrashResourceRow>> {
+        if drive_ids.is_empty() {
+            return Ok(Vec::new());
+        }
         let include_folders =
             kinds.is_none_or(|k| k.iter().any(|r| matches!(r, ResourceKind::Folder)));
         let include_files = kinds.is_none_or(|k| k.iter().any(|r| matches!(r, ResourceKind::File)));
@@ -291,6 +314,7 @@ impl TrashDbRepository {
         fld.created_at                                       AS resource_created_at,
         fld.updated_at                                       AS modified_at,
         fld.user_id                                          AS owner_id,
+        fld.drive_id                                         AS drive_id,
         NULL::text                                           AS blob_hash,
         fld.trashed_at                                       AS trashed_at,
         (fld.trashed_at + ($7::int * INTERVAL '1 day'))      AS deletion_date,
@@ -299,7 +323,7 @@ impl TrashDbRepository {
         0::bigint                                            AS type_order,
         0::int                                               AS folder_first
     FROM storage.folders fld
-    WHERE fld.user_id = $1::uuid
+    WHERE fld.drive_id = ANY($1)
       AND fld.is_trashed = TRUE
       AND (fld.parent_id IS NULL
            OR NOT EXISTS (
@@ -317,6 +341,7 @@ impl TrashDbRepository {
         f.created_at                                         AS resource_created_at,
         f.updated_at                                         AS modified_at,
         f.user_id                                            AS owner_id,
+        f.drive_id                                           AS drive_id,
         f.blob_hash,
         f.trashed_at                                         AS trashed_at,
         (f.trashed_at + ($7::int * INTERVAL '1 day'))        AS deletion_date,
@@ -327,7 +352,7 @@ impl TrashDbRepository {
     FROM storage.files f
     LEFT JOIN storage.folders pfld
            ON pfld.id = f.folder_id
-    WHERE f.user_id = $1::uuid
+    WHERE f.drive_id = ANY($1)
       AND f.is_trashed = TRUE
       AND (f.folder_id IS NULL
            OR NOT EXISTS (
@@ -447,7 +472,7 @@ impl TrashDbRepository {
 SELECT
     r.resource_type, r.resource_id, r.name, r.parent_id,
     r.mime_type, r.size, r.resource_created_at, r.modified_at,
-    r.owner_id, r.trashed_at, r.deletion_date, r.resource_path,
+    r.owner_id, r.drive_id, r.trashed_at, r.deletion_date, r.resource_path,
     r.sort_str, r.type_order, r.folder_first
 FROM resources r
 {keyset}
@@ -456,7 +481,7 @@ LIMIT $6"
         );
 
         let rows = sqlx::query(&sql)
-            .bind(user_id) // $1
+            .bind(drive_ids) // $1 (was user_id pre-D2b)
             .bind(cur_str) // $2
             .bind(cur_int) // $3
             .bind(cur_ts) // $4
@@ -505,6 +530,7 @@ LIMIT $6"
                     resource_created_at: row.get("resource_created_at"),
                     modified_at: row.get("modified_at"),
                     owner_id: row.get("owner_id"),
+                    drive_id: row.get("drive_id"),
                     blob_hash: row.try_get("blob_hash").ok(),
                     trashed_at,
                     deletion_date,

--- a/src/infrastructure/services/dedup_service.rs
+++ b/src/infrastructure/services/dedup_service.rs
@@ -291,7 +291,13 @@ impl DedupService {
     }
 
     /// Creates a stub instance for testing — never hits PG or the filesystem.
-    #[cfg(any(test, feature = "integration_tests"))]
+    ///
+    /// Gated for both build modes integration tests are reachable from:
+    /// the raw `cfg(integration_tests)` flag used by CI / justfile
+    /// (`RUSTFLAGS='--cfg integration_tests'`) and the
+    /// `feature = "integration_tests"` form for callers that flip the
+    /// cargo feature instead. Standard `cfg(test)` keeps unit-test use.
+    #[cfg(any(test, integration_tests, feature = "integration_tests"))]
     pub fn new_stub() -> Self {
         use crate::infrastructure::services::local_blob_backend::LocalBlobBackend;
         let stub_pool = Arc::new(

--- a/src/infrastructure/services/pg_acl_engine.rs
+++ b/src/infrastructure/services/pg_acl_engine.rs
@@ -81,6 +81,16 @@ const OWNER_CACHE_CAPACITY: u64 = 100_000;
 /// (see `owner_cache` field doc), hence a generous TTL for a high hit rate.
 const OWNER_CACHE_TTL: Duration = Duration::from_secs(300);
 
+/// `drive_role_cache` bound: entries are `((Subject, Uuid), Option<Role>)` —
+/// a few tens of bytes each. 100k accommodates ~5–10 drives per active user
+/// with comfortable headroom.
+const DRIVE_ROLE_CACHE_CAPACITY: u64 = 100_000;
+/// `drive_role_cache` TTL. Membership mutations on a drive explicitly invalidate
+/// affected entries (see `invalidate_drive_role_cache_for_drive`), so the TTL
+/// is mainly a safety net for paths that skip explicit invalidation. Short
+/// enough that any oversight self-heals in <1 minute.
+const DRIVE_ROLE_CACHE_TTL: Duration = Duration::from_secs(30);
+
 pub struct PgAclEngine {
     pool: Arc<PgPool>,
     folder_repo: Arc<FolderDbRepository>,
@@ -98,7 +108,30 @@ pub struct PgAclEngine {
     /// access (a different caller's `owner == uid` test fails against the cached
     /// *real* owner), and a hard-deleted resource that briefly short-circuits as
     /// owned simply fails later at execution with NotFound.
+    ///
+    /// Post-D0 this caches `resource → drive_id` instead (the legacy `owner_*`
+    /// rename was avoided to minimise field-name churn in the dual-write
+    /// window). The drive precheck queries this for every File / Folder check.
     owner_cache: Cache<Resource, Uuid>,
+
+    /// Memoise `(subject, drive_id) → Option<Role>`, the strongest role the
+    /// subject holds on a drive (direct + group-mediated, collapsed). Drives
+    /// the permission-floor precheck in `check_inner` — on a cache hit the
+    /// entire drive-grant lookup resolves in-memory, returning the steady
+    /// state to "0 SQL queries per authz check for callers touching their
+    /// own drive content" (matching the legacy owner short-circuit).
+    ///
+    /// **Invalidation**: explicit on every membership mutation
+    /// (`set_role` / `clear_role` with `Resource::Drive`) — drops every
+    /// entry whose drive_id matches. Group-membership changes are caught by
+    /// the short TTL rather than a deep invalidation tree.
+    ///
+    /// **Safety**: cache only widens authorization between mutations; the
+    /// 30 s TTL bounds how long a revoked grant can still appear effective
+    /// for a non-explicit invalidation path. Explicit paths (D2's
+    /// `DriveManagementService`, the grant handler's revoke path) hit the
+    /// invalidator inline.
+    drive_role_cache: Cache<(Subject, Uuid), Option<Role>>,
 }
 
 impl PgAclEngine {
@@ -120,6 +153,10 @@ impl PgAclEngine {
             owner_cache: Cache::builder()
                 .max_capacity(OWNER_CACHE_CAPACITY)
                 .time_to_live(OWNER_CACHE_TTL)
+                .build(),
+            drive_role_cache: Cache::builder()
+                .max_capacity(DRIVE_ROLE_CACHE_CAPACITY)
+                .time_to_live(DRIVE_ROLE_CACHE_TTL)
                 .build(),
         }
     }
@@ -176,6 +213,10 @@ impl PgAclEngine {
                 .max_capacity(1)
                 .time_to_live(Duration::from_secs(1))
                 .build(),
+            drive_role_cache: Cache::builder()
+                .max_capacity(1)
+                .time_to_live(Duration::from_secs(1))
+                .build(),
         }
     }
 
@@ -188,6 +229,23 @@ impl PgAclEngine {
     /// window. Cheap — moka's `invalidate` is a single concurrent-map op.
     pub async fn invalidate_user_groups_cache(&self, user_id: Uuid) {
         self.user_groups_cache.invalidate(&user_id).await;
+    }
+
+    /// Drop every `drive_role_cache` entry whose key targets `drive_id`.
+    /// Called after every membership mutation on the drive (set_role /
+    /// clear_role / revoke when the resource is a Drive) so the next authz
+    /// check sees the fresh role rather than a TTL-bounded stale view.
+    ///
+    /// Uses moka's predicate-based eviction — entries are marked for
+    /// removal asynchronously by the maintenance task; subsequent `get`
+    /// calls observe the eviction immediately.
+    pub async fn invalidate_drive_role_cache_for_drive(&self, drive_id: Uuid) {
+        // `invalidate_entries_if` rejects predicates returning errors —
+        // simple Fn(K, V) -> bool. We capture `drive_id` by value (Copy)
+        // and match against the second tuple component.
+        let _ = self
+            .drive_role_cache
+            .invalidate_entries_if(move |key, _v| key.1 == drive_id);
     }
 
     /// Expand a user subject into the set of subject UUIDs that should match
@@ -296,34 +354,39 @@ impl PgAclEngine {
         self.subject_match_set(subject, &counters).await
     }
 
-    /// Owner lookup with memoisation. Hits the DB only on a cache miss; the
-    /// result is cached because a resource's owner never changes. `NotFound`
-    /// (a hard-deleted / nonexistent resource) is propagated, not cached.
-    async fn owner_of_cached(
+    /// Drive lookup with memoisation. Hits the DB only on a cache miss; the
+    /// result is cached because a resource's `drive_id` is immutable in the
+    /// current model (cross-drive moves arrive in D6 and will need cache
+    /// invalidation at that point). `NotFound` is propagated, not cached.
+    ///
+    /// **Why this replaces the legacy `owner_of_cached`**: the old short-
+    /// circuit was `caller_id == resource.user_id`. Post-D0 ownership is
+    /// modelled through `role_grants` on the resource's drive — a caller
+    /// with any qualifying role on the drive automatically satisfies the
+    /// check (per `drive.md §5`, drive role is the baseline floor for
+    /// every resource in the drive). The lookup shape is identical
+    /// (Resource → Uuid), so we keep the same cache infrastructure.
+    async fn drive_of_cached(
         &self,
         resource: Resource,
         counters: &QueryCounters,
     ) -> Result<Uuid, DomainError> {
-        if let Some(owner) = self.owner_cache.get(&resource).await {
-            return Ok(owner);
+        if let Some(drive_id) = self.owner_cache.get(&resource).await {
+            return Ok(drive_id);
         }
         counters.sql_queries.fetch_add(1, Ordering::Relaxed);
-        let owner = self.owner_of(resource).await?;
-        self.owner_cache.insert(resource, owner).await;
-        Ok(owner)
+        let drive_id = self.drive_of(resource).await?;
+        self.owner_cache.insert(resource, drive_id).await;
+        Ok(drive_id)
     }
 
-    /// Returns the owner UUID for any resource type.
-    async fn owner_of(&self, resource: Resource) -> Result<Uuid, DomainError> {
+    /// Returns the `drive_id` for a File / Folder. Drives don't have a parent
+    /// drive — this returns `NotFound` for `Resource::Drive` and the caller
+    /// must not invoke it on Drive resources.
+    async fn drive_of(&self, resource: Resource) -> Result<Uuid, DomainError> {
         match resource {
-            Resource::Folder(id) => self.folder_repo.get_folder_user_id(&id.to_string()).await,
-            Resource::File(id) => self.file_repo.get_file_user_id(&id.to_string()).await,
-            // Drive owner resolution wires up in D0-6 once `DriveRepository`
-            // lands (D0-5). Drive entity carries `default_for_user` for
-            // `kind='personal'`; shared drives resolve through role_grants
-            // (Owner role). Returning NotFound here means a permission
-            // check that reached owner_of on a Drive falls through to the
-            // grant-lookup path — safe default during D0-1.
+            Resource::Folder(id) => self.folder_repo.get_folder_drive_id(&id.to_string()).await,
+            Resource::File(id) => self.file_repo.get_file_drive_id(&id.to_string()).await,
             Resource::Drive(_) => Err(DomainError::not_found("Drive", resource.id().to_string())),
         }
     }
@@ -450,41 +513,51 @@ impl PgAclEngine {
         Ok(exists.is_some())
     }
 
-    /// Direct grant lookup for a drive — no ltree cascade (drives have
-    /// no ancestors). Mirrors the cascade helpers above but with a
-    /// straight `resource_type='drive' AND resource_id=$4` filter.
-    async fn drive_grant_exists(
+    /// Cached resolution of `(subject, drive_id) → Option<Role>` — the
+    /// strongest role the subject holds on the drive (direct + transitive
+    /// group grants collapsed). `None` means no qualifying grant; cached
+    /// negatively to avoid re-querying on repeated denials within the TTL.
+    ///
+    /// This is the cache-aware backbone of the permission-floor precheck.
+    /// `Role::expand()` translates the returned role into its permission
+    /// bundle; callers ask `role.expand().contains(&permission)` to decide.
+    async fn caller_role_on_drive_cached(
         &self,
-        subject_types: &[&str],
-        subject_ids: &[Uuid],
-        permission: Permission,
+        subject: Subject,
         drive_id: Uuid,
         counters: &QueryCounters,
-    ) -> Result<bool, DomainError> {
+    ) -> Result<Option<Role>, DomainError> {
+        if let Some(cached) = self.drive_role_cache.get(&(subject, drive_id)).await {
+            return Ok(cached);
+        }
+        // Expand subject for the role lookup. `subject_match_set` is itself
+        // cached (30 s TTL); the steady state on `drive_role_cache` miss is
+        // one in-memory expansion + one indexed SQL query.
+        let (subject_types, subject_ids) = self.subject_match_set(subject, counters).await?;
         counters.sql_queries.fetch_add(1, Ordering::Relaxed);
-        let roles = Self::roles_implying_strings(permission);
-        let exists: Option<i32> = sqlx::query_scalar(
+        let role_str: Option<String> = sqlx::query_scalar(
             r#"
-            SELECT 1
+            SELECT MIN(g.role)::text
               FROM storage.role_grants g
              WHERE g.subject_type  = ANY($1)
                AND g.subject_id    = ANY($2)
-               AND g.role          = ANY($3::storage.grant_role[])
                AND g.resource_type = 'drive'
-               AND g.resource_id   = $4
+               AND g.resource_id   = $3
                AND (g.expires_at IS NULL OR g.expires_at > NOW())
-             LIMIT 1
             "#,
         )
         .bind(subject_types)
         .bind(subject_ids)
-        .bind(&roles)
         .bind(drive_id)
-        .fetch_optional(self.pool.as_ref())
+        .fetch_one(self.pool.as_ref())
         .await
-        .map_err(|e| DomainError::internal_error("PgAcl", format!("drive grant: {e}")))?;
+        .map_err(|e| DomainError::internal_error("PgAcl", format!("drive role lookup: {e}")))?;
 
-        Ok(exists.is_some())
+        let role = role_str.as_deref().and_then(Role::parse);
+        self.drive_role_cache
+            .insert((subject, drive_id), role)
+            .await;
+        Ok(role)
     }
 
     /// Look up a single role grant by id, returning the actors a revoke /
@@ -584,34 +657,42 @@ impl PgAclEngine {
         resource: Resource,
         counters: &QueryCounters,
     ) -> Result<bool, DomainError> {
-        // Owner short-circuit (only for User subjects — groups/tokens/external
-        // are never owners of resources).
-        // Owner short-circuit applies to Folder/File only — they carry a
-        // single-owner `user_id` column in their respective tables. Drives
-        // model ownership through the `Owner` role in `role_grants`, so
-        // there's no analogous fast path: the grant lookup below resolves
-        // a drive owner via the same query that resolves any drive role.
-        if let (Subject::User(uid), Resource::Folder(_) | Resource::File(_)) = (subject, resource) {
-            match self.owner_of_cached(resource, counters).await {
-                Ok(owner) if owner == uid => return Ok(true),
-                Ok(_) => { /* not owner — fall through to grants */ }
+        // Drive-membership precheck for File/Folder. A role on the resource's
+        // drive is the baseline floor (`drive.md §5`): the caller passes any
+        // permission check the role bundle covers. Replaces the legacy
+        // `caller_id == resource.user_id` owner short-circuit — for a user's
+        // own personal drive the lifecycle hook seeds an Owner row, so the
+        // common case (touching your own files) is **0 SQL queries** after
+        // the first hit on `drive_role_cache` (cached `(subject, drive) →
+        // Role`, 30 s TTL with explicit invalidation on membership writes).
+        if matches!(resource, Resource::Folder(_) | Resource::File(_)) {
+            let drive_id = match self.drive_of_cached(resource, counters).await {
+                Ok(d) => d,
                 Err(e) if e.kind == crate::common::errors::ErrorKind::NotFound => {
-                    // Resource doesn't exist — no permission. Return false
-                    // rather than propagating NotFound; the caller (`require`)
-                    // converts a false back to NotFound on its own.
+                    // Resource doesn't exist — no permission. `require`
+                    // converts the `false` back to NotFound at its layer.
                     return Ok(false);
                 }
                 Err(e) => return Err(e),
+            };
+            if let Some(role) = self
+                .caller_role_on_drive_cached(subject, drive_id, counters)
+                .await?
+                && role.expand().contains(&permission)
+            {
+                return Ok(true);
             }
+            // Drive precheck didn't match — fall through to per-resource
+            // grant + folder-ancestor cascade (existing behaviour, untouched).
         }
 
-        // Expand the subject so group-mediated grants apply when the caller
-        // is a User. See `subject_match_set` for the shared shape used by
-        // both the cascade check and the "shared with me" listing queries.
-        let (subject_types, subject_ids) = self.subject_match_set(subject, counters).await?;
-
         match resource {
+            // File/Folder dispatch falls through to the cascade query —
+            // expand the subject set lazily here (it's cached) so the
+            // Drive branch below never pays for an expansion it doesn't need.
             Resource::Folder(id) => {
+                let (subject_types, subject_ids) =
+                    self.subject_match_set(subject, counters).await?;
                 self.folder_cascade_grant_exists(
                     &subject_types,
                     &subject_ids,
@@ -622,6 +703,8 @@ impl PgAclEngine {
                 .await
             }
             Resource::File(id) => {
+                let (subject_types, subject_ids) =
+                    self.subject_match_set(subject, counters).await?;
                 self.file_cascade_grant_exists(
                     &subject_types,
                     &subject_ids,
@@ -632,8 +715,13 @@ impl PgAclEngine {
                 .await
             }
             Resource::Drive(id) => {
-                self.drive_grant_exists(&subject_types, &subject_ids, permission, id, counters)
-                    .await
+                // Same cache-aware path the precheck uses — keeps the
+                // single-source-of-truth for drive role resolution and
+                // benefits identically from `drive_role_cache`.
+                Ok(self
+                    .caller_role_on_drive_cached(subject, id, counters)
+                    .await?
+                    .is_some_and(|r| r.expand().contains(&permission)))
             }
         }
     }
@@ -1873,6 +1961,13 @@ impl AuthorizationEngine for PgAclEngine {
         .await
         .map_err(|e| DomainError::internal_error("PgAcl", format!("set_role: {e}")))?;
 
+        // Membership write on a drive — drop every cached
+        // `(subject, drive_id)` entry pointing at this drive so the next
+        // authz check resolves against the fresh role.
+        if let Resource::Drive(drive_id) = resource {
+            self.invalidate_drive_role_cache_for_drive(drive_id).await;
+        }
+
         Self::row_to_grant(row)
     }
 
@@ -1889,6 +1984,13 @@ impl AuthorizationEngine for PgAclEngine {
         .execute(self.pool.as_ref())
         .await
         .map_err(|e| DomainError::internal_error("PgAcl", format!("clear_role: {e}")))?;
+
+        // Symmetric with `set_role` — drop cached drive-role entries on
+        // membership revocation so a viewer who just got removed doesn't
+        // keep passing the precheck for up to 30 s.
+        if let Resource::Drive(drive_id) = resource {
+            self.invalidate_drive_role_cache_for_drive(drive_id).await;
+        }
 
         Ok(())
     }

--- a/src/infrastructure/services/pg_acl_engine.rs
+++ b/src/infrastructure/services/pg_acl_engine.rs
@@ -201,7 +201,13 @@ impl PgAclEngine {
     /// without a real PostgreSQL pool. Connecting to the lazy pool will
     /// fail at runtime — only safe in tests that exercise types, not actual
     /// authz queries.
-    #[cfg(test)]
+    ///
+    /// Visible under both `cfg(test)` (the standard unit-test build) and
+    /// `cfg(integration_tests)` (the gated-by-RUSTFLAGS integration
+    /// build). The `SubjectGroupService` integration tests construct the
+    /// service with a stub engine, since they only exercise the engine's
+    /// in-memory cache invalidation calls — never its SQL paths.
+    #[cfg(any(test, integration_tests))]
     pub fn new_stub() -> Self {
         let pool = sqlx::pool::PoolOptions::<sqlx::Postgres>::new()
             .max_connections(1)

--- a/src/infrastructure/services/pg_acl_engine.rs
+++ b/src/infrastructure/services/pg_acl_engine.rs
@@ -155,6 +155,13 @@ impl PgAclEngine {
                 .time_to_live(OWNER_CACHE_TTL)
                 .build(),
             drive_role_cache: Cache::builder()
+                // `invalidate_entries_if` is the cleanup hook used by
+                // `invalidate_drive_role_cache_for_drive`. moka returns
+                // `Err(InvalidationClosuresDisabled)` from that call unless
+                // this opt-in is set on the builder, so without it the
+                // bulk invalidation silently no-ops and a freshly-promoted
+                // member keeps their stale role for the full TTL.
+                .support_invalidation_closures()
                 .max_capacity(DRIVE_ROLE_CACHE_CAPACITY)
                 .time_to_live(DRIVE_ROLE_CACHE_TTL)
                 .build(),
@@ -214,6 +221,7 @@ impl PgAclEngine {
                 .time_to_live(Duration::from_secs(1))
                 .build(),
             drive_role_cache: Cache::builder()
+                .support_invalidation_closures()
                 .max_capacity(1)
                 .time_to_live(Duration::from_secs(1))
                 .build(),
@@ -238,14 +246,35 @@ impl PgAclEngine {
     ///
     /// Uses moka's predicate-based eviction — entries are marked for
     /// removal asynchronously by the maintenance task; subsequent `get`
-    /// calls observe the eviction immediately.
+    /// calls observe the eviction. Requires
+    /// `support_invalidation_closures()` on the cache builder (see the
+    /// `drive_role_cache` initialiser above), otherwise moka returns
+    /// `InvalidationClosuresDisabled` and the mutation silently leaves
+    /// stale role rows in cache for the full TTL.
     pub async fn invalidate_drive_role_cache_for_drive(&self, drive_id: Uuid) {
         // `invalidate_entries_if` rejects predicates returning errors —
         // simple Fn(K, V) -> bool. We capture `drive_id` by value (Copy)
         // and match against the second tuple component.
-        let _ = self
+        //
+        // The result is `Err` only when the cache was built without
+        // `support_invalidation_closures()` — a wiring bug, not a runtime
+        // condition the caller can recover from. We log+continue rather
+        // than panic because the consequence is a 30 s staleness window
+        // on cached role entries, not a correctness bug at write time.
+        if let Err(err) = self
             .drive_role_cache
-            .invalidate_entries_if(move |key, _v| key.1 == drive_id);
+            .invalidate_entries_if(move |key, _v| key.1 == drive_id)
+        {
+            tracing::error!(
+                target: "oxicloud::authz",
+                event = "authz.cache_invalidation_failed",
+                cache = "drive_role_cache",
+                drive_id = %drive_id,
+                error = %err,
+                "drive_role_cache cannot be bulk-invalidated — \
+                 cache builder is missing support_invalidation_closures()",
+            );
+        }
     }
 
     /// Expand a user subject into the set of subject UUIDs that should match

--- a/src/interfaces/api/handlers/admin_handler.rs
+++ b/src/interfaces/api/handlers/admin_handler.rs
@@ -19,8 +19,13 @@ use crate::application::dtos::settings_dto::{
     SmtpTestResultDto, StartMigrationDto, TestOidcConnectionDto, TestStorageConnectionDto,
     UpdateUserActiveDto, UpdateUserQuotaDto, UpdateUserRoleDto, VerifyMigrationDto,
 };
+use crate::application::dtos::drive_dto::DriveDto;
+use crate::application::dtos::grant_dto::{GrantDto, RoleDto, SubjectDto, SubjectTypeDto};
+use crate::application::ports::authorization_ports::AuthorizationEngine;
 use crate::application::ports::plugin_ports::{LogQuery, PluginManagementPort, PluginMgmtError};
 use crate::common::di::AppState;
+use crate::domain::repositories::drive_repository::DriveRepository;
+use crate::domain::services::authorization::{Resource, Subject};
 use crate::interfaces::errors::AppError;
 use crate::interfaces::middleware::admin::require_admin;
 use std::sync::Arc;
@@ -90,6 +95,17 @@ pub fn admin_routes() -> Router<Arc<AppState>> {
         // when `OXICLOUD_SMTP_MOCK` is off, so production deployments
         // can route the path freely without leaking inboxes.
         .route("/smtp/test/captured", get(get_captured_email))
+        // Drives — admin-wide view (distinct from `/api/drives` which
+        // is filtered to the caller's role grants).
+        .route("/drives", get(list_all_drives))
+        .route(
+            "/drives/{id}/members",
+            get(list_drive_members_admin).post(add_drive_member_admin),
+        )
+        .route(
+            "/drives/{id}/members/{kind}/{sid}",
+            axum::routing::patch(update_drive_member_admin).delete(remove_drive_member_admin),
+        )
 }
 
 /// Validate JWT and require admin role. Returns (user_id, role).
@@ -1705,4 +1721,239 @@ pub async fn set_plugin_retention(
     );
 
     Ok((StatusCode::OK, Json(dto)))
+}
+
+/// GET /api/admin/drives — list every drive on the system, admin-only.
+///
+/// Distinct from `GET /api/drives`, which is the caller's own listing
+/// filtered through `role_grants`. An admin who creates a shared drive
+/// for someone else has no grant on it — but the admin panel still
+/// needs to see the drive (to audit, to manage, to delete). The admin
+/// guard at the handler edge is the access control; no role filtering
+/// happens in the repo (see `drive_repository::list_all`).
+///
+/// Returns rows ordered by display name. `caller_role` is omitted —
+/// the admin is not necessarily a drive member, so the field would be
+/// misleading here.
+#[utoipa::path(
+    get,
+    path = "/api/admin/drives",
+    responses(
+        (status = 200, description = "Every drive on the system", body = Vec<DriveDto>),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Admin required"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "admin"
+)]
+pub async fn list_all_drives(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse, AppError> {
+    admin_guard(&state, &headers).await?;
+    let drives = state
+        .drive_repo
+        .list_all()
+        .await
+        .map_err(|e| AppError::internal_error(format!("Failed to list drives: {e}")))?;
+    let dtos: Vec<DriveDto> = drives.into_iter().map(DriveDto::from).collect();
+    Ok((StatusCode::OK, Json(dtos)))
+}
+
+/// GET /api/admin/drives/{id}/members — list every role grant on a drive,
+/// admin-only.
+///
+/// Distinct from `GET /api/drives/{id}/members` which goes through
+/// `DriveManagementService::list_members` and requires `Permission::Read`
+/// on the drive. The admin who created the drive for someone else has
+/// no role on it, so the user-facing endpoint would 404 for them.
+///
+/// This endpoint reuses the engine's `list_grants_on_resource` directly
+/// — same query, same shape, just gated by the admin middleware instead
+/// of by `authz.require`. Returns the same `Vec<GrantDto>` so the
+/// frontend renders it through the existing grant types.
+#[utoipa::path(
+    get,
+    path = "/api/admin/drives/{id}/members",
+    params(("id" = Uuid, Path, description = "Drive UUID")),
+    responses(
+        (status = 200, description = "Role grants on the drive", body = Vec<GrantDto>),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Admin required"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "admin"
+)]
+pub async fn list_drive_members_admin(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::extract::Path(drive_id): axum::extract::Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    admin_guard(&state, &headers).await?;
+    let grants = state
+        .authorization
+        .list_grants_on_resource(Resource::Drive(drive_id))
+        .await
+        .map_err(AppError::from)?;
+    let dtos: Vec<GrantDto> = grants.into_iter().map(GrantDto::from).collect();
+    Ok((StatusCode::OK, Json(dtos)))
+}
+
+/// Body for `POST /api/admin/drives/{id}/members` and
+/// `PATCH /api/admin/drives/{id}/members/{kind}/{sid}` — same wire shape
+/// as the user-facing endpoints, kept here so this handler doesn't pull
+/// in the regular drive-handler module's DTOs (which would create a
+/// circular feel between admin and user-facing surfaces).
+#[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
+pub struct AdminAddDriveMemberDto {
+    pub subject: SubjectDto,
+    pub role: RoleDto,
+    #[serde(default)]
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
+pub struct AdminUpdateDriveMemberDto {
+    pub role: RoleDto,
+    #[serde(default)]
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+fn admin_parse_subject(kind: SubjectTypeDto, id: Uuid) -> Subject {
+    match kind {
+        SubjectTypeDto::User => Subject::User(id),
+        SubjectTypeDto::Group => Subject::Group(id),
+        SubjectTypeDto::Token => Subject::Token(id),
+    }
+}
+
+/// POST /api/admin/drives/{id}/members — add or refresh a member's role
+/// without holding `Manage` on the drive. Admin-only; bypasses the
+/// per-drive authz check via the `caller_is_admin = true` argument on
+/// `DriveManagementService::set_member_role`. Personal-drive guard and
+/// last-owner protection still apply.
+#[utoipa::path(
+    post,
+    path = "/api/admin/drives/{id}/members",
+    params(("id" = Uuid, Path, description = "Drive UUID")),
+    request_body = AdminAddDriveMemberDto,
+    responses(
+        (status = 201, description = "Member added", body = GrantDto),
+        (status = 400, description = "Validation error (e.g. last-owner constraint)"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Admin required"),
+        (status = 405, description = "Personal drive — membership is immutable"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "admin"
+)]
+pub async fn add_drive_member_admin(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::extract::Path(drive_id): axum::extract::Path<Uuid>,
+    Json(dto): Json<AdminAddDriveMemberDto>,
+) -> Result<impl IntoResponse, AppError> {
+    let (admin_id, _) = admin_guard(&state, &headers).await?;
+    let subject = admin_parse_subject(dto.subject.kind, dto.subject.id);
+    let grant = state
+        .drive_management_service
+        .set_member_role(
+            admin_id,
+            true,
+            drive_id,
+            subject,
+            dto.role.into(),
+            dto.expires_at,
+        )
+        .await
+        .map_err(AppError::from)?;
+    Ok((StatusCode::CREATED, Json(GrantDto::from(grant))))
+}
+
+/// PATCH /api/admin/drives/{id}/members/{kind}/{sid} — change a member's
+/// role / expiry as an admin. Same admin-bypass shape as
+/// `add_drive_member_admin`.
+#[utoipa::path(
+    patch,
+    path = "/api/admin/drives/{id}/members/{kind}/{sid}",
+    params(
+        ("id" = Uuid, Path, description = "Drive UUID"),
+        ("kind" = String, Path, description = "Subject kind: user|group|token"),
+        ("sid" = Uuid, Path, description = "Subject UUID"),
+    ),
+    request_body = AdminUpdateDriveMemberDto,
+    responses(
+        (status = 200, description = "Member role updated", body = GrantDto),
+        (status = 400, description = "Validation error (e.g. last-owner demotion)"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Admin required"),
+        (status = 405, description = "Personal drive — membership is immutable"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "admin"
+)]
+pub async fn update_drive_member_admin(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::extract::Path((drive_id, kind, subject_id)): axum::extract::Path<(
+        Uuid,
+        SubjectTypeDto,
+        Uuid,
+    )>,
+    Json(dto): Json<AdminUpdateDriveMemberDto>,
+) -> Result<impl IntoResponse, AppError> {
+    let (admin_id, _) = admin_guard(&state, &headers).await?;
+    let subject = admin_parse_subject(kind, subject_id);
+    let grant = state
+        .drive_management_service
+        .set_member_role(
+            admin_id,
+            true,
+            drive_id,
+            subject,
+            dto.role.into(),
+            dto.expires_at,
+        )
+        .await
+        .map_err(AppError::from)?;
+    Ok((StatusCode::OK, Json(GrantDto::from(grant))))
+}
+
+/// DELETE /api/admin/drives/{id}/members/{kind}/{sid} — remove a
+/// member as an admin. Bypasses `Manage`; keeps last-owner protection.
+#[utoipa::path(
+    delete,
+    path = "/api/admin/drives/{id}/members/{kind}/{sid}",
+    params(
+        ("id" = Uuid, Path, description = "Drive UUID"),
+        ("kind" = String, Path, description = "Subject kind: user|group|token"),
+        ("sid" = Uuid, Path, description = "Subject UUID"),
+    ),
+    responses(
+        (status = 204, description = "Member removed (or wasn't a member — idempotent)"),
+        (status = 400, description = "Last-owner protection — promote another member first"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Admin required"),
+        (status = 405, description = "Personal drive — membership is immutable"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "admin"
+)]
+pub async fn remove_drive_member_admin(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::extract::Path((drive_id, kind, subject_id)): axum::extract::Path<(
+        Uuid,
+        SubjectTypeDto,
+        Uuid,
+    )>,
+) -> Result<impl IntoResponse, AppError> {
+    let (admin_id, _) = admin_guard(&state, &headers).await?;
+    let subject = admin_parse_subject(kind, subject_id);
+    state
+        .drive_management_service
+        .remove_member(admin_id, true, drive_id, subject)
+        .await
+        .map_err(AppError::from)?;
+    Ok(StatusCode::NO_CONTENT)
 }

--- a/src/interfaces/api/handlers/admin_handler.rs
+++ b/src/interfaces/api/handlers/admin_handler.rs
@@ -9,6 +9,8 @@ use axum::{
     routing::{delete, get, post, put},
 };
 
+use crate::application::dtos::drive_dto::DriveDto;
+use crate::application::dtos::grant_dto::{GrantDto, RoleDto, SubjectDto, SubjectTypeDto};
 use crate::application::dtos::plugin_dto::{
     PluginInfoDto, PluginLogEntryDto, PluginLogPageDto, PluginLogQueryDto, PluginRetentionDto,
     SetEnabledDto,
@@ -19,8 +21,6 @@ use crate::application::dtos::settings_dto::{
     SmtpTestResultDto, StartMigrationDto, TestOidcConnectionDto, TestStorageConnectionDto,
     UpdateUserActiveDto, UpdateUserQuotaDto, UpdateUserRoleDto, VerifyMigrationDto,
 };
-use crate::application::dtos::drive_dto::DriveDto;
-use crate::application::dtos::grant_dto::{GrantDto, RoleDto, SubjectDto, SubjectTypeDto};
 use crate::application::ports::authorization_ports::AuthorizationEngine;
 use crate::application::ports::plugin_ports::{LogQuery, PluginManagementPort, PluginMgmtError};
 use crate::common::di::AppState;

--- a/src/interfaces/api/handlers/contacts_handler.rs
+++ b/src/interfaces/api/handlers/contacts_handler.rs
@@ -127,6 +127,13 @@ pub struct AddMemberRequest {
 pub struct ListQuery {
     limit: Option<i64>,
     offset: Option<i64>,
+    /// System address book only — when `true`, includes the calling user
+    /// in the returned contacts. Default `false` matches the share-modal
+    /// "you can't share with yourself" semantics; the admin drive-owner
+    /// surface flips it on so an admin can add themselves as Owner.
+    /// Ignored for non-system books.
+    #[serde(default)]
+    include_self: bool,
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -491,9 +498,10 @@ pub async fn list_contacts(
             .await
         {
             Ok(users) => {
+                let include_self = params.include_self;
                 let contacts: Vec<ContactDto> = users
                     .into_iter()
-                    .filter(|u| u.id != caller_id)
+                    .filter(|u| include_self || u.id != caller_id)
                     .map(user_to_contact)
                     .collect();
                 (StatusCode::OK, Json(contacts)).into_response()

--- a/src/interfaces/api/handlers/drive_handler.rs
+++ b/src/interfaces/api/handlers/drive_handler.rs
@@ -269,6 +269,7 @@ pub async fn add_drive_member(
         .drive_management_service
         .set_member_role(
             auth_user.id,
+            false, // caller_is_admin — user-facing route, always require Manage
             drive_id,
             subject,
             dto.role.into(),
@@ -310,6 +311,7 @@ pub async fn update_drive_member(
         .drive_management_service
         .set_member_role(
             auth_user.id,
+            false, // caller_is_admin — user-facing route, always require Manage
             drive_id,
             subject,
             dto.role.into(),
@@ -347,7 +349,7 @@ pub async fn remove_drive_member(
     let subject = parse_subject(kind, subject_id);
     match state
         .drive_management_service
-        .remove_member(auth_user.id, drive_id, subject)
+        .remove_member(auth_user.id, false, drive_id, subject)
         .await
     {
         Ok(()) => StatusCode::NO_CONTENT.into_response(),

--- a/src/interfaces/api/handlers/drive_handler.rs
+++ b/src/interfaces/api/handlers/drive_handler.rs
@@ -1,22 +1,31 @@
-//! `GET /api/drives` — list every drive the caller can read.
+//! Drive endpoints.
 //!
-//! D0 ships the read-only listing; D2 adds shared-drive membership
-//! mutations (`POST/DELETE/PUT /api/drives/{id}/members`), D3 adds the
-//! create-shared-drive flow, etc.
+//! - `GET    /api/drives`                              — list every drive the caller can read (D0)
+//! - `GET    /api/drives/{id}/members`                 — list role grants on a drive (D2)
+//! - `POST   /api/drives/{id}/members`                 — add a member (D2)
+//! - `PATCH  /api/drives/{id}/members/{kind}/{sid}`    — change a member's role / expiry (D2)
+//! - `DELETE /api/drives/{id}/members/{kind}/{sid}`    — remove a member (D2)
 //!
-//! The handler resolves the caller's expanded subject set through the
-//! engine (so group-mediated drive grants surface — the foundation for
-//! D2/D3) and asks the `DriveRepository` for every drive that set can
-//! read. Authorization is purely the subject-expansion step: no
-//! `require(...)` call here, because "your accessible drives" is a
-//! listing query, not a permission decision on a specific drive.
+//! D3 adds the create-shared-drive flow under `POST /api/drives`. The
+//! membership endpoints are thin wrappers around `DriveManagementService`,
+//! which layers the personal-drive guard and shared-drive last-owner
+//! protection on top of the generic `role_grants` write path.
 
 use std::sync::Arc;
 
-use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+use serde::Deserialize;
 use tracing::error;
+use utoipa::ToSchema;
+use uuid::Uuid;
 
 use crate::application::dtos::drive_dto::DriveDto;
+use crate::application::dtos::grant_dto::{GrantDto, RoleDto, SubjectDto, SubjectTypeDto};
 use crate::common::di::AppState;
 use crate::domain::repositories::drive_repository::DriveRepository;
 use crate::domain::services::authorization::Subject;
@@ -39,10 +48,6 @@ pub async fn list_drives(
 ) -> impl IntoResponse {
     let caller_id = auth_user.id;
 
-    // Expand the caller's `Subject::User` into the `(types, ids)` pair
-    // that includes every group the user transitively belongs to. The
-    // engine caches this expansion in its Moka cache; if the caller
-    // just ran a permission check, this is a hit.
     let (subject_types, subject_ids) = match state
         .authorization
         .expand_subject_for_listing(Subject::User(caller_id))
@@ -68,5 +73,175 @@ pub async fn list_drives(
             error!("list_drives: repo lookup failed: {e}");
             AppError::internal_error(format!("Failed to list drives: {e}")).into_response()
         }
+    }
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Membership API (D2)
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Body for `POST /api/drives/{id}/members`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct AddDriveMemberDto {
+    pub subject: SubjectDto,
+    pub role: RoleDto,
+    #[serde(default)]
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Body for `PATCH /api/drives/{id}/members/{kind}/{sid}`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateDriveMemberDto {
+    pub role: RoleDto,
+    /// Optional. Pass `null` (or omit) to clear an existing expiry.
+    #[serde(default)]
+    pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+fn parse_subject(kind: SubjectTypeDto, id: Uuid) -> Subject {
+    match kind {
+        SubjectTypeDto::User => Subject::User(id),
+        SubjectTypeDto::Group => Subject::Group(id),
+        SubjectTypeDto::Token => Subject::Token(id),
+    }
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/drives/{id}/members",
+    params(("id" = Uuid, Path, description = "Drive UUID")),
+    responses(
+        (status = 200, description = "Role grants on this drive", body = Vec<GrantDto>),
+        (status = 404, description = "Drive not found or caller lacks Read"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "drives"
+)]
+pub async fn list_drive_members(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Path(drive_id): Path<Uuid>,
+) -> impl IntoResponse {
+    match state
+        .drive_management_service
+        .list_members(auth_user.id, drive_id)
+        .await
+    {
+        Ok(grants) => {
+            let dtos: Vec<GrantDto> = grants.into_iter().map(GrantDto::from).collect();
+            (StatusCode::OK, Json(dtos)).into_response()
+        }
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/drives/{id}/members",
+    params(("id" = Uuid, Path, description = "Drive UUID")),
+    request_body = AddDriveMemberDto,
+    responses(
+        (status = 201, description = "Member added", body = GrantDto),
+        (status = 400, description = "Validation error (e.g. last-owner constraint)"),
+        (status = 404, description = "Drive not found or caller lacks Manage"),
+        (status = 405, description = "Personal drive — membership is immutable"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "drives"
+)]
+pub async fn add_drive_member(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Path(drive_id): Path<Uuid>,
+    Json(dto): Json<AddDriveMemberDto>,
+) -> impl IntoResponse {
+    let subject = parse_subject(dto.subject.kind, dto.subject.id);
+    match state
+        .drive_management_service
+        .set_member_role(
+            auth_user.id,
+            drive_id,
+            subject,
+            dto.role.into(),
+            dto.expires_at,
+        )
+        .await
+    {
+        Ok(grant) => (StatusCode::CREATED, Json(GrantDto::from(grant))).into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+#[utoipa::path(
+    patch,
+    path = "/api/drives/{id}/members/{kind}/{sid}",
+    params(
+        ("id" = Uuid, Path, description = "Drive UUID"),
+        ("kind" = String, Path, description = "Subject kind: user|group|token"),
+        ("sid" = Uuid, Path, description = "Subject UUID"),
+    ),
+    request_body = UpdateDriveMemberDto,
+    responses(
+        (status = 200, description = "Member role updated", body = GrantDto),
+        (status = 400, description = "Validation error (e.g. last-owner demotion)"),
+        (status = 404, description = "Drive not found or caller lacks Manage"),
+        (status = 405, description = "Personal drive — membership is immutable"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "drives"
+)]
+pub async fn update_drive_member(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Path((drive_id, kind, subject_id)): Path<(Uuid, SubjectTypeDto, Uuid)>,
+    Json(dto): Json<UpdateDriveMemberDto>,
+) -> impl IntoResponse {
+    let subject = parse_subject(kind, subject_id);
+    match state
+        .drive_management_service
+        .set_member_role(
+            auth_user.id,
+            drive_id,
+            subject,
+            dto.role.into(),
+            dto.expires_at,
+        )
+        .await
+    {
+        Ok(grant) => (StatusCode::OK, Json(GrantDto::from(grant))).into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}
+
+#[utoipa::path(
+    delete,
+    path = "/api/drives/{id}/members/{kind}/{sid}",
+    params(
+        ("id" = Uuid, Path, description = "Drive UUID"),
+        ("kind" = String, Path, description = "Subject kind: user|group|token"),
+        ("sid" = Uuid, Path, description = "Subject UUID"),
+    ),
+    responses(
+        (status = 204, description = "Member removed (or was never a member — idempotent)"),
+        (status = 400, description = "Last-owner protection — promote another member first"),
+        (status = 404, description = "Drive not found or caller lacks Manage"),
+        (status = 405, description = "Personal drive — membership is immutable"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "drives"
+)]
+pub async fn remove_drive_member(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Path((drive_id, kind, subject_id)): Path<(Uuid, SubjectTypeDto, Uuid)>,
+) -> impl IntoResponse {
+    let subject = parse_subject(kind, subject_id);
+    match state
+        .drive_management_service
+        .remove_member(auth_user.id, drive_id, subject)
+        .await
+    {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => AppError::from(e).into_response(),
     }
 }

--- a/src/interfaces/api/handlers/drive_handler.rs
+++ b/src/interfaces/api/handlers/drive_handler.rs
@@ -98,11 +98,120 @@ pub struct UpdateDriveMemberDto {
     pub expires_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Body for `POST /api/drives` (D3a — create drive).
+///
+/// `kind` discriminates the drive flavour. D3a wires the `shared` branch
+/// end-to-end; the `personal` branch (secondary personal drives, distinct
+/// from the lifecycle-created default) is a recognised wire shape but
+/// returns 501 today — its authz model (self-service vs admin-only) and
+/// quota source (borrowed from per-user pool? separate cap?) are still
+/// open product questions. The body shape stays stable so future PRs only
+/// need to flip the service's `kind=personal` arm from rejecting to
+/// dispatching `create_personal_drive_atomic` with `default_for_user=NULL`.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateDriveDto {
+    /// Drive flavour. `"shared"` is implemented; `"personal"` is reserved.
+    pub kind: DriveKindDto,
+    /// Drive name (becomes the root folder's name). Trimmed; must be
+    /// non-empty after trim.
+    pub name: String,
+    /// Initial Owner subject. For `kind="shared"`: either a `user` (sole
+    /// drive Owner) or a `group` (transitive user members all gain Owner
+    /// via subject expansion). `token` is refused at the service edge.
+    /// For `kind="personal"` (when implemented): MUST be a `user`.
+    pub owner: SubjectDto,
+    /// Optional storage cap in bytes. `None` / omitted → no quota.
+    /// Quota mutation post-creation is OxiCloud-admin-only (D4).
+    #[serde(default)]
+    pub quota_bytes: Option<i64>,
+}
+
+/// Wire-shape enum for the drive flavour. Mirrors backend `DriveKind`.
+#[derive(Debug, Clone, Copy, Deserialize, ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum DriveKindDto {
+    Personal,
+    Shared,
+}
+
 fn parse_subject(kind: SubjectTypeDto, id: Uuid) -> Subject {
     match kind {
         SubjectTypeDto::User => Subject::User(id),
         SubjectTypeDto::Group => Subject::Group(id),
         SubjectTypeDto::Token => Subject::Token(id),
+    }
+}
+
+/// Create a drive (D3a — shared today; personal kind reserved).
+///
+/// **AuthZ**: OxiCloud-`admin` role only. The plan (`drive.md §6`) reads
+/// "admin OR group owner triggers" — D3a starts with admin-only and later
+/// iterations can broaden the gate without changing the wire shape.
+///
+/// Body:
+/// ```json
+/// {
+///   "kind": "shared",
+///   "name": "Engineering",
+///   "owner": { "type": "group", "id": "<group-uuid>" },
+///   "quota_bytes": 53687091200
+/// }
+/// ```
+///
+/// Returns the new `DriveDto`. If `owner.type == "group"`, the group must
+/// have ≥1 direct member or the request is refused with 400 — otherwise
+/// the drive would be created with no effective Owner-user.
+///
+/// `kind: "personal"` is recognised on the wire but returns 501 — the
+/// authz model (self-service vs admin-only) and quota source for
+/// secondary personal drives are still open product questions.
+#[utoipa::path(
+    post,
+    path = "/api/drives",
+    request_body = CreateDriveDto,
+    responses(
+        (status = 201, description = "Drive created", body = DriveDto),
+        (status = 400, description = "Empty name, empty owner group, or invalid input"),
+        (status = 403, description = "Caller is not an OxiCloud admin"),
+        (status = 501, description = "kind=personal not yet implemented"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "drives"
+)]
+pub async fn create_drive(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Json(dto): Json<CreateDriveDto>,
+) -> impl IntoResponse {
+    let caller_is_admin = auth_user.role == "admin";
+
+    // Personal kind is a wire-shape placeholder — see DTO doc.
+    if dto.kind == DriveKindDto::Personal {
+        return (
+            StatusCode::NOT_IMPLEMENTED,
+            Json(serde_json::json!({
+                "error": "Creating secondary personal drives is not yet implemented. \
+                          The authz model and quota source are still open product \
+                          questions — this body shape is reserved for the future PR."
+            })),
+        )
+            .into_response();
+    }
+
+    let owner = parse_subject(dto.owner.kind, dto.owner.id);
+    match state
+        .drive_management_service
+        .create_shared_drive(
+            auth_user.id,
+            caller_is_admin,
+            &dto.name,
+            owner,
+            dto.quota_bytes,
+        )
+        .await
+    {
+        Ok(drive) => (StatusCode::CREATED, Json(DriveDto::from(drive))).into_response(),
+        Err(e) => AppError::from(e).into_response(),
     }
 }
 

--- a/src/interfaces/api/handlers/grant_handler.rs
+++ b/src/interfaces/api/handlers/grant_handler.rs
@@ -164,7 +164,7 @@ pub async fn create_grant(
     let grant = if let Resource::Drive(drive_id) = resource {
         match state
             .drive_management_service
-            .set_member_role(caller_id, drive_id, subject, role, expires_at)
+            .set_member_role(caller_id, false, drive_id, subject, role, expires_at)
             .await
         {
             Ok(g) => g,
@@ -322,7 +322,7 @@ pub async fn revoke_grant(
         }
         if let Err(e) = state
             .drive_management_service
-            .remove_member(caller_id, drive_id, subject)
+            .remove_member(caller_id, false, drive_id, subject)
             .await
         {
             return AppError::from(e).into_response();
@@ -609,7 +609,7 @@ pub async fn set_role(
     let grant = if let Resource::Drive(drive_id) = resource {
         match state
             .drive_management_service
-            .set_member_role(caller_id, drive_id, subject, role, expires_at)
+            .set_member_role(caller_id, false, drive_id, subject, role, expires_at)
             .await
         {
             Ok(g) => g,

--- a/src/interfaces/api/handlers/grant_handler.rs
+++ b/src/interfaces/api/handlers/grant_handler.rs
@@ -19,6 +19,7 @@ use utoipa::IntoParams;
 use uuid::Uuid;
 
 use crate::application::dtos::cursor::PageCursor;
+use crate::application::dtos::drive_dto::DriveDto;
 use crate::application::dtos::grant_dto::{
     CreateGrantDto, CreateGrantResponseDto, GrantDto, MySharesDto, NotifyOutcomeSetDto,
     OutgoingResourceGrantDto, OutgoingResourceItemDto, ResourceContentDto, ResourceDto,
@@ -30,6 +31,7 @@ use crate::application::services::recipient_notification_service::NotifyTrigger;
 use crate::common::di::AppState;
 #[allow(unused_imports)]
 use crate::common::errors::DomainError;
+use crate::domain::repositories::drive_repository::DriveRepository;
 use crate::domain::services::authorization::{
     GrantCursor, IncomingGrantSummary, OutgoingResourceSummary, Permission, Resource, ResourceKind,
     Role, Subject,
@@ -43,6 +45,28 @@ type AppStateRef = Arc<AppState>;
 // POST /api/grants
 // ════════════════════════════════════════════════════════════════════════════
 
+/// Share a resource with someone — kicks off the **social flow** (invite +
+/// notification + lazy external-user provisioning if subject is an email).
+///
+/// **Use this when:** the recipient may not exist yet, hasn't been told,
+/// or this is the initial grant. The handler:
+/// - resolves `subject` (User / Group / Token / Email — email lazily creates
+///   an external user via `MagicLinkInviteService::resolve_or_create_recipient`),
+/// - writes one role-grant row via `authz.set_role` (`ON CONFLICT UPDATE`),
+/// - sends a share-notification email (magic-link arm for externals, plain
+///   notification for internal users — both honour `notify_on_share` opt-out
+///   and per-recipient rate limits).
+///
+/// **Compare with `PUT /api/grants/role`:** that endpoint is the *silent*
+/// admin-style role change for an already-known subject; it skips the
+/// invitation and notification side-effects entirely. Both write through
+/// the same idempotent UPSERT, so the only operational difference is the
+/// social flow attached here.
+///
+/// **Drive resources** (`resource.type == "drive"`) are routed through
+/// `DriveManagementService.set_member_role` internally — the
+/// personal-drive guard and shared-drive last-owner protection apply
+/// no matter which endpoint creates the grant.
 #[utoipa::path(
     post,
     path = "/api/grants",
@@ -51,6 +75,7 @@ type AppStateRef = Arc<AppState>;
         (status = 201, description = "Grant(s) created", body = CreateGrantResponseDto),
         (status = 400, description = "Invalid input (both/neither of permissions+role provided)"),
         (status = 404, description = "Resource not found OR caller lacks Share permission"),
+        (status = 405, description = "Drive resource: personal drives have immutable membership"),
     ),
     security(("bearerAuth" = [])),
     tag = "grants"
@@ -131,14 +156,30 @@ pub async fn create_grant(
     // Single role row in `storage.role_grants`. `ON CONFLICT UPDATE` in
     // the engine makes repeated POSTs with the same (subject, resource)
     // a role refresh, matching the PATCH-style semantics callers expect.
-    let grant = match authz
-        .set_role(caller_id, subject, role, resource, expires_at)
-        .await
-    {
-        Ok(g) => g,
-        Err(err) => {
-            error!("set_role write failed: {err}");
-            return AppError::from(err).into_response();
+    //
+    // Drive resources are routed through `DriveManagementService` so the
+    // personal-drive guard and shared-drive last-owner protection apply
+    // — the same guards that gate `/api/drives/{id}/members`. Defense in
+    // depth: a caller can't bypass them by hitting `/api/grants` directly.
+    let grant = if let Resource::Drive(drive_id) = resource {
+        match state
+            .drive_management_service
+            .set_member_role(caller_id, drive_id, subject, role, expires_at)
+            .await
+        {
+            Ok(g) => g,
+            Err(err) => return AppError::from(err).into_response(),
+        }
+    } else {
+        match authz
+            .set_role(caller_id, subject, role, resource, expires_at)
+            .await
+        {
+            Ok(g) => g,
+            Err(err) => {
+                error!("set_role write failed: {err}");
+                return AppError::from(err).into_response();
+            }
         }
     };
     let grants = vec![GrantDto::from(grant)];
@@ -267,33 +308,54 @@ pub async fn revoke_grant(
         Err(e) => return AppError::from(e).into_response(),
     };
 
-    // Caller is authorized if they are the granter OR have Share on the resource.
-    if granter != caller_id
-        && let Err(e) = authz
-            .require(Subject::User(caller_id), Permission::Share, resource)
+    // Drive resources are routed through `DriveManagementService` so the
+    // personal-drive guard and shared-drive last-owner protection apply.
+    // Note: the "granter can always revoke" shortcut DOES NOT apply for
+    // drive grants — drive membership mutations always require current
+    // Manage on the drive, even if you granted the row originally and
+    // were later demoted.
+    if let Resource::Drive(drive_id) = resource {
+        // Also revoke the legacy access_grants row for the dual-write
+        // window — `remove_member` handles the role_grants side.
+        if let Err(e) = authz.revoke(grant_id).await {
+            return AppError::from(e).into_response();
+        }
+        if let Err(e) = state
+            .drive_management_service
+            .remove_member(caller_id, drive_id, subject)
             .await
-    {
-        return AppError::from(e).into_response();
-    }
+        {
+            return AppError::from(e).into_response();
+        }
+    } else {
+        // Caller is authorized if they are the granter OR have Share on the resource.
+        if granter != caller_id
+            && let Err(e) = authz
+                .require(Subject::User(caller_id), Permission::Share, resource)
+                .await
+        {
+            return AppError::from(e).into_response();
+        }
 
-    if let Err(e) = authz.revoke(grant_id).await {
-        return AppError::from(e).into_response();
-    }
+        if let Err(e) = authz.revoke(grant_id).await {
+            return AppError::from(e).into_response();
+        }
 
-    // D-Prep dual-write: clear the role_grants row for this (subject,
-    // resource). Idempotent — succeeds whether or not the row existed.
-    //
-    // Today's API revokes one access_grants row by id; the role_grants
-    // row models the WHOLE (subject, resource) cluster. Calling clear_role
-    // here effectively revokes the WHOLE role assignment in role_grants,
-    // even if other per-permission access_grants rows remain. This is the
-    // correct semantics for the eventual cleanup-PR model (role_grants is
-    // role-keyed; once access_grants goes away, "revoke" means "drop the
-    // role"). During the dual-write window the two tables can drift
-    // briefly if a caller revokes only some permissions of a role, but
-    // the engine still reads access_grants so behaviour is unchanged.
-    if let Err(e) = authz.clear_role(subject, resource).await {
-        return AppError::from(e).into_response();
+        // D-Prep dual-write: clear the role_grants row for this (subject,
+        // resource). Idempotent — succeeds whether or not the row existed.
+        //
+        // Today's API revokes one access_grants row by id; the role_grants
+        // row models the WHOLE (subject, resource) cluster. Calling clear_role
+        // here effectively revokes the WHOLE role assignment in role_grants,
+        // even if other per-permission access_grants rows remain. This is the
+        // correct semantics for the eventual cleanup-PR model (role_grants is
+        // role-keyed; once access_grants goes away, "revoke" means "drop the
+        // role"). During the dual-write window the two tables can drift
+        // briefly if a caller revokes only some permissions of a role, but
+        // the engine still reads access_grants so behaviour is unchanged.
+        if let Err(e) = authz.clear_role(subject, resource).await {
+            return AppError::from(e).into_response();
+        }
     }
 
     tracing::info!(
@@ -481,13 +543,38 @@ pub async fn notify_grant_recipient(
 // PUT /api/grants/role
 // ════════════════════════════════════════════════════════════════════════════
 
+/// Change an existing member's role on a resource — **silent**, no
+/// invitation, no notification.
+///
+/// **Use this when:** the subject is already known (user/group/token has
+/// an existing grant or you've already informed them out-of-band) and you
+/// just want to bump their role. Typical use is the management UI's
+/// "Viewer → Editor" dropdown — you don't want a fresh share email
+/// firing on every dropdown change.
+///
+/// **Compare with `POST /api/grants`:** that endpoint kicks off the
+/// invitation + share-notification social flow and accepts an email-shaped
+/// subject for lazy external-user provisioning. This endpoint is the
+/// admin-style update — concrete subjects only, no side effects beyond
+/// the role row itself.
+///
+/// Both endpoints write through the same idempotent UPSERT
+/// (`authz.set_role`, unique on `(subject, resource)`), so they are
+/// indistinguishable in their effect on the role-grants table — the
+/// difference is purely the social side-effects attached to `POST`.
+///
+/// **Drive resources** (`resource.type == "drive"`) are routed through
+/// `DriveManagementService.set_member_role` internally — the
+/// personal-drive guard and shared-drive last-owner protection apply.
 #[utoipa::path(
     put,
     path = "/api/grants/role",
     request_body = UpdateRoleDto,
     responses(
         (status = 200, description = "Role applied; returns the new full grant set", body = Vec<GrantDto>),
+        (status = 400, description = "Drive resource: shared-drive last-owner demotion refused"),
         (status = 404, description = "Resource not found or caller lacks Share"),
+        (status = 405, description = "Drive resource: personal drives have immutable membership"),
     ),
     security(("bearerAuth" = [])),
     tag = "grants"
@@ -515,12 +602,27 @@ pub async fn set_role(
     // Atomic role refresh. UNIQUE on (subject, resource) + ON CONFLICT
     // UPDATE in `set_role` turns this into a single UPSERT — no diff,
     // no race window. Returns the resulting role row.
-    let grant = match authz
-        .set_role(caller_id, subject, role, resource, expires_at)
-        .await
-    {
-        Ok(g) => g,
-        Err(e) => return AppError::from(e).into_response(),
+    //
+    // Drive resources are routed through `DriveManagementService` so the
+    // personal-drive guard and shared-drive last-owner protection apply.
+    // See `create_grant` for the same delegation rationale.
+    let grant = if let Resource::Drive(drive_id) = resource {
+        match state
+            .drive_management_service
+            .set_member_role(caller_id, drive_id, subject, role, expires_at)
+            .await
+        {
+            Ok(g) => g,
+            Err(e) => return AppError::from(e).into_response(),
+        }
+    } else {
+        match authz
+            .set_role(caller_id, subject, role, resource, expires_at)
+            .await
+        {
+            Ok(g) => g,
+            Err(e) => return AppError::from(e).into_response(),
+        }
     };
 
     tracing::info!(
@@ -647,6 +749,10 @@ pub async fn list_shared_with_me(
         .iter()
         .filter(|s| matches!(s.resource_type, ResourceKind::Folder))
         .collect();
+    let drive_summaries: Vec<&IncomingGrantSummary> = summaries
+        .iter()
+        .filter(|s| matches!(s.resource_type, ResourceKind::Drive))
+        .collect();
 
     let file_service = &state.applications.file_retrieval_service;
     let folder_service = &state.applications.folder_service_concrete;
@@ -660,14 +766,16 @@ pub async fn list_shared_with_me(
         .iter()
         .map(|s| s.resource_id.to_string())
         .collect();
+    let drive_ids: Vec<Uuid> = drive_summaries.iter().map(|s| s.resource_id).collect();
 
-    // Resolve resource details in two batch queries (was one per id via
+    // Resolve resource details in three batch queries (was one per id via
     // join_all, which could fan out to ~limit concurrent pooled connections
     // and starve the primary pool). Missing ids — stale grants whose resource
     // was deleted before the cascade trigger fired — drop out of the maps.
-    let (file_list, folder_list) = tokio::join!(
+    let (file_list, folder_list, drive_list) = tokio::join!(
         file_service.get_files_by_ids(&file_ids),
-        folder_service.get_folders_by_ids(&folder_ids)
+        folder_service.get_folders_by_ids(&folder_ids),
+        state.drive_repo.get_by_ids(&drive_ids)
     );
     let file_map: HashMap<String, _> = match file_list {
         Ok(files) => files.into_iter().map(|f| (f.id.clone(), f)).collect(),
@@ -676,6 +784,16 @@ pub async fn list_shared_with_me(
     let folder_map: HashMap<String, _> = match folder_list {
         Ok(folders) => folders.into_iter().map(|f| (f.id.clone(), f)).collect(),
         Err(e) => return AppError::from(e).into_response(),
+    };
+    let drive_map: HashMap<Uuid, DriveDto> = match drive_list {
+        Ok(drives) => drives
+            .into_iter()
+            .map(|d| (d.drive.id, DriveDto::from(d)))
+            .collect(),
+        Err(e) => {
+            return AppError::internal_error(format!("Failed to batch-resolve drives: {e:?}"))
+                .into_response();
+        }
     };
 
     // Build the unified item list in original grant order (newest first),
@@ -719,13 +837,21 @@ pub async fn list_shared_with_me(
                     summary.resource_id
                 ),
             },
-            // Drive grants don't appear in the file/folder "Shared with me"
-            // listing — they're surfaced through `GET /api/drives` (D0).
-            // Silently skipping here is the right behaviour: a drive grant
-            // discovered by `list_incoming_resources_paged` is not a stale
-            // grant, just a different resource type with a different
-            // listing surface.
-            ResourceKind::Drive => continue,
+            ResourceKind::Drive => match drive_map.get(&summary.resource_id) {
+                Some(drive_dto) => {
+                    items.push(SharedWithMeItemDto {
+                        resource_type: ResourceTypeDto::Drive,
+                        permissions: summary.permissions.iter().map(|p| (*p).into()).collect(),
+                        granted_at: summary.granted_at,
+                        granted_by: summary.granted_by,
+                        resource: ResourceContentDto::Drive(drive_dto.clone()),
+                    });
+                }
+                None => warn!(
+                    "Skipping stale drive grant for resource_id={}: not found",
+                    summary.resource_id
+                ),
+            },
         }
     }
 
@@ -884,6 +1010,10 @@ pub async fn list_my_shares(
         .iter()
         .filter(|s| matches!(s.resource_type, ResourceKind::Folder))
         .collect();
+    let drive_summaries: Vec<&OutgoingResourceSummary> = summaries
+        .iter()
+        .filter(|s| matches!(s.resource_type, ResourceKind::Drive))
+        .collect();
 
     let file_ids: Vec<String> = file_summaries
         .iter()
@@ -893,11 +1023,13 @@ pub async fn list_my_shares(
         .iter()
         .map(|s| s.resource_id.to_string())
         .collect();
+    let drive_ids: Vec<Uuid> = drive_summaries.iter().map(|s| s.resource_id).collect();
 
-    // Two batch queries instead of one get_* per id (see list_shared_with_me).
-    let (file_list, folder_list) = tokio::join!(
+    // Three batch queries instead of one get_* per id (see list_shared_with_me).
+    let (file_list, folder_list, drive_list) = tokio::join!(
         file_service.get_files_by_ids(&file_ids),
-        folder_service.get_folders_by_ids(&folder_ids)
+        folder_service.get_folders_by_ids(&folder_ids),
+        state.drive_repo.get_by_ids(&drive_ids)
     );
     let file_map: HashMap<String, _> = match file_list {
         Ok(files) => files.into_iter().map(|f| (f.id.clone(), f)).collect(),
@@ -906,6 +1038,16 @@ pub async fn list_my_shares(
     let folder_map: HashMap<String, _> = match folder_list {
         Ok(folders) => folders.into_iter().map(|f| (f.id.clone(), f)).collect(),
         Err(e) => return AppError::from(e).into_response(),
+    };
+    let drive_map: HashMap<Uuid, DriveDto> = match drive_list {
+        Ok(drives) => drives
+            .into_iter()
+            .map(|d| (d.drive.id, DriveDto::from(d)))
+            .collect(),
+        Err(e) => {
+            return AppError::internal_error(format!("Failed to batch-resolve drives: {e:?}"))
+                .into_response();
+        }
     };
 
     let mut items: Vec<OutgoingResourceItemDto> = Vec::with_capacity(summaries.len());
@@ -960,10 +1102,20 @@ pub async fn list_my_shares(
                     summary.resource_id
                 ),
             },
-            // Drive grants are surfaced via `GET /api/drives` (D0), not
-            // through the My Shares outgoing-resources surface. Silently
-            // skip — symmetric with the `list_shared_with_me` arm above.
-            ResourceKind::Drive => continue,
+            ResourceKind::Drive => match drive_map.get(&summary.resource_id) {
+                Some(drive_dto) => {
+                    items.push(OutgoingResourceItemDto {
+                        resource_type: ResourceTypeDto::Drive,
+                        first_shared_at: summary.first_shared_at,
+                        resource: ResourceContentDto::Drive(drive_dto.clone()),
+                        grants,
+                    });
+                }
+                None => warn!(
+                    "Skipping stale outgoing drive grant for resource_id={}: not found",
+                    summary.resource_id
+                ),
+            },
         }
     }
 

--- a/src/interfaces/api/routes.rs
+++ b/src/interfaces/api/routes.rs
@@ -416,13 +416,21 @@ pub fn create_api_routes(app_state: &Arc<AppState>) -> Router<Arc<AppState>> {
     }
 
     // Drives — every drive the caller can read. D0 ships the read-only
-    // listing; D2 adds the membership API + shared-drive endpoints under
-    // `/api/drives/{id}/members`.
+    // listing; D2 adds the membership API; D3 the create-shared-drive flow.
     {
         use crate::interfaces::api::handlers::drive_handler;
 
         let drives_router = Router::new()
             .route("/", get(drive_handler::list_drives))
+            .route(
+                "/{id}/members",
+                get(drive_handler::list_drive_members).post(drive_handler::add_drive_member),
+            )
+            .route(
+                "/{id}/members/{kind}/{sid}",
+                axum::routing::patch(drive_handler::update_drive_member)
+                    .delete(drive_handler::remove_drive_member),
+            )
             .with_state(app_state.clone());
 
         router = router.nest("/drives", drives_router);

--- a/src/interfaces/api/routes.rs
+++ b/src/interfaces/api/routes.rs
@@ -421,14 +421,17 @@ pub fn create_api_routes(app_state: &Arc<AppState>) -> Router<Arc<AppState>> {
         use crate::interfaces::api::handlers::drive_handler;
 
         let drives_router = Router::new()
-            .route("/", get(drive_handler::list_drives))
+            .route(
+                "/",
+                get(drive_handler::list_drives).post(drive_handler::create_drive),
+            )
             .route(
                 "/{id}/members",
                 get(drive_handler::list_drive_members).post(drive_handler::add_drive_member),
             )
             .route(
                 "/{id}/members/{kind}/{sid}",
-                axum::routing::patch(drive_handler::update_drive_member)
+                patch(drive_handler::update_drive_member)
                     .delete(drive_handler::remove_drive_member),
             )
             .with_state(app_state.clone());

--- a/tests/api/drives_membership.hurl
+++ b/tests/api/drives_membership.hurl
@@ -704,30 +704,19 @@ HTTP 404
 
 
 # 26d — Editor renames the drive (root folder) → 404.
-#       Editor bundle has Update on content, but the rename
-#       endpoint uses authz.require(...) and Editor's bundle on
-#       the drive root resolves through the same drive precheck.
-#       Editor has Update; folder rename uses Update; so this
-#       should actually SUCCEED. Asserting 200 to reflect the
-#       real engine semantics — the "Editor can rename the drive"
-#       fact is a real product question worth surfacing here.
-#       If you want rename to be Owner-only, the fix is in the
-#       folder service (require Manage, not Update).
+#       Folder rename normally requires `Permission::Update` (which
+#       Editor has on every folder in the drive via the engine's drive
+#       precheck). The folder service promotes the requirement to
+#       `Permission::Manage` when the target folder has `parent_id IS
+#       NULL` — i.e. it's a drive root — so the drive-rename surface is
+#       Owner-only per drive.md §6, without changing the public folder
+#       endpoint shape. Anti-enum: refusal returns 404 (not 403).
 PUT {{base_url}}/api/folders/{{team_root_folder_id}}/rename
 Authorization: Bearer {{bob_token}}
 Content-Type: application/json
 { "name": "team-drive-editor-renamed" }
 
-HTTP 200
-
-
-# Restore the previous name so downstream assertions don't drift.
-PUT {{base_url}}/api/folders/{{team_root_folder_id}}/rename
-Authorization: Bearer {{alice_token}}
-Content-Type: application/json
-{ "name": "team-drive-renamed" }
-
-HTTP 200
+HTTP 404
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/api/drives_membership.hurl
+++ b/tests/api/drives_membership.hurl
@@ -1,0 +1,218 @@
+# =============================================================
+# OxiCloud — D2 drive membership API + delegation + caller_role
+# =============================================================
+# Verifies the D2 membership surface on personal drives (the only
+# drive kind today — shared-drive positive cases land alongside D3's
+# create endpoint):
+#
+#   1. `GET /api/drives` exposes `caller_role` on every row.
+#   2. `GET /api/drives/{id}/members` lists role grants on a drive
+#      (one Owner row for the lifecycle-hook-provisioned default).
+#   3. Personal-drive guard refuses every membership mutation
+#      (POST / PATCH / DELETE on `/api/drives/{id}/members*`) with
+#      405 — personal drives are single-user single-owner.
+#   4. The same guard fires on the generic `/api/grants` write paths
+#      (POST / PUT / DELETE) when `resource.type='drive'` and the
+#      drive is personal — verifies the `DriveManagementService`
+#      delegation that closes the bypass.
+#   5. Drive grants surface in `GET /api/grants/incoming/resources`
+#      with `resource_types=drive` filter (previously hard-skipped).
+#   6. Anti-enum: an unrelated user gets the same `404` for a drive
+#      they can't read, whether or not it exists.
+#
+# Self-contained: provisions its own users so it can run after
+# drives_foundation without aliasing state.
+# =============================================================
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 1 — admin login
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "{{username}}", "password": "{{password}}" }
+
+HTTP 200
+[Captures]
+admin_token: jsonpath "$.access_token"
+admin_user_id: jsonpath "$.user.id"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 2 — Admin's GET /api/drives now includes `caller_role`.
+#          Personal-drive owner role is seeded by
+#          PersonalDriveLifecycleHook on user creation.
+# ─────────────────────────────────────────────────────────────
+GET {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$[0].kind"             == "personal"
+jsonpath "$[0].default_for_user" == "{{admin_user_id}}"
+jsonpath "$[0].caller_role"      == "owner"
+
+[Captures]
+admin_drive_id: jsonpath "$[0].id"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 3 — GET /api/drives/{id}/members returns the lifecycle-
+#          seeded Owner row and only that.
+# ─────────────────────────────────────────────────────────────
+GET {{base_url}}/api/drives/{{admin_drive_id}}/members
+Authorization: Bearer {{admin_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$"                       count == 1
+jsonpath "$[0].subject.type"       == "user"
+jsonpath "$[0].subject.id"         == "{{admin_user_id}}"
+jsonpath "$[0].resource.type"      == "drive"
+jsonpath "$[0].resource.id"        == "{{admin_drive_id}}"
+jsonpath "$[0].role"               == "owner"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 4 — Create a fresh user (mbr_alice) so we have a second
+#          subject the personal-drive guard can refuse on.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/admin/users
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{ "username": "mbr_alice", "password": "MbrAlicePassword1!", "email": "mbr_alice@example.com", "role": "user" }
+
+HTTP 201
+[Captures]
+alice_user_id: jsonpath "$.id"
+
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "mbr_alice", "password": "MbrAlicePassword1!" }
+
+HTTP 200
+[Captures]
+alice_token: jsonpath "$.access_token"
+
+# Alice's GET /api/drives surfaces her own default with caller_role=owner.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{alice_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$"                     count == 1
+jsonpath "$[0].caller_role"      == "owner"
+jsonpath "$[0].default_for_user" == "{{alice_user_id}}"
+
+[Captures]
+alice_drive_id: jsonpath "$[0].id"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 5 — Personal-drive guard via the dedicated endpoint:
+#          POST /api/drives/{id}/members refuses with 405.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives/{{admin_drive_id}}/members
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "subject": { "type": "user", "id": "{{alice_user_id}}" },
+  "role": "editor"
+}
+
+HTTP 405
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 6 — PATCH on a personal drive's members → 405 (even for
+#          the owner row itself; personal drives' membership
+#          is structurally immutable).
+# ─────────────────────────────────────────────────────────────
+PATCH {{base_url}}/api/drives/{{admin_drive_id}}/members/user/{{admin_user_id}}
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{ "role": "editor" }
+
+HTTP 405
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 7 — DELETE on a personal drive's owner → 405. (Verifies
+#          the guard fires BEFORE the last-owner check; the order
+#          matters for the right error.)
+# ─────────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/drives/{{admin_drive_id}}/members/user/{{admin_user_id}}
+Authorization: Bearer {{admin_token}}
+
+HTTP 405
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 8 — Generic /api/grants delegation. POST /api/grants with
+#          resource.type='drive' on a personal drive must hit the
+#          same guard, otherwise the membership rules are bypassable.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/grants
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "resource": { "type": "drive", "id": "{{admin_drive_id}}" },
+  "subject":  { "type": "user",  "id": "{{alice_user_id}}" },
+  "role": "editor"
+}
+
+HTTP 405
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 9 — PUT /api/grants/role (silent admin update) on a drive
+#          resource — also delegated. Same guard fires.
+# ─────────────────────────────────────────────────────────────
+PUT {{base_url}}/api/grants/role
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "resource": { "type": "drive", "id": "{{admin_drive_id}}" },
+  "subject":  { "type": "user",  "id": "{{admin_user_id}}" },
+  "role": "editor"
+}
+
+HTTP 405
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 10 — Drive grants in /api/grants/incoming/resources.
+#           Default UI calls pass `resource_types=file,folder` so
+#           drives don't appear; explicit `resource_types=drive`
+#           must surface the admin's Owner grant on their own drive.
+# ─────────────────────────────────────────────────────────────
+GET {{base_url}}/api/grants/incoming/resources?resource_types=drive
+Authorization: Bearer {{admin_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.items"                count >= 1
+jsonpath "$.items[0].resource_type" == "drive"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 11 — Anti-enum: Alice queries the members of admin's
+#           personal drive. She has no Read on it → 404, same
+#           shape as "drive doesn't exist". Operators see the
+#           real reason in the audit log; she sees nothing.
+# ─────────────────────────────────────────────────────────────
+GET {{base_url}}/api/drives/{{admin_drive_id}}/members
+Authorization: Bearer {{alice_token}}
+
+HTTP 404
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 12 — The same anti-enum shape for a UUID that doesn't
+#           exist at all. Indistinguishable from step 11 to the
+#           caller — the canonical no-leak response.
+# ─────────────────────────────────────────────────────────────
+GET {{base_url}}/api/drives/00000000-0000-0000-0000-000000000000/members
+Authorization: Bearer {{alice_token}}
+
+HTTP 404

--- a/tests/api/drives_membership.hurl
+++ b/tests/api/drives_membership.hurl
@@ -1,10 +1,7 @@
 # =============================================================
-# OxiCloud — D2 drive membership API + delegation + caller_role
+# OxiCloud — D2/D3a drive membership + create-drive end-to-end
 # =============================================================
-# Verifies the D2 membership surface on personal drives (the only
-# drive kind today — shared-drive positive cases land alongside D3's
-# create endpoint):
-#
+# D2 coverage (steps 1-12, personal-drive-only world):
 #   1. `GET /api/drives` exposes `caller_role` on every row.
 #   2. `GET /api/drives/{id}/members` lists role grants on a drive
 #      (one Owner row for the lifecycle-hook-provisioned default).
@@ -19,6 +16,38 @@
 #      with `resource_types=drive` filter (previously hard-skipped).
 #   6. Anti-enum: an unrelated user gets the same `404` for a drive
 #      they can't read, whether or not it exists.
+#
+# D3a coverage (steps 13-22, unlocked by `POST /api/drives`):
+#   - admin-only authz gate on create
+#   - kind=personal returns 501 (placeholder for the future PR)
+#   - Owner subject = user → single Owner shared drive
+#   - Owner subject = group with members → group-mediated Owner
+#   - Owner subject = empty group → 400 (no orphan Owner)
+#   - Token subject refused
+#   - Last-owner protection on the new shared drive
+#   - Group-mediated Owner: caller_role resolves the strongest role
+#     (MIN over direct + group grants)
+#   - Editor cascade through the drive precheck (Bob gets Editor on
+#     a shared drive via the membership API and sees the drive)
+#   - Role demotion: PATCH Bob from Editor to Viewer reflects in his
+#     listing
+#
+# Per-role mutation matrix coverage (steps 23-29):
+#   - Owner CAN rename the drive (positive symmetry)
+#   - Owner CAN edit owners / editors / viewers (grant Owner, promote
+#     and demote across all role boundaries)
+#   - Viewer CANNOT POST / PATCH / DELETE members → 404
+#   - Editor CANNOT POST / PATCH / DELETE members → 404
+#   - Editor CAN modify drive content (positive role-bundle check)
+#   - Viewer CAN read drive content (positive role-bundle check)
+#   - Non-member sees 404 on every member-mutation verb AND on
+#     GET /members (anti-enum: no existence leak)
+#
+# **Known gap** surfaced by Step 26d: today's folder rename uses
+# `Permission::Update`, which is in Editor's bundle. The plan
+# (`drive.md §6`) says drive rename should be Owner-only. If/when
+# tightening: change the folder service to require `Manage` (or a
+# new `RenameDrive` permission) for folders that are drive roots.
 #
 # Self-contained: provisions its own users so it can run after
 # drives_foundation without aliasing state.
@@ -214,5 +243,584 @@ HTTP 404
 # ─────────────────────────────────────────────────────────────
 GET {{base_url}}/api/drives/00000000-0000-0000-0000-000000000000/members
 Authorization: Bearer {{alice_token}}
+
+HTTP 404
+
+
+# =============================================================
+# D3a — POST /api/drives (create shared drive)
+# =============================================================
+# Below covers the create-shared-drive endpoint + the role-bundle
+# tests that were deferred until shared-drive creation was wirable:
+#
+#  - admin-only authz gate
+#  - kind=personal returns 501 (placeholder)
+#  - Owner subject = user → single Owner shared drive
+#  - Owner subject = group with members → group-mediated Owner
+#  - Owner subject = empty group → 400 (no orphan Owner)
+#  - Token subject refused
+#  - Editor cascade: drive Owner can mutate content in the new drive
+#  - Last-owner protection on removal
+# =============================================================
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 13 — Non-admin caller refused with 403.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "should-not-exist",
+  "owner": { "type": "user", "id": "{{alice_user_id}}" }
+}
+
+HTTP 403
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 14 — kind=personal returns 501 (wire-shape placeholder).
+#           The body is accepted as valid JSON; the rejection is
+#           explicit at the service layer.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "kind": "personal",
+  "name": "side-private",
+  "owner": { "type": "user", "id": "{{alice_user_id}}" }
+}
+
+HTTP 501
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 15 — Create a shared drive with a single user owner
+#           (Alice). The new drive lands with kind=shared,
+#           default_for_user=NULL, and Alice as the sole Owner.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "alice-shared",
+  "owner": { "type": "user", "id": "{{alice_user_id}}" }
+}
+
+HTTP 201
+[Asserts]
+jsonpath "$.kind"             == "shared"
+jsonpath "$.name"             == "alice-shared"
+jsonpath "$.default_for_user" not exists
+jsonpath "$.used_bytes"       == 0
+
+[Captures]
+alice_shared_drive_id: jsonpath "$.id"
+
+
+# Alice now sees TWO drives — her default Personal + the new shared.
+# Caller_role on the shared drive is "owner" (her user grant).
+GET {{base_url}}/api/drives
+Authorization: Bearer {{alice_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$"                                count == 2
+jsonpath "$[*].id"                          contains {{alice_shared_drive_id}}
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 16 — Last-owner protection: Alice is the sole Owner of
+#           the new shared drive. Removing her grant must refuse.
+# ─────────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/drives/{{alice_shared_drive_id}}/members/user/{{alice_user_id}}
+Authorization: Bearer {{alice_token}}
+
+HTTP 400
+
+
+# And the demotion form: PATCH her role to editor → same refusal.
+PATCH {{base_url}}/api/drives/{{alice_shared_drive_id}}/members/user/{{alice_user_id}}
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "role": "editor" }
+
+HTTP 400
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 17 — Empty group is refused (would orphan the drive's Owner).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/groups
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{ "name": "empty-grp-for-drive" }
+
+HTTP 201
+[Captures]
+empty_group_id: jsonpath "$.id"
+
+
+POST {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "should-not-exist",
+  "owner": { "type": "group", "id": "{{empty_group_id}}" }
+}
+
+HTTP 400
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 18 — Empty name is refused (basic validation).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "   ",
+  "owner": { "type": "user", "id": "{{alice_user_id}}" }
+}
+
+HTTP 400
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 19 — Token subject is refused (drives can't be owned by
+#           share-link tokens).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "should-not-exist",
+  "owner": { "type": "token", "id": "00000000-0000-0000-0000-000000000099" }
+}
+
+HTTP 400
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 20 — Group-mediated Owner: create a group, add Alice, then
+#           create a shared drive with the group as Owner. Alice
+#           should see the new drive in her listing with
+#           caller_role="owner" (resolved through the group).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/groups
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{ "name": "drive-grp-with-alice" }
+
+HTTP 201
+[Captures]
+alice_group_id: jsonpath "$.id"
+
+
+POST {{base_url}}/api/groups/{{alice_group_id}}/members
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{ "user_id": "{{alice_user_id}}" }
+
+HTTP 201
+
+
+POST {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "team-drive",
+  "owner": { "type": "group", "id": "{{alice_group_id}}" }
+}
+
+HTTP 201
+[Captures]
+team_drive_id: jsonpath "$.id"
+team_root_folder_id: jsonpath "$.root_folder_id"
+
+
+# Alice's drive listing now includes the team drive with caller_role=owner.
+# `MIN(role)` over (direct grants + group-mediated grants) resolves Owner.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{alice_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$[*].id" contains {{team_drive_id}}
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 21 — Editor cascade through the drive precheck. Add a fresh
+#           user (mbr_bob) as Editor on the team drive; he should
+#           be able to read the drive root and create folders in it
+#           via the drive's Editor permission bundle, without any
+#           per-folder grant.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/admin/users
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{ "username": "mbr_bob", "password": "MbrBobPassword1!", "email": "mbr_bob@example.com", "role": "user" }
+
+HTTP 201
+[Captures]
+bob_user_id: jsonpath "$.id"
+
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "mbr_bob", "password": "MbrBobPassword1!" }
+
+HTTP 200
+[Captures]
+bob_token: jsonpath "$.access_token"
+
+
+# Bob has no role on the team drive → drive doesn't appear in his listing.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{bob_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$[*].id" not contains {{team_drive_id}}
+
+
+# Admin (well — Alice as drive Owner; admin would also work) grants Bob Editor.
+POST {{base_url}}/api/drives/{{team_drive_id}}/members
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{
+  "subject": { "type": "user", "id": "{{bob_user_id}}" },
+  "role": "editor"
+}
+
+HTTP 201
+
+
+# Bob now sees the drive with caller_role=editor.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{bob_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$[*].id"          contains {{team_drive_id}}
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 22 — Higher role wins: Bob now ALSO gets a Viewer direct
+#           grant (would lower his bundle). The collapsed caller_role
+#           must remain Editor (the stronger of his two grants).
+# ─────────────────────────────────────────────────────────────
+# Demote Bob to Viewer via PATCH — first ensure he was editor before
+# (already confirmed via the GET above).
+PATCH {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{bob_user_id}}
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "role": "viewer" }
+
+HTTP 200
+[Asserts]
+jsonpath "$.role" == "viewer"
+
+
+# Bob's listing now reflects the demotion.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{bob_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$[*].id" contains {{team_drive_id}}
+
+
+# =============================================================
+# Per-role mutation matrix — what every role can / can't do
+# =============================================================
+# Setup state at this point:
+#   - team_drive owners: alice (via alice_group) — sole Owner role grant
+#   - team_drive Viewer: bob (user grant after Step 22 demotion)
+#
+# Steps 23-29 cover the per-role authorization matrix on member
+# management + drive rename + content R/W. Anti-enum: every refusal
+# returns 404 (not 403) so an unauthorised caller can't enumerate the
+# difference between "drive doesn't exist" and "you can't manage it".
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 23 — Owner CAN rename the drive.
+#           Drive name lives on its root folder per drive.md §6,
+#           renamed via PUT /api/folders/<root_folder_id>/rename.
+#           Alice's Owner role (via her group) carries Update, so
+#           the engine drive precheck grants the rename.
+# ─────────────────────────────────────────────────────────────
+PUT {{base_url}}/api/folders/{{team_root_folder_id}}/rename
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "name": "team-drive-renamed" }
+
+HTTP 200
+[Asserts]
+jsonpath "$.name" == "team-drive-renamed"
+
+
+# The new name surfaces on the drive listing too — drive.name is
+# sourced from the root folder per DriveDto::From<DriveWithRootName>.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{alice_token}}
+
+HTTP 200
+[Asserts]
+# Filter expressions in Hurl: `[?(...)]` collapses to a scalar when there's
+# exactly one match — list-style predicates like `includes` / `contains` then
+# fail with a type mismatch. So we assert string equality instead.
+jsonpath "$[?(@.id=='{{team_drive_id}}')].name" == "team-drive-renamed"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 24 — Owner CAN edit owners, editors, and viewers.
+#           Grant Carol Owner, promote Bob to Owner, then demote
+#           Bob back to Viewer (the role he needs for Step 25).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/admin/users
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{ "username": "mbr_carol", "password": "MbrCarolPassword1!", "email": "mbr_carol@example.com", "role": "user" }
+
+HTTP 201
+[Captures]
+carol_user_id: jsonpath "$.id"
+
+
+# 24a — Owner grants Carol Owner role (Owner-creates-Owner).
+POST {{base_url}}/api/drives/{{team_drive_id}}/members
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{
+  "subject": { "type": "user", "id": "{{carol_user_id}}" },
+  "role": "owner"
+}
+
+HTTP 201
+[Asserts]
+jsonpath "$.role" == "owner"
+
+
+# 24b — Owner promotes Bob (Viewer) to Owner.
+PATCH {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{bob_user_id}}
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "role": "owner" }
+
+HTTP 200
+[Asserts]
+jsonpath "$.role" == "owner"
+
+
+# 24c — Owner demotes Bob back to Viewer (last-owner protection
+#       allows it: Carol + Alice-via-group remain as Owners).
+PATCH {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{bob_user_id}}
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "role": "viewer" }
+
+HTTP 200
+[Asserts]
+jsonpath "$.role" == "viewer"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 25 — Viewer CANNOT edit drive members.
+#           Bob is Viewer. Every member-mutation verb → 404
+#           (anti-enum: same shape as if the drive didn't exist).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives/{{team_drive_id}}/members
+Authorization: Bearer {{bob_token}}
+Content-Type: application/json
+{
+  "subject": { "type": "user", "id": "{{alice_user_id}}" },
+  "role": "editor"
+}
+
+HTTP 404
+
+
+PATCH {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{carol_user_id}}
+Authorization: Bearer {{bob_token}}
+Content-Type: application/json
+{ "role": "viewer" }
+
+HTTP 404
+
+
+DELETE {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{carol_user_id}}
+Authorization: Bearer {{bob_token}}
+
+HTTP 404
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 26 — Editor CANNOT edit drive members + CANNOT rename
+#           the drive (rename = PUT on the drive's root folder).
+#           Promote Bob to Editor first (Owner-driven).
+# ─────────────────────────────────────────────────────────────
+PATCH {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{bob_user_id}}
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "role": "editor" }
+
+HTTP 200
+
+
+# 26a — Editor POST /api/drives/{id}/members → 404.
+POST {{base_url}}/api/drives/{{team_drive_id}}/members
+Authorization: Bearer {{bob_token}}
+Content-Type: application/json
+{
+  "subject": { "type": "user", "id": "{{alice_user_id}}" },
+  "role": "viewer"
+}
+
+HTTP 404
+
+
+# 26b — Editor PATCH a member → 404.
+PATCH {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{carol_user_id}}
+Authorization: Bearer {{bob_token}}
+Content-Type: application/json
+{ "role": "viewer" }
+
+HTTP 404
+
+
+# 26c — Editor DELETE a member → 404.
+DELETE {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{carol_user_id}}
+Authorization: Bearer {{bob_token}}
+
+HTTP 404
+
+
+# 26d — Editor renames the drive (root folder) → 404.
+#       Editor bundle has Update on content, but the rename
+#       endpoint uses authz.require(...) and Editor's bundle on
+#       the drive root resolves through the same drive precheck.
+#       Editor has Update; folder rename uses Update; so this
+#       should actually SUCCEED. Asserting 200 to reflect the
+#       real engine semantics — the "Editor can rename the drive"
+#       fact is a real product question worth surfacing here.
+#       If you want rename to be Owner-only, the fix is in the
+#       folder service (require Manage, not Update).
+PUT {{base_url}}/api/folders/{{team_root_folder_id}}/rename
+Authorization: Bearer {{bob_token}}
+Content-Type: application/json
+{ "name": "team-drive-editor-renamed" }
+
+HTTP 200
+
+
+# Restore the previous name so downstream assertions don't drift.
+PUT {{base_url}}/api/folders/{{team_root_folder_id}}/rename
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "name": "team-drive-renamed" }
+
+HTTP 200
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 27 — Editor CAN modify content in the drive (positive).
+#           Confirms the Editor bundle isn't accidentally too
+#           restrictive — they can create folders under the drive
+#           root via the drive precheck.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/folders
+Authorization: Bearer {{bob_token}}
+Content-Type: application/json
+{
+  "name": "editor-created-folder",
+  "parent_id": "{{team_root_folder_id}}"
+}
+
+HTTP 201
+[Asserts]
+jsonpath "$.name" == "editor-created-folder"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 28 — Viewer CAN read content in the drive (positive).
+#           Demote Bob back to Viewer, then confirm he can still
+#           list the drive's root folder.
+# ─────────────────────────────────────────────────────────────
+PATCH {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{bob_user_id}}
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "role": "viewer" }
+
+HTTP 200
+
+
+GET {{base_url}}/api/folders/{{team_root_folder_id}}
+Authorization: Bearer {{bob_token}}
+
+HTTP 200
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 29 — A user with NO role on the drive cannot edit members.
+#           Provision a fresh user (mbr_dave) with no grants on
+#           the team drive; every member-mutation verb → 404.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/admin/users
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{ "username": "mbr_dave", "password": "MbrDavePassword1!", "email": "mbr_dave@example.com", "role": "user" }
+
+HTTP 201
+[Captures]
+dave_user_id: jsonpath "$.id"
+
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "mbr_dave", "password": "MbrDavePassword1!" }
+
+HTTP 200
+[Captures]
+dave_token: jsonpath "$.access_token"
+
+
+# 29a — Non-member POST → 404 (the drive itself appears not to exist).
+POST {{base_url}}/api/drives/{{team_drive_id}}/members
+Authorization: Bearer {{dave_token}}
+Content-Type: application/json
+{
+  "subject": { "type": "user", "id": "{{alice_user_id}}" },
+  "role": "viewer"
+}
+
+HTTP 404
+
+
+# 29b — Non-member PATCH → 404.
+PATCH {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{carol_user_id}}
+Authorization: Bearer {{dave_token}}
+Content-Type: application/json
+{ "role": "viewer" }
+
+HTTP 404
+
+
+# 29c — Non-member DELETE → 404.
+DELETE {{base_url}}/api/drives/{{team_drive_id}}/members/user/{{carol_user_id}}
+Authorization: Bearer {{dave_token}}
+
+HTTP 404
+
+
+# 29d — Non-member GET members → 404 too (anti-enum: no member-list leak).
+GET {{base_url}}/api/drives/{{team_drive_id}}/members
+Authorization: Bearer {{dave_token}}
 
 HTTP 404

--- a/tests/api/groups_effective_members.hurl
+++ b/tests/api/groups_effective_members.hurl
@@ -141,18 +141,16 @@ body contains "{{dora_id}}"
 
 
 # ─────────────────────────────────────────────────────────────
-# 8 — Teardown. Order matters: remove the nested group-member
-#     before deleting Group_B, so the FK cascade doesn't get
-#     ahead of us; remove dora's direct membership similarly.
+# 8 — Teardown.
+#     The D3a self-defense in `subject_group_service::remove_member`
+#     refuses any individual membership removal that would empty a
+#     seeded group's transitive user set — which BOTH of these
+#     would (removing Group_B from A leaves A with no users;
+#     removing dora from B leaves B with no users). So we skip the
+#     manual member-by-member unwind and just DELETE the groups
+#     directly. `delete_group` cascades through `subject_group_members`
+#     via FK and isn't subject to the per-remove guard.
 # ─────────────────────────────────────────────────────────────
-DELETE {{base_url}}/api/groups/{{group_a_id}}/members/group/{{group_b_id}}
-Authorization: Bearer {{admin_token}}
-HTTP 204
-
-DELETE {{base_url}}/api/groups/{{group_b_id}}/members/user/{{dora_id}}
-Authorization: Bearer {{admin_token}}
-HTTP 204
-
 DELETE {{base_url}}/api/groups/{{group_a_id}}
 Authorization: Bearer {{admin_token}}
 HTTP 204

--- a/tests/api/run.sh
+++ b/tests/api/run.sh
@@ -152,6 +152,7 @@ hurl --variables-file "$API_DIR/test.env" --file-root "$REPO_ROOT/tests" --test 
   "$API_DIR/groups_effective_members.hurl" \
   "$API_DIR/grants_nested_groups.hurl" \
   "$API_DIR/drives_foundation.hurl" \
+  "$API_DIR/drives_membership.hurl" \
   "$API_DIR/external_users.hurl" \
   "$API_DIR/search_basic.hurl" \
   "$API_DIR/nc_second_user_setup.hurl" \

--- a/tests/api/subject_groups.hurl
+++ b/tests/api/subject_groups.hurl
@@ -234,16 +234,64 @@ HTTP 200
 
 
 # ─────────────────────────────────────────────────────────────
-# Step 8 — Remove grace from engineering, then re-check access (after cache TTL).
-# Note: the authz cache has a 30s TTL — Hurl tests run within seconds so
-# grace may still see the folder during the cache window. We assert the
-# membership removal succeeded; the post-TTL denial is exercised by the
-# Rust integration tests, not here (test runtime cost).
+# Step 8 — Self-defense on group remove_member.
+#          A group must not drop to 0 transitive users once seeded —
+#          without this guard, an admin could empty a group that owns
+#          a shared drive (D3a), leaving the drive with no effective
+#          Owner. Conservative-by-default: the rule applies to every
+#          group, not just drive-owning ones.
+#
+#          So the first attempt to remove grace (the sole member) is
+#          refused with 400. We then seed the group with a second user,
+#          re-attempt the removal, and assert it now succeeds — the
+#          authz cascade tests below depend on grace being out of the
+#          group.
+#
+#          Note: the authz cache has a 30s TTL — Hurl tests run within
+#          seconds so grace may still see the folder during the cache
+#          window. We assert the membership removal succeeded; the
+#          post-TTL denial is exercised by the Rust integration tests,
+#          not here (test runtime cost).
 # ─────────────────────────────────────────────────────────────
+# 8a — First removal refused: grace is the sole transitive user.
+DELETE {{base_url}}/api/groups/{{engineers_id}}/members/user/{{grace_user_id}}
+Authorization: Bearer {{alice_token}}
+
+HTTP 400
+
+
+# 8b — Seed engineering with a second user so the removal can succeed.
+POST {{base_url}}/api/admin/users
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "username": "grp_helper", "password": "GrpHelperPwd1!", "email": "grp_helper@example.com", "role": "user" }
+
+HTTP 201
+[Captures]
+helper_user_id: jsonpath "$.id"
+
+
+POST {{base_url}}/api/groups/{{engineers_id}}/members
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{ "user_id": "{{helper_user_id}}" }
+
+HTTP 201
+
+
+# 8c — Grace removal now succeeds: engineering still has grp_helper.
 DELETE {{base_url}}/api/groups/{{engineers_id}}/members/user/{{grace_user_id}}
 Authorization: Bearer {{alice_token}}
 
 HTTP 204
+
+
+# 8d — Confirming the invariant still holds: removing the last user
+#      (grp_helper) is again refused.
+DELETE {{base_url}}/api/groups/{{engineers_id}}/members/user/{{helper_user_id}}
+Authorization: Bearer {{alice_token}}
+
+HTTP 400
 
 
 # ─────────────────────────────────────────────────────────────

--- a/tests/api/trash_resources.hurl
+++ b/tests/api/trash_resources.hurl
@@ -153,6 +153,10 @@ HTTP 200
 
 # ─────────────────────────────────────────────────────────────
 # Step 7 – Default listing: 4 items, all carry trashed_at + deletion_date
+#          + drive_id (D2b — enables per-drive grouping in the UI).
+#          The listing is also drive-membership scoped (D2b stage 2): the
+#          admin sees their own personal drive's trashed items, just as
+#          before, because a personal drive Owner has all roles needed.
 # ─────────────────────────────────────────────────────────────
 GET {{base_url}}/api/trash/resources
 Authorization: Bearer {{token}}
@@ -162,6 +166,11 @@ HTTP 200
 jsonpath "$.items" count == 4
 jsonpath "$.items[0].trashed_at" isString
 jsonpath "$.items[0].deletion_date" isString
+# D2b: drive_id is non-null on every trashed item.
+jsonpath "$.items[0].drive_id" isString
+jsonpath "$.items[1].drive_id" isString
+jsonpath "$.items[2].drive_id" isString
+jsonpath "$.items[3].drive_id" isString
 jsonpath "$.items[0].resource_type" matches "^(file|folder)$"
 jsonpath "$.items[*].resource.id" contains {{folder_a_id}}
 jsonpath "$.items[*].resource.id" contains {{folder_b_id}}


### PR DESCRIPTION
permit creation of other drives

- shared drives, created by oxicloud owners
- personal drive a automatically created per users
- tehnically it is possible to create another personal drives, feature kept other usages like vault
- permissions are now checked trough drive members: no more is file|folder.user_id)==caller_id
