### PR TITLE
feat(ci): also publish docker image to ghcr

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -59,6 +59,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     needs: test
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -93,6 +96,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Push Multi-Arch Image
         uses: docker/build-push-action@v6
         with:
@@ -102,6 +112,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY_IMAGE }}:${{ env.VERSION }}
             ${{ env.REGISTRY_IMAGE }}:latest
+            ghcr.io/${{ github.repository }}:${{ env.VERSION }}
+            ghcr.io/${{ github.repository }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # GitHub Actions env piped through so build.rs stamps


### PR DESCRIPTION
## Description

DockerHub has strict pull rate limitations, so push the image to ghcr can provide an offload method, and also provide an alternative trusted release source.

## Related Issue

Not applicable.

## Type of Change

<!-- Please check the option that best describes your change: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

Not tested yet, just following the ref from [Docker Docs](https://docs.docker.com/build/ci/github-actions/push-multi-registries/) and my personal experience. Further reviews and tests are preferred.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation -> not touched yet
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works -> not sure what test can be implemented for this
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules