### PR TITLE
chore/bump to 0.8.2 + security on crossbeam-epoch 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1772,9 +1772,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "oxicloud"
-version = "0.8.0"
+version = "0.8.2"
 dependencies = [
  "accept-language",
  "aes-gcm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxicloud"
-version = "0.8.0"
+version = "0.8.2"
 edition = "2024"
 default-run = "oxicloud"
 


### PR DESCRIPTION
- reflect oxicloud version from tag
- fix security audit crossbeam-epoch (RUSTSEC-2026-0204)