### PR TITLE
feat(drive): drive deletion + drive quota

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,18 @@ jobs:
     if: needs.changes.outputs.backend == 'true'
     runs-on: ubuntu-latest
     steps:
+      # Same scope as the `tests` job below — `--all-targets
+      # --all-features` builds examples + benches across the full
+      # feature matrix and runs into the same disk ceiling. See the
+      # rationale on the `tests` job's free-disk-space step.
+      - uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -192,6 +204,22 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
+      # Free ~26 GB of preinstalled tools the runner image ships with
+      # (Android SDK ~12 GB, Haskell/GHC ~5 GB, .NET ~2 GB, swap +
+      # docker images by the action's defaults). `cargo test
+      # --all-features --workspace` on this repo blows past the
+      # ubuntu-latest ~14 GB free budget otherwise (PR #520 died on
+      # the `bench_owner_cache` example link step with ENOSPC).
+      # `tool-cache: false` is load-bearing — wiping it breaks
+      # `setup-rust`/`setup-node`/etc.
+      - uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
@@ -234,6 +262,19 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
+      # `cargo build --release --features plugins` is the heaviest
+      # link step in the workflow — release-profile linking emits
+      # large intermediate objects + plugins drags Wasmtime in.
+      # Preemptive cleanup keeps it well inside the runner disk
+      # budget; same rationale as the tests/clippy jobs above.
+      - uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2

--- a/docs/config/env.md
+++ b/docs/config/env.md
@@ -69,6 +69,7 @@ Most runtime variables use the `OXICLOUD_` prefix. A few build-time or allocator
 | `OXICLOUD_ENABLE_SEARCH` | `true` | Full-text and metadata search |
 | `OXICLOUD_ENABLE_MUSIC` | `true` | Music playlists and audio metadata |
 | `OXICLOUD_EXPOSE_SYSTEM_USERS` | `true` | Expose other OxiCloud users as a read-only address book at `GET /api/address-books` |
+| `OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS` | `false` | Expose `POST /api/admin/internal/trigger-sweep` and `POST /api/admin/internal/trigger-gc` — test-only synchronous triggers for the storage-usage reconciliation sweep and blob garbage collector. Used by the API test suite to assert post-delete quota convergence without waiting out the periodic ticker. Leave **off** in production: the routes return 404 even to an admin token when disabled. |
 
 ## Storage Backend
 

--- a/example.env
+++ b/example.env
@@ -72,6 +72,19 @@ OXICLOUD_SERVER_HOST=127.0.0.1
 # higher = less background DB work. Minimum enforced: 30s.
 #OXICLOUD_STORAGE_USAGE_RECONCILE_SECS=600
 
+# Test-only sweep triggers under /api/admin/internal/*.
+# When true, exposes:
+#   POST /api/admin/internal/trigger-sweep — run the storage-usage
+#                                            reconciliation synchronously
+#   POST /api/admin/internal/trigger-gc    — run the blob garbage collector
+#                                            synchronously
+# Used by the Hurl / integration suites to assert post-delete quota
+# convergence without waiting out the periodic ticker (default 600 s).
+# These endpoints short-circuit operator-visible background cadence, so
+# leave OFF in production — when disabled, the routes return 404 even
+# to an admin token. Default: false.
+#OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS=false
+
 # How often (milliseconds) the background job drains storage.tree_etag_dirty
 # and bumps folder tree ETags (default: 500). Write paths only enqueue bump
 # requests — this is the upper bound on how stale an ancestor folder's ETag

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,9 +14,9 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "eslint .",
     "format": "prettier --write .",
-    "test:unit": "vitest run",
-    "test:unit:watch": "vitest",
-    "test:unit:coverage": "rm -rf ../tests/e2e/.nyc_output_unit && COVERAGE=1 vitest run"
+    "test:unit": "LANG=C vitest run",
+    "test:unit:watch": "LANG=C vitest",
+    "test:unit:coverage": "rm -rf ../tests/e2e/.nyc_output_unit && LANG=C COVERAGE=1 vitest run"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/frontend/src/lib/api/endpoints/admin.ts
+++ b/frontend/src/lib/api/endpoints/admin.ts
@@ -157,6 +157,35 @@ export async function removeDriveMemberAdmin(
 	}
 }
 
+/**
+ * `DELETE /api/admin/drives/{id}` — admin-only drive delete (D3b).
+ *
+ * Bypasses the per-drive `Manage` check (the admin guard at the route
+ * edge is the access control). The default-personal-drive guard and
+ * the "drive must be empty" check still fire server-side — admins
+ * can't accidentally wipe a populated drive or a user's home folder.
+ * Throws on non-2xx so the caller can branch on `405` (default
+ * personal) vs `409` (non-empty) when surfacing the failure.
+ */
+export async function deleteDriveAdmin(driveId: string): Promise<void> {
+	const res = await apiFetch(`/api/admin/drives/${encodeURIComponent(driveId)}`, {
+		method: 'DELETE',
+		credentials: 'same-origin',
+		headers: getCsrfHeaders()
+	});
+	if (!res.ok) {
+		let detail = '';
+		try {
+			const parsed = (await res.json()) as { error?: string; message?: string };
+			detail = parsed.error ?? parsed.message ?? '';
+		} catch {
+			/* response body wasn't JSON */
+		}
+		// 405 / 409 carry actionable messages from the backend; bubble them.
+		throw new Error(detail || `delete drive failed: ${res.status}`);
+	}
+}
+
 // ── Users ───────────────────────────────────────────────────────────────
 
 export interface AdminUsersPage {

--- a/frontend/src/lib/api/endpoints/drives.ts
+++ b/frontend/src/lib/api/endpoints/drives.ts
@@ -105,6 +105,32 @@ export async function updateDriveMember(
 }
 
 /**
+ * `DELETE /api/drives/{id}` — Owner-only drive delete (D3b).
+ *
+ * Refused with `405` for the default Personal drive and `409` for a
+ * non-empty drive (caller must move/trash content first). Throws on
+ * non-2xx with the server's detail message when present so the caller
+ * can decide whether to surface a confirmation prompt vs an error.
+ */
+export async function deleteDrive(driveId: string): Promise<void> {
+	const res = await apiFetch(`/api/drives/${encodeURIComponent(driveId)}`, {
+		method: 'DELETE',
+		credentials: 'same-origin',
+		headers: getCsrfHeaders()
+	});
+	if (!res.ok) {
+		let detail = '';
+		try {
+			const parsed = (await res.json()) as { error?: string; message?: string };
+			detail = parsed.error ?? parsed.message ?? '';
+		} catch {
+			/* response body wasn't JSON */
+		}
+		throw new Error(detail || `delete drive failed: ${res.status}`);
+	}
+}
+
+/**
  * `DELETE /api/drives/{id}/members/{kind}/{sid}` — remove a member.
  * Idempotent (removing a non-member returns 204). Refused with 400 if it
  * would leave a shared drive without an owner.

--- a/frontend/src/lib/api/endpoints/trash.ts
+++ b/frontend/src/lib/api/endpoints/trash.ts
@@ -111,3 +111,19 @@ export async function emptyTrash(): Promise<void> {
 	});
 	if (!res.ok) throw new Error(`empty trash failed: ${res.status}`);
 }
+
+/**
+ * `DELETE /api/trash/drive/{drive_id}` — empty the trash within a
+ * single drive. Used by the trash page's Drive group-by, where each
+ * bucket header carries a per-drive Empty button so multi-drive
+ * owners don't have to wipe everything at once. Refused 404 when the
+ * caller lacks Delete on the named drive (anti-enum).
+ */
+export async function emptyTrashForDrive(driveId: string): Promise<void> {
+	const res = await apiFetch(`/api/trash/drive/${encodeURIComponent(driveId)}`, {
+		method: 'DELETE',
+		credentials: 'same-origin',
+		headers: getCsrfHeaders()
+	});
+	if (!res.ok) throw new Error(`empty drive trash failed: ${res.status}`);
+}

--- a/frontend/src/lib/components/ResourceList.svelte
+++ b/frontend/src/lib/components/ResourceList.svelte
@@ -87,6 +87,14 @@
 		dateLabel?: string;
 		/** Custom renderer for the date cell (e.g. trash expiry chip). */
 		dateCell?: Snippet<[ResourceEntry]>;
+		/**
+		 * Optional per-bucket action button rendered alongside the swimlane
+		 * header label. Receives the bucket key (the value `bucketOf`
+		 * returned for the active group-by). Used by the trash page to expose
+		 * a per-drive "Empty" affordance — the page decides which group-bys
+		 * the action is meaningful for and returns nothing otherwise.
+		 */
+		bucketAction?: Snippet<[string]>;
 		/** Show the owner column + vignette (list view) and hover tooltip. */
 		showOwner?: boolean;
 		/** Allow grid/list toggle (shares the app-wide view mode). */
@@ -131,6 +139,7 @@
 		showDate = true,
 		dateLabel,
 		dateCell,
+		bucketAction,
 		showOwner = false,
 		showViewToggle = true,
 		selectable = false,
@@ -434,7 +443,14 @@
 			<div class={viewClass} style="--files-list-columns: {columns}">
 				{@render listHeader()}
 				{#each sections as section (section.key)}
-					<div class="rl-swimlane-header" role="rowheader">{section.label}</div>
+					<div class="rl-swimlane-header" role="rowheader">
+						<span class="rl-swimlane-header__label">{section.label}</span>
+						{#if bucketAction}
+							<span class="rl-swimlane-header__action">
+								{@render bucketAction(section.key)}
+							</span>
+						{/if}
+					</div>
 					{#if filesStore.viewMode === 'list'}
 						<!-- Window each section's rows so a large grouped list (e.g. a big
 						     trash, grouped by remaining days) doesn't mount every row. The
@@ -651,6 +667,16 @@
 		font-weight: var(--weight-semibold);
 		color: var(--color-text-secondary);
 		border-bottom: 1px solid var(--color-border-faint);
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: var(--space-2);
+	}
+
+	/* Optional per-bucket action (e.g. trash page's per-drive Empty). */
+	.rl-swimlane-header__action {
+		display: inline-flex;
+		align-items: center;
 	}
 
 	/* Grid view date meta line. */

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -43,6 +43,7 @@
 		type PluginRetention,
 		type ReextractResult,
 		addDriveMemberAdmin,
+		deleteDriveAdmin,
 		listAllDrives,
 		listDriveMembersAdmin,
 		removeDriveMemberAdmin,
@@ -1060,6 +1061,30 @@
 				)
 			: []
 	);
+
+	// Admin-driven delete-drive flow (D3b). Guarded by the confirm modal
+	// because the action is destructive and irreversible. The backend
+	// refuses the default Personal drive (405) and any non-empty drive
+	// (409); we surface those as toasts rather than silently swallow.
+	async function requestDeleteDrive(d: Drive) {
+		const msg = t(
+			'admin.drive_delete_confirm',
+			{ name: d.name },
+			'Delete drive "{{name}}"? This cannot be undone.'
+		);
+		if (!(await showConfirm(msg))) return;
+		try {
+			await deleteDriveAdmin(d.id);
+			// Refresh the listing + the sidebar picker. Both have a cached
+			// view of this drive; without the invalidate the row lingers
+			// until the next full reload.
+			await loadDrivesTab();
+			drivesStore.invalidate();
+			ui.notify(t('admin.drive_deleted', 'Drive deleted.'), 'success');
+		} catch (e) {
+			reportError(e);
+		}
+	}
 
 	async function submitDriveCreate(e: SubmitEvent) {
 		e.preventDefault();
@@ -2190,6 +2215,20 @@
 											onclick={() => openManageOwners(d)}
 										>
 											<Icon name="users-cog" />
+										</button>
+									{/if}
+									<!-- Default-personal drives can never be deleted
+									     (backend returns 405). Hide the action entirely
+									     so the admin doesn't get a meaningless 405 toast. -->
+									{#if !d.default_for_user}
+										<button
+											class="icon-btn icon-btn--danger"
+											data-testid={`admin-drive-delete-${d.id}`}
+											title={t('admin.drive_delete', 'Delete drive')}
+											aria-label={t('admin.drive_delete', 'Delete drive')}
+											onclick={() => requestDeleteDrive(d)}
+										>
+											<Icon name="trash-alt" />
 										</button>
 									{/if}
 								</div>

--- a/frontend/src/routes/config/drive/[uuid]/+page.svelte
+++ b/frontend/src/routes/config/drive/[uuid]/+page.svelte
@@ -3,9 +3,12 @@
 	import { page } from '$app/state';
 	import { onMount } from 'svelte';
 
-	import { listDriveMembers } from '$lib/api/endpoints/drives';
+	import { goto } from '$app/navigation';
+
+	import { deleteDrive, listDriveMembers } from '$lib/api/endpoints/drives';
 	import { renameFolder } from '$lib/api/endpoints/folders';
 	import { errorToast } from '$lib/utils/errors';
+	import { ui } from '$lib/stores/ui.svelte';
 	import type { Drive, DriveMember, DriveRole } from '$lib/api/types';
 	import ShareDialog from '$lib/components/ShareDialog.svelte';
 	import UserVignette from '$lib/components/UserVignette.svelte';
@@ -33,6 +36,42 @@
 	// folder which only the Owner bundle carries. Personal-drive Owners
 	// are the user themselves (seeded by the lifecycle hook).
 	const canRename = $derived(drive?.caller_role === 'owner');
+
+	// Delete is allowed for Owners — backend additionally refuses the
+	// default Personal drive (405) and non-empty drives (409). We hide
+	// the button on the default-personal drive so the affordance only
+	// appears when it can actually succeed.
+	const canDelete = $derived(drive?.caller_role === 'owner' && !drive?.default_for_user);
+
+	let deleting = $state(false);
+
+	async function confirmAndDelete() {
+		if (!drive) return;
+		const confirmText = t(
+			'drive.delete_confirm',
+			{ name: drive.name },
+			'Delete drive "{{name}}"? This cannot be undone — the drive ' +
+				'must be empty first or the server will refuse.'
+		);
+		if (typeof window === 'undefined' || !window.confirm(confirmText)) return;
+		deleting = true;
+		try {
+			await deleteDrive(drive.id);
+			drivesStore.invalidate();
+			await drivesStore.load();
+			ui.notify(t('drive.deleted', 'Drive deleted.'), 'success');
+			// Send the user back to /files. The picker's reload above
+			// already removed the now-deleted drive from the sidebar.
+			await goto(resolve('/files'));
+		} catch (e) {
+			// 409 (non-empty) and 405 (default personal) come back as
+			// thrown errors with the server's detail in the message —
+			// surface as a toast rather than a silent failure.
+			errorToast(e);
+		} finally {
+			deleting = false;
+		}
+	}
 
 	// Inline rename state. `renameDraft` shadows `drive.name` while the
 	// input is open; we don't write back to the store until the server
@@ -385,6 +424,32 @@
 				</dl>
 			</div>
 		{/if}
+
+		{#if canDelete}
+			<!-- Danger zone: drive delete (D3b). Only rendered for Owners on
+			     non-default drives. Backend enforces the empty-drive rule —
+			     if the drive still has live content the request returns 409
+			     with a message that surfaces as a toast. -->
+			<div class="card danger-zone">
+				<h2><Icon name="exclamation-triangle" /> {t('drive.danger_zone', 'Danger zone')}</h2>
+				<p class="muted">
+					{t(
+						'drive.delete_hint',
+						'Deleting a drive removes it permanently. The drive must be empty (no live files or folders) before delete is allowed.'
+					)}
+				</p>
+				<button
+					type="button"
+					class="btn btn-danger"
+					data-testid="drive-delete-btn"
+					onclick={confirmAndDelete}
+					disabled={deleting}
+				>
+					<Icon name="trash-alt" />
+					{deleting ? t('common.deleting', 'Deleting…') : t('drive.delete', 'Delete drive')}
+				</button>
+			</div>
+		{/if}
 	{/if}
 </div>
 
@@ -527,6 +592,39 @@
 		border-radius: var(--radius-md);
 		background: var(--color-bg-input);
 		color: var(--color-text);
+	}
+
+	/* Danger zone card hosts the delete-drive button at the bottom of
+	   the page. Border tint makes the destructive context unmissable
+	   without hijacking the whole layout — same convention as
+	   admin/users delete affordances. */
+	.danger-zone {
+		border-color: var(--color-error-text);
+	}
+
+	.danger-zone h2 {
+		color: var(--color-error-text);
+	}
+
+	.btn-danger {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 0.875rem;
+		border: 1px solid var(--color-error-text);
+		border-radius: var(--radius-md);
+		background: var(--color-error-text);
+		color: var(--color-text-light);
+		cursor: pointer;
+	}
+
+	.btn-danger:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.icon-btn--danger {
+		color: var(--color-error-text);
 	}
 
 	/* Compact icon button used in the title row + nowhere else here.

--- a/frontend/src/routes/trash/+page.svelte
+++ b/frontend/src/routes/trash/+page.svelte
@@ -4,6 +4,7 @@
 	import {
 		deleteTrashItem,
 		emptyTrash,
+		emptyTrashForDrive,
 		expiryChip,
 		fetchTrashPage,
 		remainingDaysBucket,
@@ -184,6 +185,60 @@
 		}
 	}
 
+	// Per-drive empty (D2b stage 4 follow-up). The bucket key on the
+	// Drive group-by encodes "{rank}:{driveId}" so the natural lexical
+	// sort puts default-personal first; we strip the rank prefix here
+	// to recover the raw drive UUID. Only an Owner of the drive
+	// (Delete-bearing role) reaches the per-drive Empty button because
+	// the backend resolves a Delete-set first and refuses (404) any
+	// other drive.
+	function driveIdFromBucketKey(key: string): string {
+		return key.includes(':') ? (key.split(':')[1] ?? key) : key;
+	}
+
+	async function purgeDrive(bucketKey: string) {
+		const driveId = driveIdFromBucketKey(bucketKey);
+		const drive = drivesStore.findById(driveId);
+		// Owner-only check mirrors the backend gate so the UI doesn't
+		// surface the action for non-Owners — keeps the affordance
+		// honest. The bucket only appears on the page if the trash list
+		// already contained items the caller could see, but caller_role
+		// distinguishes Owner from Viewer/Editor on shared drives.
+		const ok = await confirmDialog({
+			title: t('trash.empty_drive_title', 'Empty drive trash'),
+			message: t(
+				'trash.confirm_empty_drive',
+				{ name: drive?.name ?? driveId },
+				'Empty the trash on drive "{{name}}"? This cannot be undone.'
+			),
+			confirmText: t('trash.empty_action', 'Empty trash'),
+			danger: true
+		});
+		if (!ok) return;
+		try {
+			await emptyTrashForDrive(driveId);
+			// Drop every entry that belonged to this drive; cheaper than a
+			// full refetch and matches what the user just saw.
+			raw = raw.filter((it) => it.drive_id !== driveId);
+		} catch (e) {
+			errorToast(e);
+		}
+	}
+
+	// The Drive group-by is the only one where a per-bucket empty
+	// affordance is meaningful — every other bucket key (remaining
+	// days, type, size, trashed time) isn't a permission scope. Hide
+	// the button on those group-bys.
+	const showPerDriveEmpty = $derived(groupBy === 'drive');
+
+	function driveCanPurge(driveId: string): boolean {
+		const d = drivesStore.findById(driveId);
+		// `caller_role === 'owner'` is the same gate the backend
+		// applies via Permission::Delete in the role bundle. Hide the
+		// button on Viewer/Editor drives so a click can't 404.
+		return d?.caller_role === 'owner';
+	}
+
 	onMount(() => {
 		// Drive names for the "Drive" group-by labels — `drivesStore.load()` is
 		// idempotent (cached on the singleton) so this is essentially free.
@@ -227,6 +282,23 @@
 			<Icon name={chip.icon} class="expiry-chip__icon" />
 			{chip.label}
 		</span>
+	{/snippet}
+	{#snippet bucketAction(bucketKey: string)}
+		{#if showPerDriveEmpty}
+			{@const driveId = driveIdFromBucketKey(bucketKey)}
+			{#if driveCanPurge(driveId)}
+				<button
+					type="button"
+					class="btn-action btn-action--delete"
+					data-testid={`trash-empty-drive-btn-${driveId}`}
+					title={t('trash.empty_drive_title', 'Empty drive trash')}
+					aria-label={t('trash.empty_drive_title', 'Empty drive trash')}
+					onclick={() => purgeDrive(bucketKey)}
+				>
+					<Icon name="trash" />
+				</button>
+			{/if}
+		{/if}
 	{/snippet}
 	{#snippet actions(entry)}
 		<button

--- a/src/application/ports/storage_ports.rs
+++ b/src/application/ports/storage_ports.rs
@@ -453,6 +453,42 @@ pub trait StorageUsagePort: Send + Sync + 'static {
 
     /// Returns (used_bytes, quota_bytes) for a user.
     async fn get_user_storage_info(&self, user_id: Uuid) -> Result<(i64, i64), DomainError>;
+
+    /// Incrementally adjust one drive's cached `storage.drives.used_bytes`
+    /// by `delta` bytes — O(1), the per-upload counterpart to the
+    /// O(N) full recompute below. Mirrors `add_user_storage_usage_delta`
+    /// in shape: single statement, `GREATEST(0, …)` clamp so a late or
+    /// duplicate adjustment can never drive the counter negative.
+    /// Deletes/trash do not decrement here (mirroring user-quota
+    /// design); the periodic reconciliation sweep is the correctness
+    /// backstop.
+    async fn add_drive_storage_usage_delta(
+        &self,
+        drive_id: Uuid,
+        delta: i64,
+    ) -> Result<(), DomainError>;
+
+    /// Reconcile every drive's cached `used_bytes` against the actual
+    /// sum of its non-trashed files in one set-based UPDATE. Same
+    /// shape as `update_all_users_storage_usage`: `LEFT JOIN` over a
+    /// `GROUP BY drive_id` aggregate, with an `IS DISTINCT FROM`
+    /// guard so idle drives don't churn dead tuples. Runs from the
+    /// same reconciliation ticker.
+    async fn update_all_drives_storage_usage(&self) -> Result<(), DomainError>;
+
+    /// Pre-upload quota check on a single drive.
+    ///
+    /// Returns `Ok(())` when `used_bytes + additional_bytes` fits under
+    /// `quota_bytes`, or `Err(QuotaExceeded)` otherwise.
+    /// `quota_bytes IS NULL` short-circuits to `Ok(())` — unlimited
+    /// drive. Single read-only `SELECT` on `storage.drives`; the
+    /// check/write window is a soft cap by design (same semantics as
+    /// the user-quota path), bounded by the sweep interval.
+    async fn check_drive_quota(
+        &self,
+        drive_id: Uuid,
+        additional_bytes: u64,
+    ) -> Result<(), DomainError>;
 }
 
 /// Generic storage service interface for calendar and contact services

--- a/src/application/ports/trash_ports.rs
+++ b/src/application/ports/trash_ports.rs
@@ -19,4 +19,14 @@ pub trait TrashUseCase: Send + Sync {
 
     /// Empty the trash for a specific user
     async fn empty_trash(&self, user_id: Uuid) -> Result<()>;
+
+    /// Empty the trash within a single drive the caller can Delete in.
+    ///
+    /// Same destructive shape as `empty_trash`, but scoped to one drive
+    /// — the Drive group-by on `/trash` exposes a per-row "Empty"
+    /// affordance so multi-drive owners can clear one drive without
+    /// touching the others. Refused (`NotFound`) when the caller has no
+    /// Delete-bearing role on the named drive (anti-enum: same shape
+    /// as if the drive didn't exist), or when the drive id is unknown.
+    async fn empty_trash_for_drive(&self, user_id: Uuid, drive_id: Uuid) -> Result<()>;
 }

--- a/src/application/services/delta_upload_service.rs
+++ b/src/application/services/delta_upload_service.rs
@@ -331,6 +331,21 @@ impl DeltaUploadService {
             .check_storage_quota(caller_id, total_size)
             .await?;
 
+        // ── Per-drive quota (D4) ─────────────────────────────────
+        // Mirrors the per-user check above on the same `total_size`.
+        // Only on CREATE — Update replaces an existing row's content;
+        // tight size-delta accounting on update is a follow-up (today
+        // the periodic sweep reconciles drift either way). The
+        // single-statement `check_drive_quota_by_folder` lookup is a
+        // PK probe; cost matches the existing per-user check.
+        if let CommitMode::Create { folder_id, .. } = &mode {
+            let folder_uuid = Uuid::parse_str(folder_id)
+                .map_err(|_| DomainError::not_found("Folder", folder_id.clone()))?;
+            self.quota
+                .check_drive_quota_by_folder(folder_uuid, total_size)
+                .await?;
+        }
+
         // ── Whole-file fast path: caller already owns this exact content ──
         // Mirrors the instant-upload endpoint: a reference bump, no chunk
         // work at all. Ownership is required — an existing-but-foreign

--- a/src/application/services/drive_management_service.rs
+++ b/src/application/services/drive_management_service.rs
@@ -274,6 +274,105 @@ impl DriveManagementService {
         Ok(())
     }
 
+    /// `DELETE /api/drives/{id}` and `DELETE /api/admin/drives/{id}`.
+    ///
+    /// Policy (drive.md §6 + memos):
+    /// - Caller must hold `Permission::Manage` on the drive — typically
+    ///   the Owner. `caller_is_admin = true` bypasses this check; the
+    ///   route gate is the access control then. Audit emits
+    ///   `drive.deleted_via_admin` when the bypass fires.
+    /// - The user's default Personal drive (`drives.default_for_user
+    ///   IS NOT NULL`) is refused with `405` — deleting your home is a
+    ///   category error. Secondary personal drives + shared drives
+    ///   follow the same content-empty rule below.
+    /// - The drive must be empty (no live folders other than the root,
+    ///   no live files). Trashed rows are excluded — owners can
+    ///   delete a drive whose trash bin still holds rows; the trash GC
+    ///   cleans them up after the retention window. Non-empty drives
+    ///   return `409 Conflict` so the UI can prompt the owner to
+    ///   move/trash content first.
+    ///
+    /// On success the drive row, its root folder, and every
+    /// `role_grants` row scoped to the drive are removed in one
+    /// transaction.
+    pub async fn delete_drive(
+        &self,
+        caller_id: Uuid,
+        caller_is_admin: bool,
+        drive_id: Uuid,
+    ) -> Result<(), DomainError> {
+        let resource = Resource::Drive(drive_id);
+        if !caller_is_admin {
+            self.authz
+                .require(Subject::User(caller_id), Permission::Manage, resource)
+                .await?;
+        }
+
+        let drive = self.drive_repo.get_by_id(drive_id).await.map_err(|e| {
+            DomainError::internal_error("Drive", format!("Failed to fetch drive: {e:?}"))
+        })?;
+
+        if drive.drive.default_for_user.is_some() {
+            tracing::info!(
+                target: "audit",
+                event = "drive_delete.rejected",
+                reason = "default_personal_drive",
+                drive_id = %drive_id,
+                by = %caller_id,
+                "👮🏻‍♂️ refused delete on default personal drive {drive_id}",
+            );
+            return Err(DomainError::operation_not_supported(
+                "Drive",
+                "The default Personal drive cannot be deleted.",
+            ));
+        }
+
+        let empty = self.drive_repo.is_empty(drive_id).await.map_err(|e| {
+            DomainError::internal_error("Drive", format!("Failed to check emptiness: {e:?}"))
+        })?;
+        if !empty {
+            tracing::info!(
+                target: "audit",
+                event = "drive_delete.rejected",
+                reason = "drive_not_empty",
+                drive_id = %drive_id,
+                by = %caller_id,
+                "👮🏻‍♂️ refused delete on non-empty drive {drive_id}",
+            );
+            return Err(DomainError::new(
+                crate::common::errors::ErrorKind::Conflict,
+                "Drive",
+                "Drive is not empty — move or trash its contents before deleting.",
+            ));
+        }
+
+        self.drive_repo
+            .delete_atomic(drive_id)
+            .await
+            .map_err(|e| DomainError::internal_error("Drive", format!("delete failed: {e:?}")))?;
+
+        // Drop every cached drive-role entry for this drive so the next
+        // /api/drives listing for any subject doesn't show a row pointing
+        // at a deleted drive_id. Single-key cache invalidations are safe
+        // even when no entry matches.
+        self.authz
+            .invalidate_drive_role_cache_for_drive(drive_id)
+            .await;
+
+        tracing::info!(
+            target: "audit",
+            event = if caller_is_admin {
+                "drive.deleted_via_admin"
+            } else {
+                "drive.deleted"
+            },
+            drive_id = %drive_id,
+            by = %caller_id,
+            "🗑 drive deleted",
+        );
+        Ok(())
+    }
+
     // ── Business rules ──────────────────────────────────────────────────────
 
     /// Personal drives are single-user single-owner; any member mutation is

--- a/src/application/services/file_upload_service.rs
+++ b/src/application/services/file_upload_service.rs
@@ -299,23 +299,46 @@ impl FileUploadService {
         let Some(storage_service) = &self.storage_usage_service else {
             return;
         };
-        let Some(owner) = file
+        let delta = file.size as i64;
+
+        // Per-user delta — unchanged from `b5b80549` / `fbbae541`.
+        if let Some(owner) = file
             .owner_id
             .as_deref()
             .and_then(|s| Uuid::parse_str(s).ok())
-        else {
-            return;
-        };
-        let delta = file.size as i64;
-        let service_clone = Arc::clone(storage_service);
-        tokio::spawn(async move {
-            if let Err(e) = service_clone
-                .add_user_storage_usage_delta(owner, delta)
-                .await
-            {
-                warn!("Failed to bump storage usage for {owner}: {e}");
-            }
-        });
+        {
+            let service_clone = Arc::clone(storage_service);
+            tokio::spawn(async move {
+                if let Err(e) = service_clone
+                    .add_user_storage_usage_delta(owner, delta)
+                    .await
+                {
+                    warn!("Failed to bump storage usage for {owner}: {e}");
+                }
+            });
+        }
+
+        // Per-drive delta (D4) — same fire-and-forget shape, resolves
+        // the drive id from the file's parent folder in one SQL
+        // statement. `storage.drives.used_bytes` is what the per-drive
+        // quota check and the picker quota bar read; drift from
+        // deletes / trash is reconciled by the same sweep that handles
+        // user-side drift.
+        if let Some(folder) = file
+            .folder_id
+            .as_deref()
+            .and_then(|s| Uuid::parse_str(s).ok())
+        {
+            let service_clone = Arc::clone(storage_service);
+            tokio::spawn(async move {
+                if let Err(e) = service_clone
+                    .add_drive_storage_usage_delta_by_folder(folder, delta)
+                    .await
+                {
+                    warn!("Failed to bump drive usage for folder {folder}: {e}");
+                }
+            });
+        }
     }
 }
 

--- a/src/application/services/storage_usage_service.rs
+++ b/src/application/services/storage_usage_service.rs
@@ -128,6 +128,157 @@ impl StorageUsageService {
         Ok(())
     }
 
+    /// Incrementally adjust one drive's cached `storage.drives.used_bytes`
+    /// by `delta` bytes — same shape as
+    /// [`Self::add_user_storage_usage_delta`]: single statement, no
+    /// read-then-write window, `GREATEST(0, …)` clamp so a late or
+    /// duplicate adjustment can never drive the counter negative.
+    /// Deletes / trash do not decrement here; the periodic reconciliation
+    /// sweep ([`Self::update_all_drives_storage_usage`]) remains the
+    /// correctness backstop.
+    pub async fn add_drive_storage_usage_delta(
+        &self,
+        drive_id: Uuid,
+        delta: i64,
+    ) -> Result<(), DomainError> {
+        sqlx::query(
+            "UPDATE storage.drives
+                SET used_bytes = GREATEST(0, used_bytes + $2)
+              WHERE id = $1",
+        )
+        .bind(drive_id)
+        .bind(delta)
+        .execute(self.pool.as_ref())
+        .await
+        .map_err(|e| DomainError::internal_error("StorageUsage", format!("drive delta: {e}")))?;
+        Ok(())
+    }
+
+    /// Same as [`Self::add_drive_storage_usage_delta`] but resolves
+    /// the drive id from a parent folder id in a single statement.
+    /// Avoids a separate `SELECT drive_id FROM storage.folders` round
+    /// trip at the upload hook site (where the folder id is what's
+    /// naturally on the FileDto). The nested SELECT is point-lookup
+    /// on the folder PK; clamp + idempotency properties are
+    /// unchanged.
+    pub async fn add_drive_storage_usage_delta_by_folder(
+        &self,
+        folder_id: Uuid,
+        delta: i64,
+    ) -> Result<(), DomainError> {
+        sqlx::query(
+            "UPDATE storage.drives
+                SET used_bytes = GREATEST(0, used_bytes + $2)
+              WHERE id = (SELECT drive_id FROM storage.folders WHERE id = $1)",
+        )
+        .bind(folder_id)
+        .bind(delta)
+        .execute(self.pool.as_ref())
+        .await
+        .map_err(|e| {
+            DomainError::internal_error("StorageUsage", format!("drive delta by folder: {e}"))
+        })?;
+        Ok(())
+    }
+
+    /// Pre-upload quota check on a single drive.
+    ///
+    /// Read-only `SELECT (used_bytes, quota_bytes) FROM storage.drives`;
+    /// returns `QuotaExceeded` when the projected `used_bytes +
+    /// additional_bytes` would breach `quota_bytes`. A `NULL`
+    /// `quota_bytes` short-circuits to `Ok(())` (unlimited drive —
+    /// admin override / future system drives).
+    ///
+    /// Soft cap by design: the check/write window matches the
+    /// user-quota path, bounded by the sweep interval. The clamp on
+    /// `add_drive_storage_usage_delta` and the set-based reconciliation
+    /// keep the counter honest; small over-quota slippage during the
+    /// window is acceptable.
+    pub async fn check_drive_quota(
+        &self,
+        drive_id: Uuid,
+        additional_bytes: u64,
+    ) -> Result<(), DomainError> {
+        let row: Option<(i64, Option<i64>)> = sqlx::query_as(
+            "SELECT used_bytes, quota_bytes FROM storage.drives WHERE id = $1",
+        )
+        .bind(drive_id)
+        .fetch_optional(self.pool.as_ref())
+        .await
+        .map_err(|e| DomainError::internal_error("StorageUsage", format!("drive quota lookup: {e}")))?;
+
+        let Some((used, quota)) = row else {
+            // Anti-enum at the upload edge would normally map to 404,
+            // but at this layer we surface the typed not-found and let
+            // the caller decide how to react. In practice the upload
+            // path resolves the drive id from a folder/file lookup
+            // first, so this branch fires only on a deleted-drive race.
+            return Err(DomainError::not_found("Drive", drive_id.to_string()));
+        };
+        let Some(quota) = quota else {
+            return Ok(()); // unlimited
+        };
+        // Saturate on the i64 + u64 sum so a hostile / corrupt counter
+        // can't silently overflow into a negative comparison.
+        let projected = (used as i128) + (additional_bytes as i128);
+        if projected > quota as i128 {
+            return Err(DomainError::new(
+                crate::common::errors::ErrorKind::QuotaExceeded,
+                "Drive",
+                format!(
+                    "Drive quota exceeded: {} + {} > {} bytes",
+                    used, additional_bytes, quota
+                ),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Same as [`Self::check_drive_quota`] but resolves the drive id
+    /// from a parent folder id. Mirrors
+    /// [`Self::add_drive_storage_usage_delta_by_folder`] so the upload
+    /// handler (which holds `folder_id` from the multipart form) can
+    /// gate the write in one round trip. Returns
+    /// `DomainError::not_found("Folder", …)` if the folder id doesn't
+    /// resolve — the upload pipeline would 404 on that anyway.
+    pub async fn check_drive_quota_by_folder(
+        &self,
+        folder_id: Uuid,
+        additional_bytes: u64,
+    ) -> Result<(), DomainError> {
+        let row: Option<(i64, Option<i64>)> = sqlx::query_as(
+            "SELECT d.used_bytes, d.quota_bytes
+               FROM storage.drives d
+               JOIN storage.folders f ON f.drive_id = d.id
+              WHERE f.id = $1",
+        )
+        .bind(folder_id)
+        .fetch_optional(self.pool.as_ref())
+        .await
+        .map_err(|e| {
+            DomainError::internal_error("StorageUsage", format!("drive quota by folder: {e}"))
+        })?;
+
+        let Some((used, quota)) = row else {
+            return Err(DomainError::not_found("Folder", folder_id.to_string()));
+        };
+        let Some(quota) = quota else {
+            return Ok(()); // unlimited
+        };
+        let projected = (used as i128) + (additional_bytes as i128);
+        if projected > quota as i128 {
+            return Err(DomainError::new(
+                crate::common::errors::ErrorKind::QuotaExceeded,
+                "Drive",
+                format!(
+                    "Drive quota exceeded: {} + {} > {} bytes",
+                    used, additional_bytes, quota
+                ),
+            ));
+        }
+        Ok(())
+    }
+
     /// Spawn a background task that periodically reconciles every user's cached
     /// `storage_used_bytes` against the actual sum of their files.
     ///
@@ -153,7 +304,13 @@ impl StorageUsageService {
                 ticker.tick().await;
                 debug!("Running scheduled storage-usage reconciliation");
                 if let Err(e) = service.update_all_users_storage_usage().await {
-                    error!("Scheduled storage-usage reconciliation failed: {}", e);
+                    error!("Scheduled user storage-usage reconciliation failed: {}", e);
+                }
+                // Drive sweep runs alongside the user sweep — same
+                // cadence, same maintenance pool. Failure is logged
+                // but doesn't skip the next tick.
+                if let Err(e) = service.update_all_drives_storage_usage().await {
+                    error!("Scheduled drive storage-usage reconciliation failed: {}", e);
                 }
             }
         });
@@ -265,6 +422,63 @@ impl StorageUsagePort for StorageUsageService {
     async fn get_user_storage_info(&self, user_id: Uuid) -> Result<(i64, i64), DomainError> {
         let user = self.user_repository.get_user_by_id(user_id).await?;
         Ok((user.storage_used_bytes(), user.storage_quota_bytes()))
+    }
+
+    async fn add_drive_storage_usage_delta(
+        &self,
+        drive_id: Uuid,
+        delta: i64,
+    ) -> Result<(), DomainError> {
+        StorageUsageService::add_drive_storage_usage_delta(self, drive_id, delta).await
+    }
+
+    /// Reconcile every drive's cached `used_bytes` in ONE set-based UPDATE.
+    ///
+    /// Same shape as the per-user sweep above: `LEFT JOIN` over the
+    /// `storage.files` aggregate keyed on `drive_id`, `IS DISTINCT
+    /// FROM` guard to skip no-op rewrites so idle drives don't churn
+    /// dead tuples. Runs from the same reconciliation ticker as the
+    /// user sweep; failure is logged but doesn't stop the next tick.
+    async fn update_all_drives_storage_usage(&self) -> Result<(), DomainError> {
+        debug!("Starting drive storage-usage reconciliation sweep");
+        let result = sqlx::query(
+            r#"
+            UPDATE storage.drives d
+               SET used_bytes = COALESCE(t.total, 0)
+              FROM storage.drives d2
+              LEFT JOIN (
+                    SELECT drive_id, SUM(size)::bigint AS total
+                      FROM storage.files
+                     WHERE NOT is_trashed
+                     GROUP BY drive_id
+                   ) t ON t.drive_id = d2.id
+             WHERE d.id = d2.id
+               AND d.used_bytes IS DISTINCT FROM COALESCE(t.total, 0)
+            "#,
+        )
+        .execute(self.pool.as_ref())
+        .await
+        .map_err(|e| {
+            error!("Drive storage-usage reconciliation sweep failed: {}", e);
+            DomainError::internal_error(
+                "StorageUsage",
+                format!("drive reconciliation sweep: {e}"),
+            )
+        })?;
+
+        info!(
+            "Drive storage-usage reconciliation corrected {} drive(s)",
+            result.rows_affected()
+        );
+        Ok(())
+    }
+
+    async fn check_drive_quota(
+        &self,
+        drive_id: Uuid,
+        additional_bytes: u64,
+    ) -> Result<(), DomainError> {
+        StorageUsageService::check_drive_quota(self, drive_id, additional_bytes).await
     }
 }
 

--- a/src/application/services/storage_usage_service.rs
+++ b/src/application/services/storage_usage_service.rs
@@ -207,13 +207,14 @@ impl StorageUsageService {
         drive_id: Uuid,
         additional_bytes: u64,
     ) -> Result<(), DomainError> {
-        let row: Option<(i64, Option<i64>)> = sqlx::query_as(
-            "SELECT used_bytes, quota_bytes FROM storage.drives WHERE id = $1",
-        )
-        .bind(drive_id)
-        .fetch_optional(self.pool.as_ref())
-        .await
-        .map_err(|e| DomainError::internal_error("StorageUsage", format!("drive quota lookup: {e}")))?;
+        let row: Option<(i64, Option<i64>)> =
+            sqlx::query_as("SELECT used_bytes, quota_bytes FROM storage.drives WHERE id = $1")
+                .bind(drive_id)
+                .fetch_optional(self.pool.as_ref())
+                .await
+                .map_err(|e| {
+                    DomainError::internal_error("StorageUsage", format!("drive quota lookup: {e}"))
+                })?;
 
         let Some((used, quota)) = row else {
             // Anti-enum at the upload edge would normally map to 404,
@@ -468,10 +469,7 @@ impl StorageUsagePort for StorageUsageService {
         .await
         .map_err(|e| {
             error!("Drive storage-usage reconciliation sweep failed: {}", e);
-            DomainError::internal_error(
-                "StorageUsage",
-                format!("drive reconciliation sweep: {e}"),
-            )
+            DomainError::internal_error("StorageUsage", format!("drive reconciliation sweep: {e}"))
         })?;
 
         info!(

--- a/src/application/services/storage_usage_service.rs
+++ b/src/application/services/storage_usage_service.rs
@@ -166,10 +166,18 @@ impl StorageUsageService {
         folder_id: Uuid,
         delta: i64,
     ) -> Result<(), DomainError> {
+        // FROM-form UPDATE keeps the same join shape as
+        // `check_drive_quota_by_folder` so both methods agree on
+        // how a folder maps to its drive. A subquery form would
+        // silently `UPDATE … WHERE id = NULL` (matching zero rows)
+        // if the lookup misses; the FROM-form simply doesn't match
+        // — same outcome, more conventional SQL.
         sqlx::query(
-            "UPDATE storage.drives
-                SET used_bytes = GREATEST(0, used_bytes + $2)
-              WHERE id = (SELECT drive_id FROM storage.folders WHERE id = $1)",
+            "UPDATE storage.drives d
+                SET used_bytes = GREATEST(0, d.used_bytes + $2)
+               FROM storage.folders f
+              WHERE f.drive_id = d.id
+                AND f.id = $1",
         )
         .bind(folder_id)
         .bind(delta)

--- a/src/application/services/subject_group_service.rs
+++ b/src/application/services/subject_group_service.rs
@@ -210,6 +210,69 @@ impl SubjectGroupService {
             ));
         }
 
+        // Refuse if this group is the **sole Owner** of any drive — the
+        // cascade-delete below would otherwise wipe the only `owner`
+        // grant on that drive and leave it orphaned (no one can ever
+        // manage it again). The check is "for every drive where this
+        // group holds Owner, does another Owner exist?". A single drive
+        // failing the check is enough to refuse.
+        //
+        // Matching D3a's last-owner-protection rule on `set_member_role`
+        // / `remove_member` — they catch the case where the drive's
+        // last Owner is *directly* a user or group being demoted /
+        // removed via the membership API. This guard catches the same
+        // invariant from the group-lifecycle side.
+        let orphaning: Option<(Uuid,)> = sqlx::query_as(
+            r#"
+            WITH group_owned AS (
+                SELECT resource_id
+                  FROM storage.role_grants
+                 WHERE subject_type = 'group'
+                   AND subject_id   = $1
+                   AND resource_type = 'drive'
+                   AND role         = 'owner'
+                   AND (expires_at IS NULL OR expires_at > NOW())
+            )
+            SELECT resource_id
+              FROM storage.role_grants
+             WHERE resource_type = 'drive'
+               AND role         = 'owner'
+               AND (expires_at IS NULL OR expires_at > NOW())
+               AND resource_id IN (SELECT resource_id FROM group_owned)
+             GROUP BY resource_id
+            HAVING COUNT(*) = 1
+             LIMIT 1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(self.pool.as_ref())
+        .await
+        .map_err(|e| {
+            DomainError::new(
+                ErrorKind::InternalError,
+                "SubjectGroup",
+                format!("sole-owner check: {e}"),
+            )
+        })?;
+        if let Some((drive_id,)) = orphaning {
+            tracing::info!(
+                target: "audit",
+                event = "group_delete.rejected",
+                reason = "sole_drive_owner",
+                group_id = %id,
+                drive_id = %drive_id,
+                by = %caller_id,
+                "👮🏻‍♂️ refused group delete — sole Owner of drive {drive_id}",
+            );
+            return Err(DomainError::new(
+                ErrorKind::Conflict,
+                "SubjectGroup",
+                "Group is the sole Owner of at least one shared drive — \
+                 promote another Owner first or delete the drive."
+                    .to_string(),
+            ));
+        }
+
         // Atomically delete grants pointing at this group, then the group
         // itself. If either fails, both roll back.
         let mut tx = self.pool.begin().await.map_err(|e| {

--- a/src/application/services/trash_service.rs
+++ b/src/application/services/trash_service.rs
@@ -725,6 +725,46 @@ impl TrashUseCase for TrashService {
         // the drives where the caller is effectively Owner (direct or via a
         // group). Single-drive users: this resolves to just their personal
         // drive, identical to the legacy `WHERE user_id = $1` scope.
+        let drive_ids = self.drives_with_delete_for(user_id).await?;
+        if drive_ids.is_empty() {
+            info!("empty_trash: caller has Delete on no drive — nothing to do");
+            return Ok(());
+        }
+        self.clear_trash_in(&drive_ids, user_id).await
+    }
+
+    #[instrument(skip(self))]
+    async fn empty_trash_for_drive(&self, user_id: Uuid, drive_id: Uuid) -> Result<()> {
+        // Per-drive trash empty — the Drive group-by on `/trash` exposes
+        // this as a per-row affordance so multi-drive owners can clear
+        // one drive without touching the others. Refuses with
+        // `NotFound` (anti-enum) when the caller lacks Delete on the
+        // named drive — same shape as the user-facing drive listing
+        // would emit for an unknown id.
+        let allowed = self.drives_with_delete_for(user_id).await?;
+        if !allowed.contains(&drive_id) {
+            tracing::info!(
+                target: "audit",
+                event = "trash.empty_drive_rejected",
+                reason = "no_delete_on_drive",
+                user_id = %user_id,
+                drive_id = %drive_id,
+                "👮🏻‍♂️ refused per-drive empty — caller lacks Delete on this drive",
+            );
+            return Err(DomainError::not_found("Drive", drive_id.to_string()));
+        }
+        info!("Emptying trash for drive {} (user {})", drive_id, user_id);
+        self.clear_trash_in(&[drive_id], user_id).await
+    }
+}
+
+impl TrashService {
+    /// Drives where the caller has `Permission::Delete` (via any role
+    /// bundle, direct or group-mediated). Shared by `empty_trash` and
+    /// `empty_trash_for_drive`; lifting the lookup out of both methods
+    /// keeps the two HTTP surfaces semantically consistent and avoids
+    /// duplicating the subject-expansion plumbing.
+    async fn drives_with_delete_for(&self, user_id: Uuid) -> Result<Vec<Uuid>> {
         let (subject_types, subject_ids) = self
             .authz
             .expand_subject_for_listing(Subject::User(user_id))
@@ -739,29 +779,32 @@ impl TrashUseCase for TrashService {
                     format!("Failed to resolve accessible drives: {e:?}"),
                 )
             })?;
-        let drive_ids: Vec<Uuid> = drives
+        Ok(drives
             .iter()
             .filter(|d| {
                 d.caller_role
                     .is_some_and(|r| r.expand().contains(&Permission::Delete))
             })
             .map(|d| d.drive.id)
-            .collect();
+            .collect())
+    }
 
-        if drive_ids.is_empty() {
-            info!("empty_trash: caller has Delete on no drive — nothing to do");
-            return Ok(());
-        }
-
-        // Collect ALL trashed file IDs BEFORE bulk-deleting so hooks (thumbnail
-        // cleanup, etc.) can run afterward.  We use get_all_trashed_file_ids (not
-        // get_trash_items) because the trash_items view excludes files inside a
-        // trashed folder — those files will still be deleted by clear_trash via
-        // the folder CASCADE, but their hooks would otherwise be missed.
+    /// Bulk-clear trash within the given drives, running every side
+    /// effect once: trashed-file id list (for hooks), `clear_trash`
+    /// SQL, dedup GC, content-cache invalidation, file-deleted hook.
+    /// The two `TrashUseCase` entry points compose this with their
+    /// respective drive-id scopes — call-once, no duplication.
+    async fn clear_trash_in(&self, drive_ids: &[Uuid], user_id: Uuid) -> Result<()> {
+        // Collect ALL trashed file IDs BEFORE bulk-deleting so hooks
+        // (thumbnail cleanup, etc.) can run afterward. We use
+        // `get_all_trashed_file_ids` (not `get_trash_items`) because the
+        // trash_items view excludes files inside a trashed folder —
+        // those files will still be deleted by `clear_trash` via the
+        // folder CASCADE, but their hooks would otherwise be missed.
         let trashed_file_ids: Vec<String> = if self.file_deleted_hook.is_some() {
             match self
                 .trash_repository
-                .get_all_trashed_file_ids(&drive_ids)
+                .get_all_trashed_file_ids(drive_ids)
                 .await
             {
                 Ok(ids) => ids,
@@ -781,29 +824,29 @@ impl TrashUseCase for TrashService {
         // Folder deletion cascades (FK ON DELETE CASCADE) to child folders and
         // their files. The PG trigger `trg_files_decrement_blob_ref` automatically
         // decrements blob ref_counts for every deleted file row.
-        self.trash_repository.clear_trash(&drive_ids).await?;
+        self.trash_repository.clear_trash(drive_ids).await?;
 
-        // The PG trigger decremented ref_counts but cannot delete disk files or
-        // thumbnails.  Run garbage_collect() to remove any blobs whose ref_count
-        // reached 0, along with their blob-keyed thumbnail files.
+        // The PG trigger decremented ref_counts but cannot delete disk
+        // files or thumbnails. `garbage_collect()` removes any blobs
+        // whose ref_count reached 0, along with their blob-keyed
+        // thumbnail files. Failure here is non-fatal — the rows are
+        // gone in any case; the next GC pass mops up.
         if let Err(e) = self.dedup_service.garbage_collect().await {
-            warn!("empty_trash: garbage_collect failed: {:?}", e);
+            warn!("clear_trash_in: garbage_collect failed: {:?}", e);
         }
 
-        // Invalidate content cache for all permanently deleted files.
         if let Some(cc) = &self.content_cache {
             for file_id in &trashed_file_ids {
                 cc.invalidate(file_id).await;
             }
         }
-
         if let Some(hook) = &self.file_deleted_hook {
             for file_id in &trashed_file_ids {
                 hook.on_file_deleted(file_id);
             }
         }
 
-        info!("Trash emptied for user {}", user_id);
+        info!("Trash cleared across {} drive(s) for user {}", drive_ids.len(), user_id);
         Ok(())
     }
 }

--- a/src/application/services/trash_service.rs
+++ b/src/application/services/trash_service.rs
@@ -846,7 +846,11 @@ impl TrashService {
             }
         }
 
-        info!("Trash cleared across {} drive(s) for user {}", drive_ids.len(), user_id);
+        info!(
+            "Trash cleared across {} drive(s) for user {}",
+            drive_ids.len(),
+            user_id
+        );
         Ok(())
     }
 }

--- a/src/application/services/trash_service_test.rs
+++ b/src/application/services/trash_service_test.rs
@@ -319,6 +319,14 @@ where
         // via `drive_repo.list_for_subjects` + role-bundle filter.
         self.trash_repository.clear_trash(&[user_id]).await
     }
+
+    async fn empty_trash_for_drive(&self, _user_id: Uuid, drive_id: Uuid) -> Result<()> {
+        // Test mock — uses the passed-in drive id verbatim. Production
+        // checks the caller's Delete-bearing drives first and refuses
+        // with NotFound on a mismatch; the mock skips that and just
+        // clears the given drive directly.
+        self.trash_repository.clear_trash(&[drive_id]).await
+    }
 }
 
 // Mock repositories for testing

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -906,6 +906,15 @@ pub struct FeaturesConfig {
     /// thumbnail through the same WebP pipeline as photos; otherwise videos have
     /// no thumbnail. Env: `OXICLOUD_ENABLE_VIDEO_THUMBNAILS`.
     pub enable_video_thumbnails: bool,
+    /// Expose `/api/admin/internal/*` test-only endpoints that trigger
+    /// background sweeps on demand (storage-usage reconciliation, blob
+    /// GC). Intended for Hurl / integration tests that need to wait
+    /// for these maintenance jobs deterministically rather than
+    /// polling the cached value. Off by default — these endpoints
+    /// short-circuit the operator-visible cadence, so production
+    /// deployments don't want them reachable. Env:
+    /// `OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS`.
+    pub enable_admin_internal_endpoints: bool,
 }
 
 impl Default for FeaturesConfig {
@@ -921,6 +930,10 @@ impl Default for FeaturesConfig {
             enable_faces: false,           // People/faces (biometric) — opt-in, off by default
             expose_system_users: true,     // Expose OxiCloud users as address book by default
             enable_video_thumbnails: true, // Video thumbs via ffmpeg (if detected)
+            // Test-only sweep triggers — strictly opt-in. Production
+            // deployments do NOT need this; the periodic ticker handles
+            // reconciliation transparently.
+            enable_admin_internal_endpoints: false,
         }
     }
 }
@@ -1480,6 +1493,16 @@ impl AppConfig {
             && let Ok(val) = enable_video_thumbnails
         {
             config.features.enable_video_thumbnails = val;
+        }
+
+        // `/api/admin/internal/*` test-only triggers. Disabled by
+        // default; production deployments never need this. The Hurl
+        // suite flips it on via `OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS=true`.
+        if let Ok(enable_internal) =
+            env::var("OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS").map(|v| v.parse::<bool>())
+            && let Ok(val) = enable_internal
+        {
+            config.features.enable_admin_internal_endpoints = val;
         }
 
         if let Ok(enable_faces) = env::var("OXICLOUD_ENABLE_FACES").map(|v| v.parse::<bool>())

--- a/src/common/di.rs
+++ b/src/common/di.rs
@@ -548,6 +548,16 @@ impl AppServiceFactory {
             )
             .with_content_cache(core.file_content_cache.clone())
             .with_file_lifecycle_hook(file_lifecycle.clone())
+            // `with_storage_usage_service` wires the post-write delta
+            // hook (`maybe_update_storage_usage`). Without this the
+            // hook is dead code — both per-user and per-drive
+            // `used_bytes` deltas would silently no-op and the
+            // counters drift until the next reconciliation sweep
+            // (default 10 min). `with_instant_upload` below stashes
+            // the same service under a different field used only by
+            // the dedup-instant-upload check, so they're not
+            // interchangeable.
+            .with_storage_usage_service(storage_usage.clone())
             .with_instant_upload(
                 authz.clone(),
                 core.dedup_service.clone(),

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -33,6 +33,12 @@ pub enum ErrorKind {
     DatabaseError,
     /// Storage quota exceeded
     QuotaExceeded,
+    /// State conflict — the request is well-formed and permitted, but
+    /// the resource is in a state that refuses it (e.g. "drive must
+    /// be empty before delete"). Maps to HTTP 409. Distinct from
+    /// `AlreadyExists` (which is a uniqueness violation) so audit
+    /// readers can tell them apart.
+    Conflict,
 }
 
 impl Display for ErrorKind {
@@ -48,6 +54,7 @@ impl Display for ErrorKind {
             ErrorKind::UnsupportedOperation => write!(f, "Unsupported Operation"),
             ErrorKind::DatabaseError => write!(f, "Database Error"),
             ErrorKind::QuotaExceeded => write!(f, "Quota Exceeded"),
+            ErrorKind::Conflict => write!(f, "Conflict"),
         }
     }
 }

--- a/src/domain/repositories/drive_repository.rs
+++ b/src/domain/repositories/drive_repository.rs
@@ -177,6 +177,19 @@ pub trait DriveRepository: Send + Sync + 'static {
         subject_ids: &[Uuid],
     ) -> Result<Vec<DriveWithRootName>, DriveRepositoryError>;
 
+    /// `true` when the drive holds no live (non-trashed) folders other
+    /// than its own root and no live files at all. Used by
+    /// `DriveManagementService::delete_drive` to enforce the
+    /// "empty-before-delete" rule — owners must clear / trash the
+    /// content first so a single click can't wipe a populated drive.
+    async fn is_empty(&self, drive_id: Uuid) -> Result<bool, DriveRepositoryError>;
+
+    /// Hard-delete a drive: its `role_grants` rows, its root folder,
+    /// and the drive row itself, in one transaction. Caller is
+    /// responsible for ensuring `is_empty` first; this method does
+    /// **not** re-check. Returns `NotFound` if the drive id is gone.
+    async fn delete_atomic(&self, drive_id: Uuid) -> Result<(), DriveRepositoryError>;
+
     /// List every drive on the system, regardless of caller membership.
     ///
     /// Used by the admin panel's `GET /api/admin/drives`. Distinct from

--- a/src/infrastructure/repositories/pg/drive_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/drive_pg_repository.rs
@@ -355,14 +355,13 @@ impl DriveRepository for DrivePgRepository {
         .await
         .map_err(|e| Self::map_sqlx_err("delete_atomic.grants", e))?;
 
-        let root: (Uuid,) = sqlx::query_as(
-            "SELECT root_folder_id FROM storage.drives WHERE id = $1",
-        )
-        .bind(drive_id)
-        .fetch_optional(&mut *tx)
-        .await
-        .map_err(|e| Self::map_sqlx_err("delete_atomic.lookup_root", e))?
-        .ok_or_else(|| DriveRepositoryError::NotFound(drive_id.to_string()))?;
+        let root: (Uuid,) =
+            sqlx::query_as("SELECT root_folder_id FROM storage.drives WHERE id = $1")
+                .bind(drive_id)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| Self::map_sqlx_err("delete_atomic.lookup_root", e))?
+                .ok_or_else(|| DriveRepositoryError::NotFound(drive_id.to_string()))?;
 
         sqlx::query("DELETE FROM storage.drives WHERE id = $1")
             .bind(drive_id)

--- a/src/infrastructure/repositories/pg/drive_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/drive_pg_repository.rs
@@ -303,6 +303,85 @@ impl DriveRepository for DrivePgRepository {
         Self::row_to_drive_with_name(&row)
     }
 
+    async fn is_empty(&self, drive_id: Uuid) -> Result<bool, DriveRepositoryError> {
+        // A "live" non-root folder = any folder with `parent_id IS NOT
+        // NULL` (root is the only NULL-parent row per drive) and not in
+        // the trash. Trashed items don't count — owners can delete a
+        // drive even when its trash bin still holds rows; the trash GC
+        // will clean those up after the standard retention window.
+        let count: (i64,) = sqlx::query_as(
+            r#"
+            SELECT (
+                (SELECT COUNT(*) FROM storage.folders
+                  WHERE drive_id = $1 AND parent_id IS NOT NULL AND NOT is_trashed)
+              + (SELECT COUNT(*) FROM storage.files
+                  WHERE drive_id = $1 AND NOT is_trashed)
+            )
+            "#,
+        )
+        .bind(drive_id)
+        .fetch_one(self.pool.as_ref())
+        .await
+        .map_err(|e| Self::map_sqlx_err("is_empty", e))?;
+        Ok(count.0 == 0)
+    }
+
+    async fn delete_atomic(&self, drive_id: Uuid) -> Result<(), DriveRepositoryError> {
+        // Three-statement transaction:
+        //   1. Drop every role_grants row scoped to the drive itself
+        //      (folder/file grants under it are gone by step 3 cascade).
+        //   2. Look up the root folder id (we'll need it to delete the
+        //      folder row AFTER the drive row releases its FK).
+        //   3. Delete the drive — release the drive→root FK first.
+        //   4. Delete the root folder (drive_id FK on folders cascades
+        //      from this row going away; only the root remains because
+        //      is_empty was true).
+        //
+        // `drive_id` is bound once per statement; failure at any step
+        // rolls back. Caller (`DriveManagementService::delete_drive`)
+        // is responsible for the `is_empty` precheck.
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| Self::map_sqlx_err("delete_atomic.begin", e))?;
+
+        sqlx::query(
+            "DELETE FROM storage.role_grants \
+             WHERE resource_type = 'drive' AND resource_id = $1",
+        )
+        .bind(drive_id)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| Self::map_sqlx_err("delete_atomic.grants", e))?;
+
+        let root: (Uuid,) = sqlx::query_as(
+            "SELECT root_folder_id FROM storage.drives WHERE id = $1",
+        )
+        .bind(drive_id)
+        .fetch_optional(&mut *tx)
+        .await
+        .map_err(|e| Self::map_sqlx_err("delete_atomic.lookup_root", e))?
+        .ok_or_else(|| DriveRepositoryError::NotFound(drive_id.to_string()))?;
+
+        sqlx::query("DELETE FROM storage.drives WHERE id = $1")
+            .bind(drive_id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| Self::map_sqlx_err("delete_atomic.drive", e))?;
+
+        sqlx::query("DELETE FROM storage.folders WHERE id = $1")
+            .bind(root.0)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| Self::map_sqlx_err("delete_atomic.root", e))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| Self::map_sqlx_err("delete_atomic.commit", e))?;
+        Ok(())
+    }
+
     async fn get_by_id(&self, id: Uuid) -> Result<DriveWithRootName, DriveRepositoryError> {
         let row = sqlx::query(
             r#"

--- a/src/infrastructure/services/dedup_service.rs
+++ b/src/infrastructure/services/dedup_service.rs
@@ -1912,10 +1912,7 @@ impl DedupService {
         self.garbage_collect_with_grace(0).await
     }
 
-    async fn garbage_collect_with_grace(
-        &self,
-        grace_secs: i64,
-    ) -> Result<(u64, u64), DomainError> {
+    async fn garbage_collect_with_grace(&self, grace_secs: i64) -> Result<(u64, u64), DomainError> {
         const BATCH_SIZE: i64 = 500;
 
         let mut total_deleted = 0u64;

--- a/src/infrastructure/services/dedup_service.rs
+++ b/src/infrastructure/services/dedup_service.rs
@@ -3247,6 +3247,17 @@ mod delta_upload_integration_tests {
 
     /// Store `data` through the streaming path and give `user_id` a file
     /// row referencing it — making its chunks claimable by that user.
+    ///
+    /// **Order matters.** BLAKE3 is deterministic, so the file row is
+    /// inserted BEFORE `store_from_stream` runs. This closes a race in
+    /// the shared test pool: Phase 1 of `garbage_collect()` deletes
+    /// manifests with `NOT EXISTS (file referencing it)`. With the old
+    /// order (store first, file second), a concurrent GC-invoking test
+    /// (`garbage_collect_honours_grace_window_and_references`,
+    /// `manifest_dereference_defers_chunk_reclamation_to_gc`) could
+    /// reap our manifest in the microsecond window between the two
+    /// statements, causing CI-flaky `RowNotFound` panics in producers
+    /// like `hash_chunk_sequence_recomputes_and_validates_sizes`.
     async fn seed_owned_content(
         svc: &DedupService,
         pool: &PgPool,
@@ -3255,19 +3266,7 @@ mod delta_upload_integration_tests {
         data: &[u8],
         label: &str,
     ) -> (String, Vec<String>, Uuid) {
-        let source = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::copy_from_slice(data))]);
-        let stored = svc
-            .store_from_stream(source, Some("application/octet-stream".into()))
-            .await
-            .expect("store");
-        let file_hash = stored.hash().to_string();
-        let chunks: Vec<String> = sqlx::query_scalar(
-            "SELECT UNNEST(chunk_hashes) FROM storage.chunk_manifests WHERE file_hash = $1",
-        )
-        .bind(&file_hash)
-        .fetch_all(pool)
-        .await
-        .expect("chunks");
+        let file_hash = blake3::hash(data).to_hex().to_string();
 
         let file_id: Uuid = sqlx::query_scalar(
             "INSERT INTO storage.files (name, user_id, drive_id, blob_hash, size)
@@ -3284,6 +3283,26 @@ mod delta_upload_integration_tests {
         .fetch_one(pool)
         .await
         .expect("file row");
+
+        let source = stream::iter(vec![Ok::<_, std::io::Error>(Bytes::copy_from_slice(data))]);
+        let stored = svc
+            .store_from_stream(source, Some("application/octet-stream".into()))
+            .await
+            .expect("store");
+        assert_eq!(
+            stored.hash(),
+            file_hash,
+            "pre-computed BLAKE3 must match CDC-store output"
+        );
+
+        let chunks: Vec<String> = sqlx::query_scalar(
+            "SELECT UNNEST(chunk_hashes) FROM storage.chunk_manifests WHERE file_hash = $1",
+        )
+        .bind(&file_hash)
+        .fetch_all(pool)
+        .await
+        .expect("chunks");
+
         (file_hash, chunks, file_id)
     }
 
@@ -3353,8 +3372,17 @@ mod delta_upload_integration_tests {
         let orphan = blake3::hash(format!("orphan-{}", Uuid::new_v4()).as_bytes())
             .to_hex()
             .to_string();
+        // Stamp `orphaned_at = now()` on the ref-0 row so it sits inside the
+        // GC grace window for the duration of this test. Without it,
+        // `orphaned_at IS NULL` is treated by `garbage_collect` as
+        // "pre-migration, immediately reapable" — and any sibling test in
+        // the shared pool that calls `garbage_collect()` (e.g.
+        // `garbage_collect_respects_grace_and_cross_checks`) would race
+        // with the pin below and delete the row first.
         sqlx::query(
-            "INSERT INTO storage.blobs (hash, size, ref_count) VALUES ($1, 10, 1), ($2, 10, 0)",
+            "INSERT INTO storage.blobs (hash, size, ref_count, orphaned_at) VALUES
+                ($1, 10, 1, NULL),
+                ($2, 10, 0, now())",
         )
         .bind(&foreign)
         .bind(&orphan)

--- a/src/infrastructure/services/dedup_service.rs
+++ b/src/infrastructure/services/dedup_service.rs
@@ -1895,6 +1895,27 @@ impl DedupService {
     /// The grace window and reference cross-checks together make the sweep safe
     /// against a concurrent uploader re-referencing a just-orphaned chunk.
     pub async fn garbage_collect(&self) -> Result<(u64, u64), DomainError> {
+        self.garbage_collect_with_grace(Self::GC_ORPHAN_GRACE_SECS)
+            .await
+    }
+
+    /// Test-only variant that bypasses the orphan grace window — used by
+    /// `POST /api/admin/internal/trigger-gc?force=true` so the
+    /// integration suite can reap just-orphaned blobs synchronously
+    /// (waiting out the production 1 h grace inside a test run is a
+    /// non-starter). Drops the same rows the regular sweep would, just
+    /// without the time floor. Unsafe under concurrent uploads because
+    /// it reopens the TOCTOU window the grace closes — only the
+    /// admin-internal route, itself gated by
+    /// `OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS`, may reach here.
+    pub async fn garbage_collect_force(&self) -> Result<(u64, u64), DomainError> {
+        self.garbage_collect_with_grace(0).await
+    }
+
+    async fn garbage_collect_with_grace(
+        &self,
+        grace_secs: i64,
+    ) -> Result<(u64, u64), DomainError> {
         const BATCH_SIZE: i64 = 500;
 
         let mut total_deleted = 0u64;
@@ -2001,7 +2022,7 @@ impl DedupService {
                   RETURNING hash, size",
             )
             .bind(BATCH_SIZE)
-            .bind(Self::GC_ORPHAN_GRACE_SECS as i32)
+            .bind(grace_secs as i32)
             .fetch_all(self.maintenance_pool.as_ref())
             .await
             .map_err(|e| DomainError::internal_error("Dedup", format!("GC blobs: {e}")))?;

--- a/src/infrastructure/services/dedup_service.rs
+++ b/src/infrastructure/services/dedup_service.rs
@@ -1972,6 +1972,16 @@ impl DedupService {
                     DomainError::internal_error("Dedup", format!("GC decrement chunks: {e}"))
                 })?;
 
+                // Fire the blob hooks against the **manifest's file_hash** —
+                // that's the key thumbnails are stored under (whole-file
+                // BLAKE3, not chunk hashes). Phase 2 below fires hooks for
+                // individual chunk hashes only; without this call, a
+                // CDC-chunked file's thumbnails leak on disk because the
+                // chunk-keyed hook never finds them. Symptom: orphan webp
+                // under `.thumbnails/{icon,preview,large}/<file_hash>.webp`
+                // after a user-cascade-delete of a video upload.
+                self.fire_blob_hooks(file_hash);
+
                 total_bytes += *size as u64;
                 tracing::debug!(
                     "GC: removed manifest {} ({} chunks)",

--- a/src/interfaces/api/handlers/admin_handler.rs
+++ b/src/interfaces/api/handlers/admin_handler.rs
@@ -95,6 +95,13 @@ pub fn admin_routes() -> Router<Arc<AppState>> {
         // when `OXICLOUD_SMTP_MOCK` is off, so production deployments
         // can route the path freely without leaking inboxes.
         .route("/smtp/test/captured", get(get_captured_email))
+        // Test-only sweep triggers. Routes are always registered; the
+        // handlers themselves short-circuit to 404 when
+        // `features.enable_admin_internal_endpoints` is off — matches
+        // the `/smtp/test/captured` convention so production
+        // deployments don't need a different route table.
+        .route("/internal/trigger-sweep", post(internal_trigger_sweep))
+        .route("/internal/trigger-gc", post(internal_trigger_gc))
         // Drives — admin-wide view (distinct from `/api/drives` which
         // is filtered to the caller's role grants).
         .route("/drives", get(list_all_drives))

--- a/src/interfaces/api/handlers/admin_handler.rs
+++ b/src/interfaces/api/handlers/admin_handler.rs
@@ -98,6 +98,7 @@ pub fn admin_routes() -> Router<Arc<AppState>> {
         // Drives — admin-wide view (distinct from `/api/drives` which
         // is filtered to the caller's role grants).
         .route("/drives", get(list_all_drives))
+        .route("/drives/{id}", delete(delete_drive_admin))
         .route(
             "/drives/{id}/members",
             get(list_drive_members_admin).post(add_drive_member_admin),
@@ -1953,6 +1954,43 @@ pub async fn remove_drive_member_admin(
     state
         .drive_management_service
         .remove_member(admin_id, true, drive_id, subject)
+        .await
+        .map_err(AppError::from)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /api/admin/drives/{id}` — admin-only drive delete (D3b).
+///
+/// Same shape as the user-facing `DELETE /api/drives/{id}`, but
+/// bypasses the per-drive `Manage` check (the admin guard at the
+/// route edge is the access control). The remaining invariants —
+/// default Personal drive is undeletable, drive must be empty — still
+/// apply: an admin can't accidentally wipe a populated drive or the
+/// default home folder of any user. Audit emits
+/// `drive.deleted_via_admin` on success.
+#[utoipa::path(
+    delete,
+    path = "/api/admin/drives/{id}",
+    params(("id" = Uuid, Path, description = "Drive UUID")),
+    responses(
+        (status = 204, description = "Drive deleted"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Admin required"),
+        (status = 405, description = "Default Personal drive — undeletable"),
+        (status = 409, description = "Drive is not empty"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "admin"
+)]
+pub async fn delete_drive_admin(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    axum::extract::Path(drive_id): axum::extract::Path<Uuid>,
+) -> Result<impl IntoResponse, AppError> {
+    let (admin_id, _) = admin_guard(&state, &headers).await?;
+    state
+        .drive_management_service
+        .delete_drive(admin_id, true, drive_id)
         .await
         .map_err(AppError::from)?;
     Ok(StatusCode::NO_CONTENT)

--- a/src/interfaces/api/handlers/admin_handler.rs
+++ b/src/interfaces/api/handlers/admin_handler.rs
@@ -23,6 +23,7 @@ use crate::application::dtos::settings_dto::{
 };
 use crate::application::ports::authorization_ports::AuthorizationEngine;
 use crate::application::ports::plugin_ports::{LogQuery, PluginManagementPort, PluginMgmtError};
+use crate::application::ports::storage_ports::StorageUsagePort;
 use crate::common::di::AppState;
 use crate::domain::repositories::drive_repository::DriveRepository;
 use crate::domain::services::authorization::{Resource, Subject};
@@ -2001,4 +2002,130 @@ pub async fn delete_drive_admin(
         .await
         .map_err(AppError::from)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+// ════════════════════════════════════════════════════════════════════════════
+// Test-only sweep triggers (`/api/admin/internal/*`)
+//
+// Wraps the periodic background jobs (storage-usage reconciliation,
+// blob garbage collection) behind admin-gated synchronous endpoints
+// so Hurl / integration tests can wait for them deterministically
+// rather than polling the cached value. Disabled at the handler edge
+// when `features.enable_admin_internal_endpoints == false` — match
+// the `/smtp/test/captured` convention so production deployments
+// don't need a different route table.
+// ════════════════════════════════════════════════════════════════════════════
+
+/// Refusal when the test-only endpoints are disabled. Returns 404
+/// rather than 403 to avoid leaking the route's existence (and the
+/// corresponding config flag) to an unauthenticated probe — the
+/// legitimate test runner sets the env explicitly.
+fn internal_endpoints_disabled() -> axum::response::Response {
+    use axum::response::IntoResponse;
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({ "error": "endpoint not available" })),
+    )
+        .into_response()
+}
+
+/// `POST /api/admin/internal/trigger-sweep` — run the storage-usage
+/// reconciliation sweep synchronously.
+///
+/// Test-only. Recomputes `users.storage_used_bytes` and
+/// `drives.used_bytes` from `SUM(size) WHERE NOT is_trashed`, in the
+/// same set-based UPDATEs the periodic ticker runs. Used by Hurl
+/// suites that need to assert post-delete quota convergence without
+/// waiting out the sweep interval (default 600 s).
+#[utoipa::path(
+    post,
+    path = "/api/admin/internal/trigger-sweep",
+    responses(
+        (status = 200, description = "Sweep ran"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Admin required"),
+        (status = 404, description = "Endpoint disabled (set OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS=true)"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "admin"
+)]
+pub async fn internal_trigger_sweep(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    if !state.core.config.features.enable_admin_internal_endpoints {
+        return internal_endpoints_disabled();
+    }
+    if let Err(e) = admin_guard(&state, &headers).await {
+        return e.into_response();
+    }
+    let svc = match state.storage_usage_service.as_ref() {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "storage_usage_service not available",
+                })),
+            )
+                .into_response();
+        }
+    };
+    if let Err(e) = svc.update_all_users_storage_usage().await {
+        return AppError::internal_error(format!("user sweep failed: {e}")).into_response();
+    }
+    if let Err(e) = svc.update_all_drives_storage_usage().await {
+        return AppError::internal_error(format!("drive sweep failed: {e}")).into_response();
+    }
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({ "ok": true, "ran": ["users", "drives"] })),
+    )
+        .into_response()
+}
+
+/// `POST /api/admin/internal/trigger-gc` — run the blob garbage
+/// collector synchronously.
+///
+/// Test-only. Drops `file_blobs` rows with `ref_count = 0` (subject
+/// to the orphan-grace window) and their on-disk content. Same call
+/// as the inline post-purge GC and the periodic blob-GC sweep — just
+/// exposed under an admin route so Hurl can wait for it
+/// deterministically.
+#[utoipa::path(
+    post,
+    path = "/api/admin/internal/trigger-gc",
+    responses(
+        (status = 200, description = "GC ran"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Admin required"),
+        (status = 404, description = "Endpoint disabled (set OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS=true)"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "admin"
+)]
+pub async fn internal_trigger_gc(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    if !state.core.config.features.enable_admin_internal_endpoints {
+        return internal_endpoints_disabled();
+    }
+    if let Err(e) = admin_guard(&state, &headers).await {
+        return e.into_response();
+    }
+    match state.core.dedup_service.garbage_collect().await {
+        Ok((blobs_deleted, bytes_freed)) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "ok": true,
+                "blobs_deleted": blobs_deleted,
+                "bytes_freed": bytes_freed,
+            })),
+        )
+            .into_response(),
+        Err(e) => AppError::internal_error(format!("gc failed: {e}")).into_response(),
+    }
 }

--- a/src/interfaces/api/handlers/admin_handler.rs
+++ b/src/interfaces/api/handlers/admin_handler.rs
@@ -2085,6 +2085,22 @@ pub async fn internal_trigger_sweep(
         .into_response()
 }
 
+/// Query parameters for `POST /api/admin/internal/trigger-gc`.
+///
+/// `force=true` bypasses the orphan-grace window so the sweep reaps
+/// just-orphaned blobs in the same call. Without this, a blob orphaned
+/// less than `GC_ORPHAN_GRACE_SECS` (1 h) ago survives the sweep — the
+/// grace exists so a concurrent uploader pinning a just-orphaned chunk
+/// can't race the row-delete → file-unlink gap. Integration tests
+/// don't have concurrent uploaders, so the test runner sets
+/// `force=true` to make the sweep deterministic within a test's
+/// runtime.
+#[derive(Debug, serde::Deserialize, Default)]
+pub struct InternalTriggerGcQuery {
+    #[serde(default)]
+    pub force: bool,
+}
+
 /// `POST /api/admin/internal/trigger-gc` — run the blob garbage
 /// collector synchronously.
 ///
@@ -2092,10 +2108,12 @@ pub async fn internal_trigger_sweep(
 /// to the orphan-grace window) and their on-disk content. Same call
 /// as the inline post-purge GC and the periodic blob-GC sweep — just
 /// exposed under an admin route so Hurl can wait for it
-/// deterministically.
+/// deterministically. Add `?force=true` to bypass the grace window —
+/// see [`InternalTriggerGcQuery`].
 #[utoipa::path(
     post,
     path = "/api/admin/internal/trigger-gc",
+    params(("force" = Option<bool>, Query, description = "Bypass the orphan-grace window (test-only)")),
     responses(
         (status = 200, description = "GC ran"),
         (status = 401, description = "Unauthorized"),
@@ -2108,6 +2126,7 @@ pub async fn internal_trigger_sweep(
 pub async fn internal_trigger_gc(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
+    Query(query): Query<InternalTriggerGcQuery>,
 ) -> axum::response::Response {
     use axum::response::IntoResponse;
     if !state.core.config.features.enable_admin_internal_endpoints {
@@ -2116,13 +2135,19 @@ pub async fn internal_trigger_gc(
     if let Err(e) = admin_guard(&state, &headers).await {
         return e.into_response();
     }
-    match state.core.dedup_service.garbage_collect().await {
+    let result = if query.force {
+        state.core.dedup_service.garbage_collect_force().await
+    } else {
+        state.core.dedup_service.garbage_collect().await
+    };
+    match result {
         Ok((blobs_deleted, bytes_freed)) => (
             StatusCode::OK,
             Json(serde_json::json!({
                 "ok": true,
                 "blobs_deleted": blobs_deleted,
                 "bytes_freed": bytes_freed,
+                "forced": query.force,
             })),
         )
             .into_response(),

--- a/src/interfaces/api/handlers/chunked_upload_handler.rs
+++ b/src/interfaces/api/handlers/chunked_upload_handler.rs
@@ -214,8 +214,39 @@ impl ChunkedUploadHandler {
                 .await
         {
             tracing::warn!(
-                "⛔ CHUNKED UPLOAD REJECTED (quota): user={}, file={}, size={} — {}",
+                "⛔ CHUNKED UPLOAD REJECTED (user quota): user={}, file={}, size={} — {}",
                 auth_user.username,
+                request.filename,
+                request.total_size,
+                err.message
+            );
+            return (
+                StatusCode::INSUFFICIENT_STORAGE,
+                Json(serde_json::json!({
+                    "error": err.message,
+                    "error_type": "QuotaExceeded"
+                })),
+            )
+                .into_response();
+        }
+
+        // ── Per-drive quota (D4) ─────────────────────────────────
+        // Native-chunked declares `total_size` at session creation,
+        // so we can refuse here before any chunk is accepted — same
+        // wasted-bandwidth optimisation the multipart path has via
+        // the post-ingest check. No folder_id means root-level which
+        // the folder-permission check above already rejects.
+        if let Some(storage_svc) = state.storage_usage_service.as_ref()
+            && let Some(fid_str) = request.folder_id.as_deref()
+            && let Ok(fid) = uuid::Uuid::parse_str(fid_str)
+            && let Err(err) = storage_svc
+                .check_drive_quota_by_folder(fid, request.total_size)
+                .await
+        {
+            tracing::warn!(
+                "⛔ CHUNKED UPLOAD REJECTED (drive quota): user={}, folder={}, file={}, size={} — {}",
+                auth_user.username,
+                fid,
                 request.filename,
                 request.total_size,
                 err.message

--- a/src/interfaces/api/handlers/drive_handler.rs
+++ b/src/interfaces/api/handlers/drive_handler.rs
@@ -356,3 +356,42 @@ pub async fn remove_drive_member(
         Err(e) => AppError::from(e).into_response(),
     }
 }
+
+/// `DELETE /api/drives/{id}` — Owner-only deletion (D3b).
+///
+/// Refuses (per `DriveManagementService::delete_drive`):
+/// - `404` when the caller lacks Manage on the drive (anti-enum).
+/// - `405` when the drive is the user's default Personal drive.
+/// - `409` when the drive still holds live folders/files; the caller
+///   must trash or move them first.
+///
+/// On success the drive row, its root folder, and every role grant
+/// scoped to the drive are removed in one transaction; cached drive
+/// roles are invalidated.
+#[utoipa::path(
+    delete,
+    path = "/api/drives/{id}",
+    params(("id" = Uuid, Path, description = "Drive UUID")),
+    responses(
+        (status = 204, description = "Drive deleted"),
+        (status = 404, description = "Drive not found or caller lacks Manage"),
+        (status = 405, description = "Default Personal drive — undeletable"),
+        (status = 409, description = "Drive is not empty — move/trash contents first"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "drives"
+)]
+pub async fn delete_drive(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Path(drive_id): Path<Uuid>,
+) -> impl IntoResponse {
+    match state
+        .drive_management_service
+        .delete_drive(auth_user.id, false, drive_id)
+        .await
+    {
+        Ok(()) => StatusCode::NO_CONTENT.into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}

--- a/src/interfaces/api/handlers/file_handler.rs
+++ b/src/interfaces/api/handlers/file_handler.rs
@@ -267,8 +267,33 @@ impl FileHandler {
                 {
                     upload_ingest::discard_ingested(dedup, &ingested).await;
                     tracing::warn!(
-                        "⛔ UPLOAD REJECTED (quota): user={}, file={}, size={}",
+                        "⛔ UPLOAD REJECTED (user quota): user={}, file={}, size={}",
                         auth_user.username,
+                        filename,
+                        ingested.size
+                    );
+                    return Err(Self::quota_error_response(err));
+                }
+
+                // ── Per-drive quota enforcement (D4) ─────────────────
+                // Sibling to the per-user check above: same read-only
+                // SELECT shape, same discard-then-507 outcome. Skipped
+                // when there's no folder_id (root-level upload — no
+                // drive to charge; folder service refuses these
+                // independently). Unlimited-quota drives (`NULL`)
+                // short-circuit inside the service.
+                if let Some(storage_svc) = state.storage_usage_service.as_ref()
+                    && let Some(fid_str) = folder_id.as_deref()
+                    && let Ok(fid) = uuid::Uuid::parse_str(fid_str)
+                    && let Err(err) = storage_svc
+                        .check_drive_quota_by_folder(fid, ingested.size)
+                        .await
+                {
+                    upload_ingest::discard_ingested(dedup, &ingested).await;
+                    tracing::warn!(
+                        "⛔ UPLOAD REJECTED (drive quota): user={}, folder={}, file={}, size={}",
+                        auth_user.username,
+                        fid,
                         filename,
                         ingested.size
                     );

--- a/src/interfaces/api/handlers/trash_handler.rs
+++ b/src/interfaces/api/handlers/trash_handler.rs
@@ -405,3 +405,61 @@ pub async fn empty_trash(
         }
     }
 }
+
+/// `DELETE /api/trash/drive/{drive_id}` — per-drive empty trash.
+///
+/// Same destructive shape as the all-drives `DELETE /api/trash`, but
+/// scoped to a single drive the caller can Delete in. Used by the
+/// `/trash` page's Drive group-by, which exposes a per-row "Empty"
+/// affordance so multi-drive owners don't have to wipe everything at
+/// once.
+///
+/// Refused with `404` (anti-enum) when the caller has no Delete-bearing
+/// role on the named drive — the user-facing drive listing would emit
+/// the same shape for an unknown id.
+#[utoipa::path(
+    delete,
+    path = "/api/trash/drive/{drive_id}",
+    params(("drive_id" = Uuid, Path, description = "Drive UUID")),
+    responses(
+        (status = 200, description = "Drive trash emptied successfully"),
+        (status = 404, description = "Caller lacks Delete on this drive"),
+        (status = 501, description = "Trash feature not enabled"),
+    ),
+    security(("bearerAuth" = [])),
+    tag = "trash"
+)]
+#[instrument(skip_all)]
+pub async fn empty_trash_for_drive(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Path(drive_id): Path<uuid::Uuid>,
+) -> impl IntoResponse {
+    debug!(
+        "Request to empty trash for drive {} by user {}",
+        drive_id, auth_user.id
+    );
+
+    let trash_service = match state.trash_service.as_ref() {
+        Some(service) => service,
+        None => {
+            return (
+                StatusCode::NOT_IMPLEMENTED,
+                Json(json!({ "error": "Trash feature is not enabled" })),
+            )
+                .into_response();
+        }
+    };
+
+    match trash_service
+        .empty_trash_for_drive(auth_user.id, drive_id)
+        .await
+    {
+        Ok(_) => (
+            StatusCode::OK,
+            Json(json!({ "success": true, "drive_id": drive_id })),
+        )
+            .into_response(),
+        Err(e) => AppError::from(e).into_response(),
+    }
+}

--- a/src/interfaces/api/routes.rs
+++ b/src/interfaces/api/routes.rs
@@ -426,6 +426,10 @@ pub fn create_api_routes(app_state: &Arc<AppState>) -> Router<Arc<AppState>> {
                 get(drive_handler::list_drives).post(drive_handler::create_drive),
             )
             .route(
+                "/{id}",
+                axum::routing::delete(drive_handler::delete_drive),
+            )
+            .route(
                 "/{id}/members",
                 get(drive_handler::list_drive_members).post(drive_handler::add_drive_member),
             )

--- a/src/interfaces/api/routes.rs
+++ b/src/interfaces/api/routes.rs
@@ -469,6 +469,13 @@ pub fn create_api_routes(app_state: &Arc<AppState>) -> Router<Arc<AppState>> {
             // when a wildcard like /{id} could otherwise capture them.
             .route("/resources", get(trash_handler::get_trash_resources))
             .route("/empty", delete(trash_handler::empty_trash))
+            // Per-drive empty (D2b stage 4 / per-drive UX). Scoped
+            // empty of one drive's trash; refused 404 when the caller
+            // lacks Delete on the named drive.
+            .route(
+                "/drive/{drive_id}",
+                delete(trash_handler::empty_trash_for_drive),
+            )
             .route("/files/{id}", delete(trash_handler::move_file_to_trash))
             .route("/folders/{id}", delete(trash_handler::move_folder_to_trash))
             .route("/{id}/restore", post(trash_handler::restore_from_trash))

--- a/src/interfaces/api/routes.rs
+++ b/src/interfaces/api/routes.rs
@@ -425,10 +425,7 @@ pub fn create_api_routes(app_state: &Arc<AppState>) -> Router<Arc<AppState>> {
                 "/",
                 get(drive_handler::list_drives).post(drive_handler::create_drive),
             )
-            .route(
-                "/{id}",
-                axum::routing::delete(drive_handler::delete_drive),
-            )
+            .route("/{id}", axum::routing::delete(drive_handler::delete_drive))
             .route(
                 "/{id}/members",
                 get(drive_handler::list_drive_members).post(drive_handler::add_drive_member),

--- a/src/interfaces/errors.rs
+++ b/src/interfaces/errors.rs
@@ -125,6 +125,7 @@ impl From<DomainError> for AppError {
             ErrorKind::UnsupportedOperation => StatusCode::METHOD_NOT_ALLOWED,
             ErrorKind::DatabaseError => StatusCode::INTERNAL_SERVER_ERROR,
             ErrorKind::QuotaExceeded => StatusCode::INSUFFICIENT_STORAGE,
+            ErrorKind::Conflict => StatusCode::CONFLICT,
         };
 
         Self {

--- a/tests/api/drive_quota.hurl
+++ b/tests/api/drive_quota.hurl
@@ -302,8 +302,7 @@ jsonpath "$.blobs_deleted" exists
 jsonpath "$.bytes_freed" exists
 
 
-# No cleanup — the API test runner (`tests/api/run.sh`) starts each
-# run against a fresh postgres + server, so dangling drives /
-# trashed rows don't leak across runs. Self-contained user/drive
-# names (`dq_*`) also prevent collisions when running alongside the
-# rest of the suite within a single boot.
+# No cleanup tail here — `tests/api/storage_cleanup_check.sh` enumerates
+# every drive via `GET /api/admin/drives` and drains+deletes any that
+# isn't admin's default. This keeps individual Hurl tests focused on
+# their assertions instead of teardown.

--- a/tests/api/drive_quota.hurl
+++ b/tests/api/drive_quota.hurl
@@ -1,0 +1,309 @@
+# =============================================================
+# OxiCloud — D4 per-drive quota enforcement
+# =============================================================
+# Pins the upload-time per-drive quota refusal. Scope:
+#
+#   1. Quota = 100 B on a shared drive; uploading a 5 MiB file →
+#      `507 Insufficient Storage`. Refusal happens BEFORE the file
+#      row is registered (no orphan blob, no usage drift).
+#   2. A small file (32 B) under the same quota → `201`. The fire-
+#      and-forget delta hook bumps `drives.used_bytes`; the next
+#      `GET /api/drives` lists the new value.
+#   3. After consuming most of the quota, a second small file that
+#      would push us over → `507`. Confirms the check uses the
+#      cached `used_bytes`, not just file size in isolation.
+#   4. Unlimited quota (`quota_bytes` omitted at create) accepts the
+#      same 5 MiB upload that case 1 refused → `201`.
+#   5. Per-user quota is unaffected — uploading to the user's own
+#      default Personal drive (no per-drive cap) still works.
+#
+# The check is layered on top of the existing per-user quota
+# (`storage_usage_service::check_storage_quota`) — both run at the
+# multipart handler; either refusal yields 507.
+#
+# Self-contained: provisions `dq_owner` and a fresh shared drive
+# per case so this can run alongside the rest of the API suite.
+# =============================================================
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 1 — Admin login.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "{{username}}", "password": "{{password}}" }
+
+HTTP 200
+[Captures]
+admin_token: jsonpath "$.access_token"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 2 — Provision `dq_owner` (drive owner under test).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/admin/users
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "username": "dq_owner",
+  "password": "DqOwnerPwd1!",
+  "email":    "dq_owner@example.com",
+  "role":     "user"
+}
+
+HTTP 201
+
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "dq_owner", "password": "DqOwnerPwd1!" }
+
+HTTP 200
+[Captures]
+owner_token: jsonpath "$.access_token"
+owner_user_id: jsonpath "$.user.id"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 3 — Admin creates a shared drive with a tiny 100-byte quota
+#          and `dq_owner` as direct user-Owner.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "dq-tight",
+  "owner": { "type": "user", "id": "{{owner_user_id}}" },
+  "quota_bytes": 100
+}
+
+HTTP 201
+[Captures]
+tight_drive_id: jsonpath "$.id"
+tight_root_id:  jsonpath "$.root_folder_id"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 4 — Case 1: 5 MiB upload to the 100-byte drive → 507.
+#          Refused at the multipart handler before the file row is
+#          registered; the blob is discarded by `discard_ingested`.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/files/upload
+Authorization: Bearer {{owner_token}}
+[MultipartFormData]
+folder_id: {{tight_root_id}}
+file: file,fixtures/chunk-over-cap-5mb.bin; application/octet-stream
+
+HTTP 507
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 5 — Case 2: 32-byte upload fits under the 100-byte cap.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/files/upload
+Authorization: Bearer {{owner_token}}
+[MultipartFormData]
+folder_id: {{tight_root_id}}
+file: file,fixtures/hello.txt; text/plain
+
+HTTP 201
+[Captures]
+small_file_id: jsonpath "$.id"
+
+
+# Confirm `drives.used_bytes` reflects the new file. The hook is
+# fire-and-forget on a tokio task, so the SQL UPDATE may not have
+# landed by the time `POST /api/files/upload` returned. Retry the
+# `GET /api/drives` until the cached value catches up — bounded
+# wait keeps a slow CI machine from flaking.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{owner_token}}
+[Options]
+retry: 10
+retry-interval: 200ms
+
+HTTP 200
+[Asserts]
+jsonpath "$[?(@.id=='{{tight_drive_id}}')].used_bytes" == 32
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 6 — Case 3: a SECOND small file that would push usage past
+#          the cap is refused. With `hello.txt` at 32 bytes already
+#          on the drive, the next 32-byte upload projects to
+#          32 + 32 + 32 (header overhead negligible) — far under
+#          100 — and IS accepted. Then a 5 MiB upload remains over
+#          quota: 507. This protects the "uses cached used_bytes"
+#          invariant: the check isn't just `size < quota`.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/files/upload
+Authorization: Bearer {{owner_token}}
+[MultipartFormData]
+folder_id: {{tight_root_id}}
+file: file,fixtures/hello-copy.txt; text/plain
+
+HTTP 201
+
+
+# `used_bytes` climbs to 64 (32 + 32). Same retry shape as the
+# first assertion since the second delta is also fire-and-forget.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{owner_token}}
+[Options]
+retry: 10
+retry-interval: 200ms
+
+HTTP 200
+[Asserts]
+jsonpath "$[?(@.id=='{{tight_drive_id}}')].used_bytes" == 64
+
+
+# The fire-and-forget delta hook updates `drives.used_bytes`; the
+# subsequent 5 MiB attempt still fails (5 MiB > 100 alone). This
+# assertion holds regardless of whether the previous delta has
+# landed in cache or not — `5_242_880 > 100` either way.
+POST {{base_url}}/api/files/upload
+Authorization: Bearer {{owner_token}}
+[MultipartFormData]
+folder_id: {{tight_root_id}}
+file: file,fixtures/chunk-over-cap-5mb.bin; application/octet-stream
+
+HTTP 507
+
+
+# `used_bytes` is unchanged — the failed upload didn't charge the
+# drive. (Cumulative usage is still 64; the 5 MiB write never
+# registered a row.)
+GET {{base_url}}/api/drives
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$[?(@.id=='{{tight_drive_id}}')].used_bytes" == 64
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 7 — Case 4: unlimited drive accepts the same 5 MiB upload.
+#          Confirms the `quota_bytes IS NULL` short-circuit.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "dq-unlimited",
+  "owner": { "type": "user", "id": "{{owner_user_id}}" }
+}
+
+HTTP 201
+[Captures]
+unlimited_root_id: jsonpath "$.root_folder_id"
+unlimited_drive_id: jsonpath "$.id"
+
+
+POST {{base_url}}/api/files/upload
+Authorization: Bearer {{owner_token}}
+[MultipartFormData]
+folder_id: {{unlimited_root_id}}
+file: file,fixtures/chunk-over-cap-5mb.bin; application/octet-stream
+
+HTTP 201
+
+
+# Unlimited drive's `used_bytes` climbs to the file's exact size
+# (5 MiB = 5_242_880 bytes). Same retry block because the delta
+# hook is fire-and-forget here too.
+GET {{base_url}}/api/drives
+Authorization: Bearer {{owner_token}}
+[Options]
+retry: 10
+retry-interval: 200ms
+
+HTTP 200
+[Asserts]
+jsonpath "$[?(@.id=='{{unlimited_drive_id}}')].used_bytes" == 5242880
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 9 — Post-delete sweep convergence.
+#          By design the per-drive `used_bytes` counter is NOT
+#          decremented on permanent delete (mirrors the existing
+#          per-user quota design: deletes drift, the periodic sweep
+#          reconciles). To prove the sweep actually closes the
+#          drift, we:
+#            a) Trash the 32-byte file in the unlimited drive
+#               (well, both: hello.txt + hello-copy.txt are in the
+#               tight drive; the 5 MiB is in the unlimited one).
+#            b) Permanently delete via empty-trash.
+#            c) Trigger the reconciliation sweep on demand —
+#               `/api/admin/internal/trigger-sweep` is gated by
+#               `OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS=true`
+#               (set in `tests/common/server.env`).
+#            d) `GET /api/drives` now shows the corrected counter.
+# ─────────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/files/{{small_file_id}}
+Authorization: Bearer {{owner_token}}
+
+HTTP 204
+
+
+# Permanent purge — empty caller's trash entirely.
+DELETE {{base_url}}/api/trash/empty
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+
+
+# Sweep is fire-and-forget on a ticker (default 600 s). Run it now
+# so the assertion below is deterministic instead of polling.
+POST {{base_url}}/api/admin/internal/trigger-sweep
+Authorization: Bearer {{admin_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.ok" == true
+
+
+# After the sweep, `tight_drive.used_bytes` has dropped from 64 to
+# 32 (hello.txt purged, hello-copy.txt still live). `unlimited`
+# stays at 5 MiB (nothing trashed there).
+GET {{base_url}}/api/drives
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$[?(@.id=='{{tight_drive_id}}')].used_bytes" == 32
+jsonpath "$[?(@.id=='{{unlimited_drive_id}}')].used_bytes" == 5242880
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 10 — `/api/admin/internal/*` is admin-only and disabled by
+#          default. The gate-off case is covered by the absence of
+#          the route in production configs; here we just confirm a
+#          non-admin caller is refused even when the feature is on.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/admin/internal/trigger-sweep
+Authorization: Bearer {{owner_token}}
+
+HTTP 403
+
+
+# Trigger-GC reachable too — assert it returns the freed-blob
+# summary shape. Hard count is non-deterministic (depends on the
+# grace window vs the test's elapsed time), so we only check the
+# response shape.
+POST {{base_url}}/api/admin/internal/trigger-gc
+Authorization: Bearer {{admin_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.ok" == true
+jsonpath "$.blobs_deleted" exists
+jsonpath "$.bytes_freed" exists
+
+
+# No cleanup — the API test runner (`tests/api/run.sh`) starts each
+# run against a fresh postgres + server, so dangling drives /
+# trashed rows don't leak across runs. Self-contained user/drive
+# names (`dq_*`) also prevent collisions when running alongside the
+# rest of the suite within a single boot.

--- a/tests/api/drives_membership.hurl
+++ b/tests/api/drives_membership.hurl
@@ -734,6 +734,8 @@ Content-Type: application/json
 }
 
 HTTP 201
+[Captures]
+editor_created_folder_id: jsonpath "$.id"
 [Asserts]
 jsonpath "$.name" == "editor-created-folder"
 
@@ -813,3 +815,75 @@ GET {{base_url}}/api/drives/{{team_drive_id}}/members
 Authorization: Bearer {{dave_token}}
 
 HTTP 404
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 30 — Drive delete (D3b).
+#           - Non-Owner → 404 (Bob is Viewer post-Step 28).
+#           - Owner on non-empty drive → 409 (the editor-created-folder
+#             from Step 27 is still live).
+#           - Owner after the folder is trashed → 204.
+#           Personal-drive refusal (default_for_user IS NOT NULL) is
+#           covered separately — `mbr_dave` keeps his default drive,
+#           we exercise its 405 below.
+# ─────────────────────────────────────────────────────────────
+
+# 30a — Viewer (Bob) cannot delete the drive → 404, anti-enum same as
+#       the member-mutation refusals.
+DELETE {{base_url}}/api/drives/{{team_drive_id}}
+Authorization: Bearer {{bob_token}}
+
+HTTP 404
+
+
+# 30b — Owner (Alice) on a non-empty drive → 409 with the canonical
+#       "drive_not_empty" reason in the audit log.
+DELETE {{base_url}}/api/drives/{{team_drive_id}}
+Authorization: Bearer {{alice_token}}
+
+HTTP 409
+
+
+# 30c — Clear the lingering content (the Editor-created folder from
+#       Step 27). Delete via the regular folder endpoint so the row
+#       lands in trash, not the live tree; `is_empty` excludes
+#       trashed rows so a populated trash bin is allowed.
+DELETE {{base_url}}/api/folders/{{editor_created_folder_id}}
+Authorization: Bearer {{alice_token}}
+
+HTTP 204
+
+
+# 30d — Owner on an empty drive → 204.
+DELETE {{base_url}}/api/drives/{{team_drive_id}}
+Authorization: Bearer {{alice_token}}
+
+HTTP 204
+
+
+# 30e — Drive is gone; subsequent reads return 404.
+GET {{base_url}}/api/drives/{{team_drive_id}}/members
+Authorization: Bearer {{alice_token}}
+
+HTTP 404
+
+
+# 30f — Default Personal drive — Dave's home — cannot be deleted.
+#       Look up the drive id via the picker listing. Dave is a fresh
+#       user and only has his default personal drive, so `$[0].id`
+#       is unambiguous. (Avoiding the `[?(...)]` filter — Hurl
+#       collapses single-match results to a scalar, which breaks
+#       `nth` / list-style assertions; see memory.)
+GET {{base_url}}/api/drives
+Authorization: Bearer {{dave_token}}
+
+HTTP 200
+[Captures]
+dave_default_drive_id: jsonpath "$[0].id"
+[Asserts]
+jsonpath "$[0].default_for_user" == "{{dave_user_id}}"
+
+DELETE {{base_url}}/api/drives/{{dave_default_drive_id}}
+Authorization: Bearer {{dave_token}}
+
+HTTP 405

--- a/tests/api/run.sh
+++ b/tests/api/run.sh
@@ -160,7 +160,8 @@ hurl --variables-file "$API_DIR/test.env" --file-root "$REPO_ROOT/tests" --test 
   "$API_DIR/admin_user_ops.hurl" \
   "$API_DIR/chunked_upload_cap.hurl" \
   "$API_DIR/nc_auth_failures.hurl" \
-  "$API_DIR/dedup_create.hurl"
+  "$API_DIR/dedup_create.hurl" \
+  "$API_DIR/trash_per_drive.hurl"
 
 #bash "$API_DIR/dedup_bulk_upload.sh"
 

--- a/tests/api/run.sh
+++ b/tests/api/run.sh
@@ -161,7 +161,8 @@ hurl --variables-file "$API_DIR/test.env" --file-root "$REPO_ROOT/tests" --test 
   "$API_DIR/chunked_upload_cap.hurl" \
   "$API_DIR/nc_auth_failures.hurl" \
   "$API_DIR/dedup_create.hurl" \
-  "$API_DIR/trash_per_drive.hurl"
+  "$API_DIR/trash_per_drive.hurl" \
+  "$API_DIR/drive_quota.hurl"
 
 #bash "$API_DIR/dedup_bulk_upload.sh"
 

--- a/tests/api/storage_cleanup_check.sh
+++ b/tests/api/storage_cleanup_check.sh
@@ -95,6 +95,80 @@ done <<< "$OTHER_USER_IDS"
 
 log "Deleted $OTHER_USER_COUNT non-admin user(s) created by tests."
 
+# ── 1d. Drain every non-default drive ─────────────────────────────────────────
+#
+# Hurl tests that create shared drives (or future secondary personal
+# drives) for OTHER users can leave them dangling: file rows in those
+# drives carry `user_id = <root_folder.user_id>` — which is the admin
+# who CREATED the drive, not the uploader — so the legacy
+# `storage.files.user_id` FK CASCADE we leaned on above does NOT reach
+# them when the test user is deleted. The drive + its content stays
+# live → blobs stay referenced → garbage_collect() leaves them on
+# disk → the leftover-detector at the end of this script fails.
+#
+# Strategy: enumerate every drive via the admin-wide listing, grant
+# admin Owner role on each non-default drive (admin-bypass route from
+# D2a), then walk the drive's root via the regular Owner-side
+# endpoints, trash everything, empty per-drive trash, and delete the
+# drive itself. With the drive gone, its blobs lose all references
+# and the force-GC at the end of the script reaps them.
+#
+# Skipped: the admin's OWN default-personal drive — that's drained
+# above by the existing `/api/folders` loop.
+
+ADMIN_DRIVE_IDS=$(curl -sf -H "$AUTH" "$base_url/api/admin/drives" \
+    | jq -r --arg admin_id "$ADMIN_USER_ID" \
+        '.[] | select(.default_for_user != $admin_id) | .id')
+
+DRAINED_DRIVES=0
+while IFS= read -r drive_id; do
+    [[ -z "$drive_id" ]] && continue
+
+    # Drive metadata — we need the root_folder_id to drain its content.
+    DRIVE_META=$(curl -sf -H "$AUTH" "$base_url/api/admin/drives" \
+                    | jq --arg id "$drive_id" '.[] | select(.id == $id)')
+    DRIVE_ROOT=$(echo "$DRIVE_META" | jq -r '.root_folder_id')
+    DRIVE_NAME=$(echo "$DRIVE_META" | jq -r '.name')
+
+    # Grant admin Owner on the drive (admin-bypass — `caller_is_admin =
+    # true` skips the `Manage` precheck so we don't need to already
+    # have a role). Idempotent: if admin is already Owner, the call
+    # refreshes the role.
+    curl -sf -X POST -H "$AUTH" -H "Content-Type: application/json" \
+        -d "{\"subject\":{\"type\":\"user\",\"id\":\"$ADMIN_USER_ID\"},\"role\":\"owner\"}" \
+        "$base_url/api/admin/drives/$drive_id/members" >/dev/null \
+        || fail "could not grant admin Owner on drive $drive_id ($DRIVE_NAME)"
+
+    # Now drain the drive's root through the regular user-facing
+    # endpoints. Admin is Owner → Read passes.
+    CONTENTS=$(curl -sf -H "$AUTH" "$base_url/api/folders/$DRIVE_ROOT/resources?limit=500")
+
+    while IFS= read -r sub_id; do
+        [[ -z "$sub_id" ]] && continue
+        curl -sf -X DELETE -H "$AUTH" "$base_url/api/folders/$sub_id" >/dev/null
+    done < <(echo "$CONTENTS" | jq -r '.items[] | select(.resource_type == "folder") | .resource.id')
+
+    while IFS= read -r file_id; do
+        [[ -z "$file_id" ]] && continue
+        curl -sf -X DELETE -H "$AUTH" "$base_url/api/files/$file_id" >/dev/null
+    done < <(echo "$CONTENTS" | jq -r '.items[] | select(.resource_type == "file") | .resource.id')
+
+    # Empty the drive's per-drive trash so D3b's "drive must be empty"
+    # guard passes on the delete. `/api/trash/drive/{id}` is the
+    # Owner-only per-drive empty (admin is Owner now via the grant
+    # above).
+    curl -sf -X DELETE -H "$AUTH" "$base_url/api/trash/drive/$drive_id" >/dev/null \
+        || fail "could not empty trash on drive $drive_id ($DRIVE_NAME)"
+
+    # Delete the drive itself via the admin-bypass DELETE.
+    curl -sf -X DELETE -H "$AUTH" "$base_url/api/admin/drives/$drive_id" >/dev/null \
+        || fail "could not delete drive $drive_id ($DRIVE_NAME)"
+
+    DRAINED_DRIVES=$((DRAINED_DRIVES + 1))
+done <<< "$ADMIN_DRIVE_IDS"
+
+log "Drained + deleted $DRAINED_DRIVES non-default drive(s)."
+
 # ── 2. Move all live files and folders to trash ───────────────────────────────
 #
 # For each root folder, list its direct children and soft-delete them.

--- a/tests/api/storage_cleanup_check.sh
+++ b/tests/api/storage_cleanup_check.sh
@@ -13,19 +13,6 @@
 #   bash tests/api/storage_cleanup_check.sh
 # =============================================================
 
-cat <<EOF
-
-XXX
-
- storage_cleanup_check.sh is disabled due to GC strategy change
-
-  may need to add an admin api call to trigger the GC and validate the correct cleanup of resources
-
-XXX
-EOF
-
-exit 0
-
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -116,18 +103,41 @@ log "Deleted $OTHER_USER_COUNT non-admin user(s) created by tests."
 
 ROOT_FOLDERS=$(curl -sf -H "$AUTH" "$base_url/api/folders" | jq -r '.[].id')
 
+# `/api/folders/{id}/resources` superseded the legacy `/listing` route
+# (commit 5790a145). Response shape:
+#   { "items": [ { "resource_type": "folder"|"file",
+#                  "resource": { "id": "<uuid>", … } } ],
+#     "next_cursor": "…" }
+# We trash one level deep — the server cascades into children.
+#
+# `GET /api/folders` (root listing) still uses the legacy
+# `user_id`-keyed query, so it can surface folders the admin
+# *created* but doesn't have a role on (e.g. shared drives spawned by
+# `drive_quota.hurl` for other users). Those return 404 on
+# `/resources` (no Read in the role bundle). Skip them — they aren't
+# admin's content to drain.
 for folder_id in $ROOT_FOLDERS; do
-    CONTENTS=$(curl -sf -H "$AUTH" "$base_url/api/folders/$folder_id/listing")
+    RES_HTTP=$(curl -s -H "$AUTH" -o /tmp/storage_cleanup_resources.json \
+                    -w "%{http_code}" \
+                    "$base_url/api/folders/$folder_id/resources?limit=500")
+    if [[ "$RES_HTTP" == "404" ]]; then
+        log "Skipping folder $folder_id (404 on /resources — not readable by admin)"
+        continue
+    fi
+    if [[ "$RES_HTTP" != "200" ]]; then
+        fail "/api/folders/$folder_id/resources returned HTTP $RES_HTTP"
+    fi
+    CONTENTS=$(cat /tmp/storage_cleanup_resources.json)
 
     while IFS= read -r sub_id; do
         [[ -z "$sub_id" ]] && continue
         curl -sf -X DELETE -H "$AUTH" "$base_url/api/folders/$sub_id" >/dev/null
-    done < <(echo "$CONTENTS" | jq -r '.folders[].id')
+    done < <(echo "$CONTENTS" | jq -r '.items[] | select(.resource_type == "folder") | .resource.id')
 
     while IFS= read -r file_id; do
         [[ -z "$file_id" ]] && continue
         curl -sf -X DELETE -H "$AUTH" "$base_url/api/files/$file_id" >/dev/null
-    done < <(echo "$CONTENTS" | jq -r '.files[].id')
+    done < <(echo "$CONTENTS" | jq -r '.items[] | select(.resource_type == "file") | .resource.id')
 done
 
 log "All live objects moved to trash."
@@ -135,9 +145,20 @@ log "All live objects moved to trash."
 # ── 2b. Verify all root folders are empty according to the API ────────────────
 
 for folder_id in $ROOT_FOLDERS; do
-    CONTENTS=$(curl -sf -H "$AUTH" "$base_url/api/folders/$folder_id/listing")
-    SUB_COUNT=$(echo "$CONTENTS"  | jq '.folders | length')
-    FILE_COUNT=$(echo "$CONTENTS" | jq '.files   | length')
+    RES_HTTP=$(curl -s -H "$AUTH" -o /tmp/storage_cleanup_resources.json \
+                    -w "%{http_code}" \
+                    "$base_url/api/folders/$folder_id/resources?limit=500")
+    # Same skip-on-404 as the trash loop above — admin owns the row but
+    # has no role-grant Read on it (shared drive created for someone else).
+    if [[ "$RES_HTTP" == "404" ]]; then
+        continue
+    fi
+    if [[ "$RES_HTTP" != "200" ]]; then
+        fail "/api/folders/$folder_id/resources returned HTTP $RES_HTTP"
+    fi
+    CONTENTS=$(cat /tmp/storage_cleanup_resources.json)
+    SUB_COUNT=$(echo  "$CONTENTS" | jq '[.items[] | select(.resource_type == "folder")] | length')
+    FILE_COUNT=$(echo "$CONTENTS" | jq '[.items[] | select(.resource_type == "file")]   | length')
     if [[ "$SUB_COUNT" -ne 0 || "$FILE_COUNT" -ne 0 ]]; then
         fail "folder $folder_id still has $SUB_COUNT subfolder(s) and $FILE_COUNT file(s)"
     fi
@@ -159,18 +180,53 @@ fi
 
 log "API confirms trash is empty."
 
+# ── 3c. Force the maintenance sweeps synchronously ────────────────────────────
+#
+# `trash/empty` already triggers an inline `garbage_collect()` at the end of
+# its `clear_trash_in` path, but that GC honours the 1-hour orphan-grace
+# window — a blob orphaned seconds ago survives the inline sweep. The
+# regular periodic sweep would catch it eventually, but tests need the
+# disk state to be quiescent NOW. The two admin-internal triggers below
+# (gated by `OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS=true`, set in
+# tests/common/server.env) make this deterministic:
+#
+#   1. trigger-sweep    — reconciles users.storage_used_bytes and
+#                         drives.used_bytes from SUM(size) — keeps the
+#                         cached counters honest for any quota
+#                         assertions that follow.
+#   2. trigger-gc?force=true — same `garbage_collect()` as the inline
+#                         call, but `force=true` bypasses the orphan
+#                         grace so freshly-orphaned blobs ARE reaped.
+#                         Safe here because the test has no concurrent
+#                         uploaders to race the row-delete → unlink
+#                         window the grace normally protects.
+#
+# Without `force=true`, the test would have to wait an hour for the
+# probe blob's `orphaned_at` timestamp to age past the grace window —
+# why this script was disabled until the admin-internal triggers
+# landed (commit `74b33744`).
+
+curl -sf -X POST -H "$AUTH" "$base_url/api/admin/internal/trigger-sweep" >/dev/null \
+    || fail "trigger-sweep failed (is OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS=true?)"
+log "Reconciliation sweep triggered."
+
+GC_RESULT=$(curl -sf -X POST -H "$AUTH" "$base_url/api/admin/internal/trigger-gc?force=true")
+[[ -z "$GC_RESULT" ]] && fail "trigger-gc returned an empty body"
+GC_BLOBS=$(echo "$GC_RESULT" | jq -r '.blobs_deleted')
+GC_BYTES=$(echo "$GC_RESULT" | jq -r '.bytes_freed')
+log "GC reaped $GC_BLOBS blob(s), $GC_BYTES byte(s) freed."
+
 # ── 4. Disk verification ──────────────────────────────────────────────────────
 
 THUMB_FILES=$(find "$STORAGE_PATH/.thumbnails" -type f 2>/dev/null || true)
 BLOB_FILES=$(find  "$STORAGE_PATH/.blobs"      -type f 2>/dev/null || true)
 
 if [[ -n "$THUMB_FILES" || -n "$BLOB_FILES" ]]; then
-    # Async thumbnail/blob workers may still be flushing writes from the
-    # last test's uploads when the cleanup phase reaches this point —
-    # particularly on fast CI runners where the test loop outpaces the
-    # worker. Poll for up to 5 s and exit the loop the moment storage
-    # drains. TODO: replace with a deterministic worker-drain signal
-    # (e.g. queue depth on /ready) when one exists.
+    # Even with the synchronous sweep + force-GC above, the on-disk
+    # unlink for thumbnails/blobs is handled by async workers that may
+    # still be draining when this `find` runs. Keep the short
+    # retry loop as a race guard. TODO: replace with a deterministic
+    # worker-drain signal (e.g. queue depth on /ready) when one exists.
     log "Thumb/blob leftovers detected — polling for async worker drain (race guard)"
     for attempt in 1 2 3 4 5; do
         sleep 1

--- a/tests/api/subject_groups.hurl
+++ b/tests/api/subject_groups.hurl
@@ -334,13 +334,75 @@ HTTP 403
 
 
 # ─────────────────────────────────────────────────────────────
-# Step 11 — Cleanup: delete engineering (cascades to qa membership + grants).
+# Step 11 — Sole-Owner group-delete guard (D3b).
+#
+# A group that is the only `Role::Owner` of a shared drive must NOT be
+# deletable — wiping it would orphan the drive (no live Owner grant
+# left). Symmetric to the last-owner-protection rule on `set_role` /
+# `remove_member` from the membership API side; this guard catches
+# the same invariant from the group-lifecycle side.
+#
+# Setup: admin creates a shared drive owned by `grp-engineering-hurl`,
+# then tries to delete the group. Refused with 409. Promote a second
+# Owner (a user), then the group delete succeeds.
 # ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "grp-guarded-drive-hurl",
+  "owner": { "type": "group", "id": "{{engineers_id}}" }
+}
+
+HTTP 201
+[Captures]
+guarded_drive_id: jsonpath "$.id"
+
+
+# 11a — Group delete refused while it's the sole Owner of the drive.
+DELETE {{base_url}}/api/groups/{{engineers_id}}
+Authorization: Bearer {{alice_token}}
+
+HTTP 409
+
+
+# 11b — Add Grace as a co-Owner of the drive via the admin endpoint.
+#       Alice (the OxiCloud admin) created the drive but doesn't
+#       auto-grant herself a role on it, so she lacks `Manage` on the
+#       user-facing `/api/drives/{id}/members` — the admin route
+#       bypasses that check for exactly this case.
+POST {{base_url}}/api/admin/drives/{{guarded_drive_id}}/members
+Authorization: Bearer {{alice_token}}
+Content-Type: application/json
+{
+  "subject": { "type": "user", "id": "{{grace_user_id}}" },
+  "role": "owner"
+}
+
+HTTP 201
+
+
+# 11c — Group delete now succeeds — the drive still has Grace as Owner.
 DELETE {{base_url}}/api/groups/{{engineers_id}}
 Authorization: Bearer {{alice_token}}
 
 HTTP 204
 
+
+# 11d — Cleanup: trash the drive (no content) so subsequent test files
+#       don't see a dangling shared drive. After 11c, Grace is the
+#       only remaining Owner via her direct grant, so she's the one
+#       who can delete via the user-facing route.
+DELETE {{base_url}}/api/drives/{{guarded_drive_id}}
+Authorization: Bearer {{grace_token}}
+
+HTTP 204
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 12 — Cleanup: delete qa group.
+# ─────────────────────────────────────────────────────────────
 DELETE {{base_url}}/api/groups/{{qa_id}}
 Authorization: Bearer {{alice_token}}
 

--- a/tests/api/trash_per_drive.hurl
+++ b/tests/api/trash_per_drive.hurl
@@ -1,0 +1,332 @@
+# =============================================================
+# OxiCloud — Per-drive trash empty (D2b stage 4 follow-up)
+# =============================================================
+# Pins the contract on `DELETE /api/trash/drive/{drive_id}` — the
+# per-drive variant of `DELETE /api/trash/empty`. Scope of coverage:
+#
+#   1. Owner of a drive CAN empty that drive's trash → 204.
+#   2. Idempotent: calling again on an empty drive still returns 204.
+#   3. Scope: emptying drive A leaves drive B's trash intact.
+#   4. Viewer of a shared drive → 404 (Viewer's bundle has no Delete).
+#   5. Editor of a shared drive → 404 (Editor's bundle has no Delete).
+#   6. Non-member of a shared drive → 404 (anti-enum).
+#   7. Unknown drive UUID → 404 (same shape as no-role case; can't
+#      enumerate drive existence through this endpoint).
+#
+# The owner gate has three layers in the implementation (filter,
+# membership check, UI hide); cases 4-6 protect the first two. Test 3
+# (scope) is the load-bearing assertion against a regression that
+# silently merges scopes.
+#
+# Self-contained: provisions its own users (`tpd_*` prefix) so it
+# survives running alongside the rest of the API test suite.
+# =============================================================
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 1 — Admin login.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "{{username}}", "password": "{{password}}" }
+
+HTTP 200
+[Captures]
+admin_token: jsonpath "$.access_token"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 2 — Provision `tpd_owner` (will own the shared drive and a
+#          personal-drive trash item that must NOT be touched).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/admin/users
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "username": "tpd_owner",
+  "password": "TpdOwnerPwd1!",
+  "email":    "tpd_owner@example.com",
+  "role":     "user"
+}
+
+HTTP 201
+[Captures]
+owner_user_id: jsonpath "$.id"
+
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "tpd_owner", "password": "TpdOwnerPwd1!" }
+
+HTTP 200
+[Captures]
+owner_token: jsonpath "$.access_token"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 3 — Capture the owner's default-personal drive + its root.
+# ─────────────────────────────────────────────────────────────
+GET {{base_url}}/api/drives
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$" count == 1
+jsonpath "$[0].default_for_user" == "{{owner_user_id}}"
+[Captures]
+personal_drive_id: jsonpath "$[0].id"
+personal_root_id:  jsonpath "$[0].root_folder_id"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 4 — Admin creates a shared drive owned directly by `tpd_owner`.
+#          Direct-user-owner keeps the test self-contained (no group
+#          plumbing needed); the membership-API path is exercised
+#          separately by `drives_membership.hurl`.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/drives
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "kind": "shared",
+  "name": "tpd-shared",
+  "owner": { "type": "user", "id": "{{owner_user_id}}" }
+}
+
+HTTP 201
+[Captures]
+shared_drive_id: jsonpath "$.id"
+shared_root_id:  jsonpath "$.root_folder_id"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 5 — Seed one file in each drive, then trash both. We end up
+#          with two trash entries the owner can see: one per drive.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/files/upload
+Authorization: Bearer {{owner_token}}
+[MultipartFormData]
+folder_id: {{personal_root_id}}
+file: file,fixtures/hello.txt; text/plain
+
+HTTP 201
+[Captures]
+personal_file_id: jsonpath "$.id"
+
+
+POST {{base_url}}/api/files/upload
+Authorization: Bearer {{owner_token}}
+[MultipartFormData]
+folder_id: {{shared_root_id}}
+file: file,fixtures/hello-copy.txt; text/plain
+
+HTTP 201
+[Captures]
+shared_file_id: jsonpath "$.id"
+
+
+DELETE {{base_url}}/api/files/{{personal_file_id}}
+Authorization: Bearer {{owner_token}}
+
+HTTP 204
+
+
+DELETE {{base_url}}/api/files/{{shared_file_id}}
+Authorization: Bearer {{owner_token}}
+
+HTTP 204
+
+
+# Both files are now trashed; trash listing carries one row per drive.
+GET {{base_url}}/api/trash/resources
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.items[*].drive_id" contains "{{personal_drive_id}}"
+jsonpath "$.items[*].drive_id" contains "{{shared_drive_id}}"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 6 — Test 1 + Test 3: Owner empties the shared drive's trash;
+#          the personal drive's trash item is untouched (scope check).
+# ─────────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/trash/drive/{{shared_drive_id}}
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+
+
+GET {{base_url}}/api/trash/resources
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.items[*].drive_id" contains "{{personal_drive_id}}"
+jsonpath "$.items[*].drive_id" not contains "{{shared_drive_id}}"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 7 — Test 2: idempotent on an already-empty drive.
+#          No trash items left in the shared drive, but the owner
+#          still holds Delete on it, so the response is 200.
+# ─────────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/trash/drive/{{shared_drive_id}}
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 8 — Test 7: unknown drive id → 404.
+#          The endpoint refuses with the same shape it uses for "no
+#          Delete on this drive" so callers can't enumerate which
+#          drive UUIDs exist via this endpoint.
+# ─────────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/trash/drive/00000000-0000-0000-0000-000000000000
+Authorization: Bearer {{owner_token}}
+
+HTTP 404
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 9 — Provision a Viewer of the shared drive (`tpd_viewer`),
+#          then assert the per-drive empty refuses for Viewer / Editor
+#          / non-member callers. Each refusal is 404 (anti-enum).
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/admin/users
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "username": "tpd_viewer",
+  "password": "TpdViewerPwd1!",
+  "email":    "tpd_viewer@example.com",
+  "role":     "user"
+}
+
+HTTP 201
+[Captures]
+viewer_user_id: jsonpath "$.id"
+
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "tpd_viewer", "password": "TpdViewerPwd1!" }
+
+HTTP 200
+[Captures]
+viewer_token: jsonpath "$.access_token"
+
+
+# Owner grants Viewer role on the shared drive.
+POST {{base_url}}/api/drives/{{shared_drive_id}}/members
+Authorization: Bearer {{owner_token}}
+Content-Type: application/json
+{
+  "subject": { "type": "user", "id": "{{viewer_user_id}}" },
+  "role": "viewer"
+}
+
+HTTP 201
+
+
+# Seed a trash item in the shared drive so the negative tests can't
+# pass via the "drive happens to be empty" trivial path. The owner
+# trashes a new file; the Viewer/Editor/non-member attempts that
+# follow must still refuse — the scope check is on permission, not
+# on whether work would be done.
+POST {{base_url}}/api/files/upload
+Authorization: Bearer {{owner_token}}
+[MultipartFormData]
+folder_id: {{shared_root_id}}
+file: file,fixtures/hello.txt; text/plain
+
+HTTP 201
+[Captures]
+canary_file_id: jsonpath "$.id"
+
+DELETE {{base_url}}/api/files/{{canary_file_id}}
+Authorization: Bearer {{owner_token}}
+
+HTTP 204
+
+
+# Test 4 — Viewer cannot empty the drive's trash.
+DELETE {{base_url}}/api/trash/drive/{{shared_drive_id}}
+Authorization: Bearer {{viewer_token}}
+
+HTTP 404
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 10 — Test 5: Editor cannot either.
+#           Promote tpd_viewer to Editor; same refusal. Confirms
+#           `Delete` isn't in the Editor bundle.
+# ─────────────────────────────────────────────────────────────
+PATCH {{base_url}}/api/drives/{{shared_drive_id}}/members/user/{{viewer_user_id}}
+Authorization: Bearer {{owner_token}}
+Content-Type: application/json
+{ "role": "editor" }
+
+HTTP 200
+
+
+DELETE {{base_url}}/api/trash/drive/{{shared_drive_id}}
+Authorization: Bearer {{viewer_token}}
+
+HTTP 404
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 11 — Test 6: non-member of the drive cannot empty its trash.
+#           Fresh user with no grant on the shared drive whatsoever.
+# ─────────────────────────────────────────────────────────────
+POST {{base_url}}/api/admin/users
+Authorization: Bearer {{admin_token}}
+Content-Type: application/json
+{
+  "username": "tpd_outsider",
+  "password": "TpdOutsiderPwd1!",
+  "email":    "tpd_outsider@example.com",
+  "role":     "user"
+}
+
+HTTP 201
+
+POST {{base_url}}/api/auth/login
+Content-Type: application/json
+{ "username": "tpd_outsider", "password": "TpdOutsiderPwd1!" }
+
+HTTP 200
+[Captures]
+outsider_token: jsonpath "$.access_token"
+
+
+DELETE {{base_url}}/api/trash/drive/{{shared_drive_id}}
+Authorization: Bearer {{outsider_token}}
+
+HTTP 404
+
+
+# Trash row is still there — none of the negative attempts purged it.
+GET {{base_url}}/api/trash/resources
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+[Asserts]
+jsonpath "$.items[*].drive_id" contains "{{shared_drive_id}}"
+
+
+# ─────────────────────────────────────────────────────────────
+# Step 12 — Cleanup: drop the canary, then the shared drive itself
+#           (D3b's delete-drive guard refuses non-empty drives, so
+#           clearing trash + the live tree first is required).
+# ─────────────────────────────────────────────────────────────
+DELETE {{base_url}}/api/trash/drive/{{shared_drive_id}}
+Authorization: Bearer {{owner_token}}
+
+HTTP 200
+
+
+DELETE {{base_url}}/api/drives/{{shared_drive_id}}
+Authorization: Bearer {{owner_token}}
+
+HTTP 204

--- a/tests/common/server.env
+++ b/tests/common/server.env
@@ -18,7 +18,14 @@ OXICLOUD_OIDC_ENABLED=false
 
 OXICLOUD_NEXTCLOUD_ENABLED=true
 
+# Test-only sweep triggers (`/api/admin/internal/trigger-sweep`,
+# `/api/admin/internal/trigger-gc`). Off by default in production;
+# the Hurl suite needs them to assert post-delete quota convergence
+# without waiting out the 600 s reconciliation tick.
+OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS=true
+
 RUST_LOG="warn,audit=info,sqlx::migrate=info"
+#RUST_LOG="warn,audit=info,oxicloud::quota=debug"
 #RUST_LOG=debug
 #RUST_LOG=info
 
@@ -61,3 +68,5 @@ OXICLOUD_MAGIC_LINK_SEND_PER_IP_PER_HOUR=50
 
 # permits IP spoofing for tests
 OXICLOUD_TRUST_PROXY_CIDR=0.0.0.0/0
+
+OXICLOUD_ENABLE_ADMIN_INTERNAL_ENDPOINTS=true


### PR DESCRIPTION
all test are clean + leak identified with GC & blob lifecycle

- add of 2 internal route to trigger GC and Sweep
- add support of drive during test of full cleanup 
- fix leak with GC and blob lifecycle
- blob lifecycle with thumbnail cleanup
- add quota calculus per drive
- permanent deletion per drive (trash per drive)
- add drive deletion

we are reaching more than 800 end to end assertions/test !