### PR TITLE
chore(vitepress): convert ../ references to DioCrafts/OxiCloud links

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,52 @@
 import { defineConfig } from "vitepress";
+import type MarkdownIt from "markdown-it";
+
+// When a doc page links to a source-tree file with a relative path
+// escaping the docs directory (e.g. `[build.rs](../build.rs)` or
+// `[handler](../src/…/file_handler.rs)`), VitePress rightly flags it
+// as a dead link — those files aren't part of the built site. On the
+// deployed site the click would 404. Locally in an editor / on
+// GitHub, though, those relative paths ARE useful — they let a
+// reader jump to the actual source.
+//
+// This plugin bridges the two: at build time, links whose href
+// starts with `../` get rewritten to their equivalent GitHub blob
+// URL. Source stays terse and useful in-editor; deployed site links
+// resolve on GitHub instead of 404ing.
+//
+// Same repo the `editLink` already points at + the main branch —
+// keep in sync if the canonical repo ever moves.
+const GITHUB_REPO = "DioCrafts/OxiCloud";
+const GITHUB_BRANCH = "main";
+
+function rewriteSourceTreeLinks(md: MarkdownIt): void {
+  const defaultRender =
+    md.renderer.rules.link_open ??
+    ((tokens, idx, options, _env, self) =>
+      self.renderToken(tokens, idx, options));
+  md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    const token = tokens[idx];
+    const hrefIdx = token.attrIndex("href");
+    if (hrefIdx >= 0) {
+      const href = token.attrs![hrefIdx][1];
+      // Match paths that escape the docs directory. Only `../` prefix
+      // is targeted — leaves in-docs relative links alone so real
+      // dead links still get caught.
+      if (href.startsWith("../")) {
+        // Strip the leading `../` — everything after is the repo-root
+        // relative path. `#L123` line anchors on GitHub are preserved
+        // as-is because the URL fragment isn't touched.
+        const path = href.slice(3);
+        token.attrs![hrefIdx][1] =
+          `https://github.com/${GITHUB_REPO}/blob/${GITHUB_BRANCH}/${path}`;
+        // Open in a new tab since it now leaves the doc site.
+        token.attrSet("target", "_blank");
+        token.attrSet("rel", "noopener noreferrer");
+      }
+    }
+    return defaultRender(tokens, idx, options, env, self);
+  };
+}
 
 export default defineConfig({
   title: "OxiCloud",
@@ -26,6 +74,9 @@ export default defineConfig({
     image: {
       lazyLoading: true,
     },
+    // Rewrite `../src/…`, `../build.rs`, etc. → GitHub blob URLs at
+    // build time. See the `rewriteSourceTreeLinks` docstring above.
+    config: (md) => rewriteSourceTreeLinks(md),
   },
 
   lastUpdated: true,


### PR DESCRIPTION
This unblocks site generation and link code reference to github DioCrafts/OxiCloud project

this should fix this: https://github.com/AtalayaLabs/OxiCloud/actions/runs/29279108734/job/86915599344

```
  vitepress v1.6.4

- building client + server bundles...

The language 'env' is not loaded, falling back to 'txt' for syntax highlighting.

The language 'env' is not loaded, falling back to 'txt' for syntax highlighting.


(!) Found dead link ./../build.rs in file UIUX-ROADMAP.md
(!) Found dead link ./../src/common/mime_detect.rs in file UIUX-ROADMAP.md
(!) Found dead link ./../src/interfaces/api/handlers/file_handler.rs in file UIUX-ROADMAP.md
(!) Found dead link ./../static/manifest.webmanifest in file UIUX-ROADMAP.md
(!) Found dead link ./../build.rs in file UIUX-ROADMAP.md
(!) Found dead link ./../frontend/src/lib/components/Modal.svelte in file DESIGN-SYSTEM.md

If this is expected, you can disable this check via config. Refer: https://vitepress.dev/reference/site-config#ignoredeadlinks

x Build failed in 3.41s
✖ building client + server bundles...
build error:
[vitepress] 6 dead link(s) found.
[vitepress] 6 dead link(s) found.
    at Object.renderStart (file:///home/runner/work/OxiCloud/OxiCloud/docs/node_modules/vitepress/dist/node/chunk-D3CUZ4fa.js:45027:15)
    at file:///home/runner/work/OxiCloud/OxiCloud/docs/node_modules/rollup/dist/es/shared/node-entry.js:22967:40
    at async Promise.all (index 0)
    at async PluginDriver.hookParallel (file:///home/runner/work/OxiCloud/OxiCloud/docs/node_modules/rollup/dist/es/shared/node-entry.js:22877:9)
    at async Bundle.generate (file:///home/runner/work/OxiCloud/OxiCloud/docs/node_modules/rollup/dist/es/shared/node-entry.js:20991:13)
    at async file:///home/runner/work/OxiCloud/OxiCloud/docs/node_modules/rollup/dist/es/shared/node-entry.js:23954:27
    at async catchUnfinishedHookActions (file:///home/runner/work/OxiCloud/OxiCloud/docs/node_modules/rollup/dist/es/shared/node-entry.js:23321:16)
Error: Process completed with exit code 1.
```