### PR TITLE
i18n: complete Korean (ko) locale

### DIFF
--- a/frontend/static/locales/ko.json
+++ b/frontend/static/locales/ko.json
@@ -53,7 +53,9 @@
     "sharedwithme": "나와 공유됨",
     "profile": "프로필",
     "shared_with_me": "나와 공유됨",
-    "groups": "그룹"
+    "groups": "그룹",
+    "primary": "기본",
+    "toggle": "탐색 메뉴 전환"
   },
   "photos": {
     "empty_state": "아직 사진이 없습니다",
@@ -62,7 +64,21 @@
     "view_daily": "일",
     "view_monthly": "월",
     "view_yearly": "년",
-    "group_by": "그룹화 기준"
+    "group_by": "그룹화 기준",
+    "confirm_delete": "사진 {{n}}장을 휴지통으로 이동하시겠습니까?",
+    "confirm_delete_one": "{{name}}을(를) 삭제하시겠습니까?",
+    "delete": "사진 삭제",
+    "empty": "아직 사진이 없습니다.",
+    "full_resolution": "원본 해상도",
+    "trash_partial": "{{total}}개 중 {{ok}}개가 휴지통으로 이동되었습니다.",
+    "trashed": "{{n}}개가 휴지통으로 이동되었습니다.",
+    "layout_square": "그리드",
+    "layout_justified": "맞춤형",
+    "tab_moments": "순간",
+    "tab_places": "장소",
+    "tab_people": "인물",
+    "map_loading": "지도 로딩 중…",
+    "map_error": "지도를 불러올 수 없습니다"
   },
   "music": {
     "create_playlist": "재생목록 만들기",
@@ -130,7 +146,26 @@
     "share_with_user": "User ID or email",
     "toggle_public": "Visibility",
     "track_removed": "Track removed",
-    "prev": "이전"
+    "prev": "이전",
+    "add_selected": "선택 항목 추가",
+    "create_playlist_hint": "재생목록 이름을 입력하여 새로 만드세요.",
+    "created": "\"{{name}}\"이(가) 생성되었습니다.",
+    "delete_playlist": "재생목록 삭제",
+    "deleted": "\"{{name}}\"이(가) 삭제되었습니다.",
+    "edit_description": "설명 편집",
+    "empty_playlist": "이 재생목록에는 아직 트랙이 없습니다.",
+    "new_playlist": "새 재생목록",
+    "no_audio": "오디오 파일을 찾을 수 없습니다.",
+    "now_private": "재생목록이 비공개로 전환되었습니다.",
+    "now_public": "재생목록이 공개로 전환되었습니다.",
+    "pick_or_create": "기존 목록: {{list}}. 추가하거나 새로 만들려면 이름을 입력하세요.",
+    "rename_playlist": "재생목록 이름 변경",
+    "reordered": "재생목록 순서가 변경되었습니다.",
+    "seek": "탐색",
+    "selected_count": "{{n}}개 선택됨",
+    "share_added": "공유되었습니다.",
+    "track_count": "트랙 {{n}}개",
+    "tracks_added": "트랙 {{n}}개가 추가되었습니다."
   },
   "actions": {
     "search": "파일 검색...",
@@ -181,7 +216,9 @@
       "auto": "시스템과 동일"
     },
     "manage_groups": "그룹 관리",
-    "admin": "관리자"
+    "admin": "관리자",
+    "mit_license": "MIT 라이선스",
+    "title": "사용자 메뉴"
   },
   "share": {
     "dialogTitle": "공유 링크",
@@ -232,7 +269,40 @@
     "link_name": "Link name (optional)",
     "notifyByEmail": "이메일로 알림",
     "revoke": "Remove",
-    "role_label": "역할"
+    "role_label": "역할",
+    "addPassword": "비밀번호 추가",
+    "add_people": "사용자, 그룹 또는 이메일 추가…",
+    "bad_password": "비밀번호가 올바르지 않습니다. 다시 시도해 주세요.",
+    "changePassword": "비밀번호 변경",
+    "create_link": "링크 생성",
+    "created": "공개 링크가 생성되었습니다",
+    "dialog_title": "\"{{name}}\" 공유",
+    "download_zip": "ZIP 다운로드",
+    "empty_folder": "이 폴더가 비어 있습니다.",
+    "error": "문제가 발생했습니다. 다시 시도해 주세요.",
+    "expired": "이 공유 링크는 더 이상 사용할 수 없습니다.",
+    "expires_optional": "만료일 (선택 사항)",
+    "expiry": "만료일",
+    "invalid": "이 공유 링크가 유효하지 않습니다.",
+    "link": "링크",
+    "no_people": "아직 아무와도 공유되지 않았습니다.",
+    "none": "아직 공개 링크가 없습니다.",
+    "notify": {
+      "coalesced": "{{n}}명은 최근에 이미 알림을 받았습니다.",
+      "rateLimited": "{{n}}명이 속도 제한에 걸렸습니다 — 나중에 다시 시도하세요.",
+      "sent": "{{n}}명에게 이메일로 알렸습니다.",
+      "skipped": "{{n}}명 건너뜀 (이메일 없음 / 수신 거부)."
+    },
+    "passwordPrompt": "비밀번호 설정:",
+    "passwordPrompt_clear": "새 비밀번호 (제거하려면 비워두세요):",
+    "password_cleared": "비밀번호가 제거되었습니다",
+    "password_optional": "비밀번호 (선택 사항)",
+    "password_set": "비밀번호가 변경되었습니다",
+    "password_title": "비밀번호 필요",
+    "public_link": "공개 링크",
+    "set_expiry": "만료일 설정",
+    "title": "공유됨",
+    "unlock": "잠금 해제"
   },
   "share_dialogTitle": "공유 링크",
   "share_linkLabel": "공유 링크:",
@@ -365,7 +435,55 @@
     "folder": "폴더",
     "new_folder": "새 폴더",
     "share": "공유",
-    "view": "보기"
+    "view": "보기",
+    "already_favorites": "선택한 항목이 모두 이미 즐겨찾기에 있습니다",
+    "batch_delete": "선택 항목 삭제",
+    "breadcrumb": "경로",
+    "cancel_selection": "선택 취소",
+    "col_modified": "날짜",
+    "col_path": "위치",
+    "confirm_batch_delete": "{{n}}개 항목을 휴지통으로 이동하시겠습니까?",
+    "confirm_delete": "\"{{name}}\"을(를) 휴지통으로 이동하시겠습니까?",
+    "confirm_delete_n": "{{count}}개 항목을 삭제하시겠습니까?",
+    "copied": "복사됨",
+    "copy_here": "여기에 복사",
+    "copy_n": "{{n}}개 항목 복사",
+    "copy_title": "\"{{name}}\" 복사",
+    "download_zip": "ZIP으로 다운로드",
+    "edit_new_tab": "새 탭에서 편집",
+    "editor": "문서 편집기",
+    "empty_title": "이 폴더가 비어 있습니다",
+    "favorite": "즐겨찾기 추가",
+    "favorited": "즐겨찾기됨",
+    "grid": "그리드",
+    "list": "목록",
+    "more_actions": "추가 작업",
+    "move": "이동",
+    "move_here": "여기로 이동",
+    "move_n": "{{n}}개 항목 이동",
+    "move_title": "\"{{name}}\" 이동",
+    "moved": "이동됨",
+    "new_folder_prompt": "새 폴더 이름",
+    "no_home": "홈 폴더를 사용할 수 없습니다.",
+    "no_preview": "이 파일 형식은 미리보기를 지원하지 않습니다.",
+    "no_subfolders": "하위 폴더가 없습니다.",
+    "open": "열기",
+    "open_parent": "상위 폴더 열기",
+    "owner_me": "나",
+    "preview_failed": "미리보기를 불러올 수 없습니다.",
+    "select_all": "전체 선택",
+    "selected_count": "{{count}}개 선택됨",
+    "selection": "선택",
+    "shared": "공유됨",
+    "unfavorite": "즐겨찾기 해제",
+    "uploaded": "업로드 완료",
+    "uploaded_saved": "업로드 완료 — {{mb}}MB 중복 제거됨",
+    "uploaded_partial": "{{ok}}개 업로드됨, {{failed}}개 실패",
+    "uploaded_skipped": "{{ok}}개 업로드됨 · {{skipped}}개 건너뜀 (일반 파일 아님)",
+    "upload_failed": "업로드 실패",
+    "uploading": "업로드 중…",
+    "uploading_file": "{{name}} 업로드 중…",
+    "uploading_n": "파일 업로드 중 {{done}}/{{total}}…"
   },
   "dialogs": {
     "rename_folder": "폴더 이름 변경",
@@ -431,7 +549,8 @@
     "group_depth_exceeded": "중첩 깊이가 허용 최대값(8)을 초과합니다.",
     "group_virtual_immutable": "«Internal» 그룹은 시스템이 관리하며 수정할 수 없습니다.",
     "group_not_found": "그룹을 찾을 수 없습니다.",
-    "group_name_taken": "이 이름의 그룹이 이미 존재합니다."
+    "group_name_taken": "이 이름의 그룹이 이미 존재합니다.",
+    "forbidden": "파일을 불러올 수 없습니다"
   },
   "breadcrumb": {
     "home": "홈"
@@ -451,7 +570,10 @@
       "trashed_time": "삭제 시간"
     },
     "delete": "영구 삭제",
-    "empty_action": "휴지통 비우기"
+    "empty_action": "휴지통 비우기",
+    "confirm_delete": "이 항목을 영구적으로 삭제하시겠습니까? 되돌릴 수 없습니다.",
+    "confirm_empty": "휴지통을 비우시겠습니까? 되돌릴 수 없습니다.",
+    "restored": "복원됨"
   },
   "daysRemaining": {
     "expired": "만료됨",
@@ -519,7 +641,17 @@
     "magic_hint": "비밀번호가 없으신가요? 이메일을 입력하시면 일회용 로그인 링크를 보내드립니다.",
     "magic_unavailable": "이 서버에서는 이메일 로그인을 사용할 수 없습니다.",
     "passwords_match": "Passwords match",
-    "sign_in": "로그인"
+    "sign_in": "로그인",
+    "cookie_rejected": "로그인은 성공했지만 브라우저가 세션 쿠키를 거부했습니다. HTTP를 사용 중이라면 OXICLOUD_COOKIE_SECURE=false로 설정하거나 HTTPS를 사용하세요.",
+    "login_error": "로그인 오류",
+    "magic_error": "문제가 발생했습니다. 다시 시도해 주세요.",
+    "magic_prompt": "비밀번호가 없으신가요? 이메일 링크로 로그인하세요",
+    "magic_send": "링크 보내기",
+    "magic_sent": "해당 계정이 존재하면 로그인 링크가 전송되었습니다. 받은편지함을 확인하세요.",
+    "register_error": "가입 실패",
+    "session_expired": "세션이 만료되었습니다. 다시 로그인해 주세요.",
+    "signing_in": "로그인 중…",
+    "toggle_password": "비밀번호 표시"
   },
   "storage": {
     "title": "저장소",
@@ -531,7 +663,8 @@
     "download_file": "파일 다운로드",
     "zoom_in": "확대",
     "zoom_out": "축소",
-    "zoom_reset": "줌 초기화"
+    "zoom_reset": "줌 초기화",
+    "zoom": "확대/축소"
   },
   "language_selector": {
     "title": "환영합니다!",
@@ -570,7 +703,8 @@
     "accessed": "접근일",
     "empty_state": "최근 파일이 없습니다",
     "empty_hint": "열어본 파일이 여기에 표시됩니다",
-    "loadMore": "더 불러오기"
+    "loadMore": "더 불러오기",
+    "confirm_clear": "최근 항목을 지우시겠습니까?"
   },
   "notifications": {
     "file_renamed": "파일 이름이 변경되었습니다",
@@ -587,7 +721,8 @@
     "link_created": "링크 생성됨",
     "share_success": "공유 링크가 성공적으로 생성되었습니다",
     "upload_files_section_title": "여기서는 업로드할 수 없습니다",
-    "upload_files_section_body": "파일을 업로드하려면 파일 섹션으로 이동하세요"
+    "upload_files_section_body": "파일을 업로드하려면 파일 섹션으로 이동하세요",
+    "clear": "모두 지우기"
   },
   "batch": {
     "one_selected": "1개 선택됨",
@@ -826,7 +961,132 @@
       "include_in_music_index": "음악에 포함",
       "include_in_music_index_help": "이 Drive의 오디오 파일을 음악 라이브러리에 포함합니다. 기본 개인 Drive는 자동으로 포함됩니다. 실제로 음악 컬렉션이 있는 공유 Drive에서 켜세요 (예: 「가족 음악」, 「밴드 협업」).",
       "implied_by_forbid_sharing": "이미 「리소스별 공유 금지」에 의해 적용됨."
-    }
+    },
+    "tab_plugins": "플러그인",
+    "plugins_title": "플러그인",
+    "plugins_disabled": "이 서버에서는 플러그인이 비활성화되어 있습니다. WASM 플러그인을 여기서 관리하려면 OXICLOUD_ENABLE_PLUGINS=true로 설정하고 \"plugins\" 기능을 활성화하여 빌드하세요.",
+    "plugins_install_title": "플러그인 설치",
+    "plugins_install_intro": "plugin.toml과 컴파일된 WebAssembly 모듈(.wasm)이 포함된 플러그인 번들(.zip)을 업로드하세요. 설치 전에 매니페스트가 검증되고 모듈이 점검됩니다.",
+    "plugins_bundle_label": "플러그인 번들 (.zip)",
+    "plugins_install": "플러그인 설치",
+    "plugins_installed_title": "설치된 플러그인",
+    "plugins_col_name": "이름",
+    "plugins_col_id": "ID",
+    "plugins_col_version": "버전",
+    "plugins_col_events": "이벤트",
+    "plugins_col_status": "상태",
+    "plugins_col_actions": "작업",
+    "plugins_loading": "플러그인 로딩 중…",
+    "plugins_none": "설치된 플러그인이 없습니다.",
+    "plugins_enabled": "활성화됨",
+    "plugins_disabled_badge": "비활성화됨",
+    "plugins_enable": "활성화",
+    "plugins_disable": "비활성화",
+    "plugins_delete": "삭제",
+    "plugins_confirm_delete": "플러그인 \"{{name}}\"을(를) 삭제하시겠습니까? 서버에서 관련 파일이 제거됩니다.",
+    "plugins_installing": "설치 중…",
+    "plugins_installed": "{{name}}이(가) 설치되었습니다.",
+    "plugins_install_missing_bundle": "플러그인 번들(.zip)을 선택하세요.",
+    "plugins_details": "로그 및 세부 정보",
+    "plugins_back": "플러그인으로 돌아가기",
+    "plugins_retention_title": "로그 보관 기간",
+    "plugins_retention_intro": "보관 기간을 초과했거나 크기 상한을 넘은 로테이션된 로그 조각은 예약된 일정에 따라 정리됩니다.",
+    "plugins_retention_days": "보관 기간(일)",
+    "plugins_retention_max_mb": "최대 로그 크기(MB)",
+    "plugins_retention_save": "보관 설정 저장",
+    "plugins_retention_saved": "보관 설정이 저장되었습니다.",
+    "plugins_retention_invalid": "0 이상의 숫자를 입력하세요.",
+    "plugins_logs_title": "로그",
+    "plugins_logs_level_all": "모든 레벨",
+    "plugins_logs_search": "메시지 검색…",
+    "plugins_logs_live": "실시간",
+    "plugins_logs_clear": "지우기",
+    "plugins_logs_confirm_clear": "이 플러그인의 모든 로그를 지우시겠습니까?",
+    "plugins_logs_none": "로그 항목이 없습니다.",
+    "plugins_logs_col_time": "시간",
+    "plugins_logs_col_level": "레벨",
+    "plugins_logs_col_kind": "종류",
+    "plugins_logs_col_invocation": "호출",
+    "plugins_logs_col_message": "메시지",
+    "plugins_logs_showing": "{{total}}개 중 {{from}}–{{to}} 표시",
+    "auth": "인증",
+    "available": "사용 가능",
+    "confirm_delete_plugin": "플러그인 {{name}}을(를) 삭제하시겠습니까?",
+    "disable": "비활성화",
+    "email_auto": "비워두면 자동으로 생성됩니다",
+    "enable": "활성화",
+    "env_locked": "환경 변수로 설정됨",
+    "last_login": "마지막 로그인",
+    "logs_all": "모든 레벨",
+    "logs_empty": "로그 항목이 없습니다.",
+    "logs_invocation": "호출",
+    "logs_kind": "종류",
+    "logs_level": "레벨",
+    "logs_live": "실시간",
+    "logs_message": "메시지",
+    "logs_search": "검색…",
+    "logs_showing": "{{total}}개 중 {{from}}–{{to}} 표시",
+    "logs_time": "시간",
+    "mig_eta": "약 {{min}}분 남음",
+    "mig_failed": "실패한 블롭 {{n}}개",
+    "mig_start": "시작",
+    "mig_verify": "무결성 확인",
+    "mig_verify_mismatch": "크기 불일치 {{n}}건",
+    "mig_verify_missing": "누락 {{n}}건",
+    "mig_verify_summary": "{{checked}}개 확인됨, 데이터베이스 총 {{total}}개",
+    "migration": "스토리지 마이그레이션",
+    "new_password": "새 비밀번호",
+    "no_plugins": "설치된 플러그인이 없습니다.",
+    "oidc": "OIDC / SSO",
+    "oidc_admin_groups": "관리자 그룹",
+    "oidc_auth_endpoint": "인증 엔드포인트",
+    "oidc_client_secret": "클라이언트 시크릿",
+    "oidc_discover": "테스트 / 검색",
+    "oidc_enabled": "OIDC 로그인 활성화",
+    "oidc_provider_name": "제공자 이름",
+    "oidc_secret_set": "클라이언트 시크릿이 이미 구성되어 있습니다.",
+    "over_80": "할당량 80% 초과 사용자 {{n}}명",
+    "over_quota": "할당량 초과 사용자 {{n}}명",
+    "password_reset": "비밀번호 재설정",
+    "plugin": "플러그인",
+    "plugin_logs": "플러그인 로그",
+    "plugins": "플러그인",
+    "plugins_clear_logs": "로그 지우기",
+    "plugins_install_hint": "플러그인 번들(.zip)을 업로드하세요.",
+    "plugins_retention": "로그 보관 기간",
+    "plugins_retention_max": "최대 크기(MB)",
+    "plugins_upload": ".zip 업로드",
+    "quota": "스토리지 사용량",
+    "quota_for": "할당량 대상",
+    "registration": "회원가입",
+    "registration_disabled_warning": "공개 회원가입이 비활성화되어 있습니다. 관리자만 새 계정을 만들 수 있습니다.",
+    "settings_saved_ok": "설정이 저장되었습니다.",
+    "smtp": "이메일 (SMTP)",
+    "smtp_from": "보내는 사람",
+    "smtp_host": "호스트",
+    "smtp_port": "포트",
+    "smtp_status": "SMTP 상태",
+    "smtp_to": "recipient@example.com",
+    "storage_blobs": "블롭",
+    "storage_current": "현재 백엔드",
+    "storage_dedup": "중복 제거 비율",
+    "storage_preset": "프리셋",
+    "storage_size": "저장됨",
+    "storage_test": "연결 테스트",
+    "time_day_ago": "{{n}}일 전",
+    "time_hour_ago": "{{n}}시간 전",
+    "time_just_now": "방금",
+    "unchanged": "현재 값을 유지하려면 비워두세요",
+    "running": "실행 중…",
+    "maintenance": "유지 관리",
+    "maintenance_hint": "기존 파일을 다시 스캔하여 메타데이터를 채웁니다. 여러 번 실행해도 안전하며, 전체 라이브러리를 처리하므로 시간이 걸릴 수 있습니다.",
+    "reextract_audio": "오디오 메타데이터 다시 추출",
+    "reextract_photos": "사진 및 동영상 촬영 날짜 다시 추출",
+    "reextract_done": "{{processed}}/{{total}} 처리됨 · 실패 {{failed}}건",
+    "encryption": "암호화",
+    "encryption_hint": "저장 데이터(blob) 암호화를 위한 AES-256 키를 생성한 뒤, 서버 환경 변수 OXICLOUD_STORAGE_ENCRYPTION_KEY에 설정하세요.",
+    "gen_key": "키 생성",
+    "gen_key_warning": "이 키를 안전하게 보관하세요. 분실 시 암호화된 데이터를 복구할 수 없습니다."
   },
   "profile": {
     "page_title": "프로필",
@@ -914,12 +1174,20 @@
     "photo_save_failed": "Failed to save photo",
     "photo_no_file": "Please select a file first",
     "photo_managed_by_oidc": "Photo managed by your identity provider.",
-    "password_mismatch": "비밀번호가 일치하지 않습니다"
+    "password_mismatch": "비밀번호가 일치하지 않습니다",
+    "app_pw_revoke": "앱 비밀번호 취소",
+    "avatar": "아바타",
+    "copied": "복사됨",
+    "copy_failed": "복사할 수 없습니다",
+    "language": "언어",
+    "language_auto": "자동",
+    "saved": "프로필이 저장되었습니다"
   },
   "upload": {
     "uploading": "업로드 중...",
     "files": "파일",
-    "complete": "{{count}} / {{total}} 업로드됨"
+    "complete": "{{count}} / {{total}} 업로드됨",
+    "files_counter": "파일 {{completed}}/{{total}}"
   },
   "storage_quota_exceeded": "저장 공간 할당량 초과",
   "sharedwithme": {
@@ -988,7 +1256,9 @@
     "virtual_internal_explanation": "이 서버의 모든 내부 사용자",
     "create": "그룹 생성",
     "empty": "아직 그룹이 없습니다.",
-    "members": "구성원"
+    "members": "구성원",
+    "add_member_search": "추가할 사용자 또는 그룹 검색…",
+    "nested": "그룹"
   },
   "myshares": {
     "copyLink": "링크 복사",
@@ -999,11 +1269,18 @@
     "notifyRateLimited": "이 수신자에게 알림이 너무 많습니다 — 나중에 다시 시도하세요.",
     "removeAccess": "액세스 제거",
     "resendInvitation": "초대 이메일 다시 보내기",
-    "publicLinks": "Public links"
+    "publicLinks": "Public links",
+    "editSharing": "공유 편집",
+    "emptyStateDesc": "다른 사람과 공유한 항목이 여기에 표시됩니다",
+    "emptyStateTitle": "아직 공유한 항목이 없습니다",
+    "manageAccess": "접근 권한 관리",
+    "notifySent": "알림이 전송되었습니다.",
+    "passwordLinks": "비밀번호로 보호된 링크"
   },
   "sort": {
     "asc": "ascending",
-    "desc": "descending"
+    "desc": "descending",
+    "direction": "정렬 방향"
   },
   "notif": {
     "errorTitle": "Error",
@@ -1077,7 +1354,15 @@
   "category": {
     "audio": "오디오",
     "code": "코드",
-    "text": "텍스트"
+    "text": "텍스트",
+    "archives": "압축 파일",
+    "documents": "문서",
+    "images": "이미지",
+    "installers": "설치 프로그램",
+    "markdown": "마크다운",
+    "presentations": "프레젠테이션",
+    "spreadsheets": "스프레드시트",
+    "videos": "동영상"
   },
   "common": {
     "add": "추가",
@@ -1099,35 +1384,147 @@
     "save": "저장",
     "search": "검색",
     "yes": "있음",
-    "saving": "저장 중…"
+    "saving": "저장 중…",
+    "copied": "클립보드에 복사되었습니다",
+    "copy_failed": "복사 실패",
+    "empty": "아직 아무것도 없습니다.",
+    "error": "알 수 없는 오류",
+    "favorite": "즐겨찾기",
+    "ok": "확인",
+    "optional": "선택 사항",
+    "retry": "다시 시도",
+    "select": "선택",
+    "select_all": "전체 선택",
+    "dismiss": "닫기"
   },
   "device": {
     "continue": "계속",
-    "unknown": "알 수 없음"
+    "unknown": "알 수 없음",
+    "approve": "승인",
+    "approved": "기기가 승인되었습니다. 원래 기기로 돌아가셔도 됩니다.",
+    "client": "애플리케이션",
+    "denied": "기기 접근이 거부되었습니다.",
+    "deny": "거부",
+    "enter_code": "기기에 표시된 코드를 입력하세요",
+    "lookup_failed": "코드 확인에 실패했습니다. 다시 시도해 주세요.",
+    "not_found": "코드를 찾을 수 없거나 만료되었습니다. 확인 후 다시 시도해 주세요.",
+    "scopes": "접근 권한",
+    "title": "기기 인증",
+    "unauthorized": "기기를 승인하려면 로그인이 필요합니다. 먼저 로그인해 주세요."
   },
   "expiryBucket": {
     "expired": "만료됨",
     "noExpiry": "만료 없음",
     "today": "오늘",
-    "tomorrow": "내일"
+    "tomorrow": "내일",
+    "later": "이후",
+    "month": "30일 이내",
+    "week": "7일 이내"
   },
   "nextcloud": {
     "error_title": "오류",
-    "sign_in_with": "{{provider}}(으)로 로그인"
+    "sign_in_with": "{{provider}}(으)로 로그인",
+    "close_window": "창 닫기",
+    "error_expired_body": "세션이 만료되었습니다. 다시 시도해 주세요.",
+    "error_expired_title": "세션 만료",
+    "error_generic_body": "예기치 않은 오류가 발생했습니다. 다시 시도해 주세요.",
+    "error_invalid_body": "사용자 이름 또는 비밀번호가 올바르지 않습니다. 자격 증명을 확인한 후 다시 시도해 주세요.",
+    "error_invalid_title": "로그인 실패",
+    "error_notfound_body": "요청한 페이지를 찾을 수 없습니다.",
+    "error_notfound_title": "찾을 수 없음",
+    "grant": "접근 권한 부여",
+    "grant_subtitle": "Nextcloud 클라이언트가 회원님의 계정에 대한 접근 권한을 요청하고 있습니다.",
+    "grant_title": "접근 권한 부여",
+    "invalid_token": "세션 토큰이 유효하지 않습니다.",
+    "success_body": "이제 애플리케이션으로 돌아가셔도 됩니다 — 연결이 완료되었습니다.",
+    "success_title": "접근 권한이 부여되었습니다"
   },
   "search": {
     "size_label": "크기",
     "title": "검색",
     "type": {
-      "audio": "오디오"
+      "audio": "오디오",
+      "all": "모든 유형",
+      "archive": "압축 파일",
+      "document": "문서",
+      "image": "이미지",
+      "video": "동영상"
     },
-    "type_label": "유형"
+    "type_label": "유형",
+    "clear_filters": "필터 지우기",
+    "date": {
+      "all": "전체 기간",
+      "day": "지난 24시간",
+      "month": "지난 한 달",
+      "week": "지난 한 주",
+      "year": "지난 한 해"
+    },
+    "date_label": "날짜",
+    "everywhere": "모든 위치",
+    "no_results": "검색 결과가 없습니다",
+    "prompt": "위 검색창에 검색어를 입력하세요.",
+    "results_for": "\"{{q}}\"에 대한 검색 결과",
+    "scope": "범위",
+    "searching_for": "\"{{q}}\" 검색 중…",
+    "see_all": "모든 결과 보기",
+    "size": {
+      "all": "전체 크기",
+      "large": "100MB 초과",
+      "medium": "1–100MB",
+      "small": "1MB 미만"
+    },
+    "sort": {
+      "largest": "큰 순",
+      "name_asc": "이름 오름차순",
+      "name_desc": "이름 내림차순",
+      "newest": "최신순",
+      "oldest": "오래된 순",
+      "relevance": "관련도순",
+      "smallest": "작은 순"
+    },
+    "sort_by": "정렬 기준",
+    "this_folder": "이 폴더"
   },
   "sizeBucket": {
-    "folders": "폴더"
+    "folders": "폴더",
+    "empty": "비어 있음 (0B)",
+    "huge": "5GB 초과",
+    "large": "1–5GB",
+    "medium": "100MB–1GB",
+    "small": "1–100MB",
+    "tiny": "1MB 미만"
   },
   "view": {
     "grid": "그리드 보기",
-    "list": "목록 보기"
+    "list": "목록 보기",
+    "label": "보기 옵션"
+  },
+  "people": {
+    "unnamed": "이름 없음",
+    "empty": "아직 인물이 없습니다",
+    "disabled": "얼굴 인식이 비활성화되어 있습니다",
+    "rename_title": "이 인물의 이름 지정",
+    "name_label": "이름",
+    "back": "뒤로"
+  },
+  "about": {
+    "description": "OxiCloud — 빠르고 셀프 호스팅 가능한 파일 저장 및 동기화 서버입니다."
+  },
+  "cmdk": {
+    "no_results": "일치하는 명령이 없습니다",
+    "placeholder": "명령을 입력하거나 검색하세요…",
+    "title": "명령 팔레트",
+    "toggle_theme": "테마 전환"
+  },
+  "errors_loadFailed": "항목을 불러오지 못했습니다",
+  "settings": {
+    "language": "언어"
+  },
+  "shared_with_me": {
+    "empty": "아직 공유받은 항목이 없습니다.",
+    "from": "{{who}}님이 공유함"
+  },
+  "sortdir": {
+    "title": "정렬 방향"
   }
 }


### PR DESCRIPTION
## Motivation

The Korean (`ko`) locale (`frontend/static/locales/ko.json`) already existed and was already
registered in `frontend/src/lib/i18n/index.svelte.ts`, but it was only ~73% complete
(1015/1392 keys) — several feature areas added since the initial translation had no Korean
strings at all, so those UI surfaces silently fell back to English (or a raw key) for
Korean-speaking users.

한국어 로케일 파일은 이미 존재했지만 약 27%의 키(377개)가 비어 있어, 관리자 플러그인
관리, 스토리지/OIDC/SMTP 설정, 사진, 음악 재생목록, 기기 페어링, 검색 필터, 공유 대화상자
등 최근 추가된 기능 영역이 한국어로 표시되지 않는 문제가 있었습니다. 이번 PR로 누락된
번역을 모두 채워 완전한 한국어 지원을 제공합니다.

## Changes

- `frontend/static/locales/ko.json`: added the 377 missing leaf keys, bringing the file to
  full 1392/1392 parity with `en.json`. No existing translated values were altered, reordered,
  or removed — the diff is purely additive (the only "deletions" in the diff are trailing
  commas added to the previous last key of an object when new keys were appended after it).
- Missing keys spanned `admin.*` (125, plugin management/storage/OIDC/SMTP/encryption/
  migration), `files.*` (48), `search.*` (32), `share.*` (31), `music.*` (19), `photos.*`,
  `auth.*`, `device.*`, `nextcloud.*`, plus new top-level sections (`about`, `cmdk`,
  `errors_loadFailed`, `people`, `settings`, `shared_with_me`, `sortdir`).
- No code changes were needed — `ko` was already present in `SUPPORTED_LOCALES` and
  `LANGUAGES` in `frontend/src/lib/i18n/index.svelte.ts` (한국어 / 🇰🇷).

## Testing

- Wrote a script comparing every leaf key of `ko.json` against `en.json`: confirmed exact
  1392/1392 parity (0 missing, 0 extra keys).
- Verified every `{{placeholder}}` token set in each newly-added Korean string matches the
  corresponding English string's token set (0 mismatches across all 1392 keys).
- Ran `npx prettier --check static/locales/ko.json` — passes.
- Ran the existing i18n unit suite (`vitest run src/lib/i18n/i18n.test.ts`) — all 14 tests pass.
- Manually spot-checked ~20 of the newly-added translations across `admin.*`, `files.*`,
  `search.*`, `share.*`, `music.*`, `photos.*`, `device.*`, `nextcloud.*` for naturalness,
  correct register (consistent formal `-습니다/-세요` tone matching the existing file), and
  correct handling of interpolation placeholders (including natural Korean word-order
  reordering where needed, e.g. `photos.trash_partial`).

Note: the pre-existing (untouched) part of `ko.json` has a few literal English leftover
strings out of scope for this PR (e.g. `share.directoryUnavailable`, `auth.capsLock`,
`music.can_write`) — left as-is since they predate this change and are a separate cleanup.
