### PR TITLE
fix: remove panic=abort so catch_unwind guards PDF extraction.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,6 @@ required-features = ["load_seed_bin"]
 lto = "thin"
 codegen-units = 1
 opt-level = 3
-panic = "abort"
 strip = true
 
 [profile.dev]


### PR DESCRIPTION
## Description

Fixes #530

<!-- Please include a summary of the changes and the related issue (if applicable). Please also include relevant motivation and context. -->

## Related Issue

<!-- Please link to the issue here if applicable. -->

## Type of Change

Please check the option that best describes your change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

After uploading a folder filled with PDFs, the oxicloud server in a docker container was crashing. (as pointed out in #530) 
I rebuilt a local container with this change, restarted and was able to get past the crash and continue uploading files (PDF and otherwise).

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules