### PR TITLE
perf: round 10 — auth alloc purge, parent-herd batching, query-shape pack, NC 304s

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ chrono = { version = "0.4.45", features = ["serde"] }
 # component. If a spec conformance gap is found, we contribute upstream.
 ical = "0.11"
 http-body = "1.0.1"
-serde = { version = "1.0.228", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive", "rc"] }
 serde_json = "1.0.150"
 futures = "0.3.32"
 async-stream = "0.3.6"
@@ -348,6 +348,25 @@ required-features = ["bench"]
 [[example]]
 name = "bench_micro_allocs"
 path = "examples/bench_micro_allocs.rs"
+required-features = ["bench"]
+
+# Round-10 battery ────────────────────────────────────────────────────────────
+
+# Round-10 CPU/alloc micro-pack — auth identity build, basic-auth hit,
+# PROPFIND/trashbin int+date emits, webdav scope probe, base_url snapshot,
+# JWT verify-miss keys, cipher Arc, request-id. No Postgres.
+[[example]]
+name = "bench_round10_micro"
+path = "examples/bench_round10_micro.rs"
+required-features = ["bench"]
+
+# Round-10 query-shape pack — share download double-fetch, calendar-id narrow
+# read, contact-group COUNT, trash partial indexes, favorites/recents binary
+# UUID decode, save_faces UNNEST, playlist reorder UNNEST, search 3-query
+# join!, move drive-lookup join! (needs the dev Postgres up).
+[[example]]
+name = "bench_round10_queries"
+path = "examples/bench_round10_queries.rs"
 required-features = ["bench"]
 
 # Round-9 battery ─────────────────────────────────────────────────────────────

--- a/benches/ROUND10.md
+++ b/benches/ROUND10.md
@@ -1,0 +1,325 @@
+# Round 10 — auth alloc purge, parent-resolution herd batching, query-shape pack, NC conditional revalidation
+
+Benchmark-gated, same rule as ROUND2-9: every change ships with a
+BEFORE/AFTER benchmark and equivalence/safety gates; an AFTER that doesn't
+beat its BEFORE gets rolled back or redesigned. Two items this round went
+through exactly that loop: the stack integer formatters first benchmarked
+SLOWER than `to_string()` and were rewritten (§13) before adoption, and the
+first parent-batching design (a channel task) measured 66 µs of pure hop
+overhead per sequential miss and was replaced by the leader-inline protocol
+(§10) before adoption.
+
+Measured on 4 cores / 15 GiB, local PostgreSQL 16 (fsync off), release
+profile; frontend on Node 26 / vitest 4 (jsdom). Reproduce any row with the
+command in its section.
+
+## Summary
+
+| # | change | key metric | before → after |
+|--:|---|---|---|
+| 1 | Authenticated-request identity build (`Arc<str>` claims + inline `SmolStr` role) | allocs / ns per request | 4 → 1 allocs · 77 → 59 ns |
+| 2 | Basic-auth cache hit (`Arc<str>` cached identity) | allocs / ns per DAV request | 3 → 0 allocs · 62 → 41 ns |
+| 3 | Share download metadata double-fetch → `_preloaded` | queries / ms per download | 2 → 1 · 0.700 → 0.321 ms (**2.18x**) |
+| 4 | Contact-group summary → `COUNT(*)` | ms, 500-member group | 5.76 → 0.39 (**14.9x**) |
+| 5 | `save_faces` per-face INSERT loop → UNNEST batch | ms, 30-face image | 5.90 → 1.52 (**3.9x**) |
+| 6 | Playlist reorder per-track UPDATE loop → UNNEST | ms, 500-track reorder | 167.0 → 2.6 (**63.7x**), now atomic |
+| 7 | Search page files∥folders `tokio::join!` | ms per search | 4.16 → 2.87 (**1.45x**) |
+| 8 | Move pre-check drive lookups `join!` | ms per move | 0.664 → 0.311 (**2.14x**) |
+| 9 | Trash listing partial `(drive_id, trashed_at) WHERE is_trashed` | ms per page (30-drive box) | 0.615 → 0.496 (**1.2x**) |
+| 10 | Parent-resolution herd batching (leader-inline) | parent queries, 100-thumb cold herd | **100 → 2** · herd wall 65.5 → 35.4 ms (**1.9x**) |
+| 11 | Folder-cascade single-flight (`try_get_with`) | ltree queries, same-folder cold herd | K → 1 (rode along with §10's gates) |
+| 12 | NC preview + avatar honour `If-None-Match` | bytes/req on revalidation (e2e) | preview 5 004 → 0 · avatar 196 992 → 0 |
+| 13 | `common::fmt` integer LUT rewrite | ns/op vs `to_string()` | i64: 33.7 → **16.1** (std: 22.5) |
+| 14 | NC PROPFIND int props + trashbin dates → stack fmt | allocs per 500-row page / 2000-item bin | 1 501 → 1 · 4 002 → 2 (wall 1.11x / 1.13x) |
+| 15 | WebDAV scope probe, base_url snapshot, cookie OnceLock, JWT keys, cipher Arc, request-id | see §15 | e.g. base_url listing 71.5 µs → 1 ns |
+| 16 | CalDAV update/delete gate narrow read | ms (11 KB `ical_data` row) | 0.323 → 0.308 (1.05x + 11 KB less wire) |
+| 17 | Legacy favorites/recents rows: binary UUID decode | ms per 500-row page | 2.80 → 2.58 (**1.09x**) |
+| 18 | SPA: search stale-guard + AbortController | completed round-trips, 10-query burst | 10 → 1; stale-clobber eliminated |
+| 19 | SPA: `getFolder` in-flight dedup | requests per cold deep-link | 2 → 1 |
+| 20 | SPA: `gridColumns` matchMedia hoist | MQL constructions / 10k calls | 10 000 → 0 · 13.4 → 2.6 ms (**5.2x**) |
+
+Plus: `count_files` (a dead port method whose impl ran the full paginated
+search) deleted outright; NC chunk PUT retry-probe folded into the open
+(`create_new`, one stat less per chunk); tantivy per-query analyzer
+double-clone dropped.
+
+## [1][2] Auth hot path — the ROUND6/9 deferred "cheapest known win"
+
+Every authenticated request built `CurrentUser` by deep-cloning
+`username`/`email` out of the cached `Arc<TokenClaims>` and `to_string`ing
+the live role — the exact 2-allocs-per-request item deferred since ROUND6,
+plus two more nobody had counted (`flags.role.to_string()` in
+`decide_live_role`, and the Basic-auth cache handing out 3 owned Strings
+per moka hit on every DAV request).
+
+Now: `TokenClaims.username/email` are `Arc<str>` (serde `rc`, same one
+allocation at decode time), `CurrentUser.username/email` are `Arc<str>`
+(refcount bumps), `CurrentUser.role` is an inline `SmolStr` fed by
+`LiveRole::Active(SmolStr)` + the new `UserRole::as_str()` (`&'static`,
+zero alloc), and `CachedBasicAuthResult` carries the same types so a
+Basic hit is bumps + a 24-byte memcpy. JSON wire shape is unchanged
+(byte-identity gated); OpenAPI keeps `String` via `value_type`.
+
+```
+cargo run --release --features bench --example bench_round10_micro
+# [1] identity build  BEFORE 77.2 ns / 4.00 allocs → AFTER 59.0 / 1.00
+#     gate: fields + serialized JSON byte-identical
+# [2] basic-auth hit  BEFORE 62.2 ns / 3.00 allocs → AFTER 40.9 / 0.00
+```
+
+The JWT service also stopped rebuilding `EncodingKey`/`DecodingKey`/
+`Validation` per call (now fields; the verify-miss path drops 4 allocs,
+§15), and `generate_access_token`'s `format!("{}", role)` became
+`as_str().to_string()`.
+
+## [3] Share download — the handler already had the DTO
+
+`serve_share_file` fetched the file DTO for ETag/Range handling, then
+called `get_file_optimized`, which re-ran the same metadata query. The
+authenticated download path already used `get_file_optimized_preloaded`;
+the public-share path now does too (the DTO is moved, not cloned — the
+one later use of `size` is captured first).
+
+```
+cargo run --release --features bench --example bench_round10_queries
+# [1] BEFORE 2 queries 0.700 ms/download → AFTER 1 query 0.321 ms (2.18x)
+```
+
+## [4] Contact-group summary — 500 vCards hydrated to compute `len()`
+
+`get_group` called `get_contacts_in_group` — full rows (vCard TEXT that
+can carry base64 photos + 3 JSONB arrays parsed per contact) — and kept
+only the count. New `count_contacts_in_group` port method backed by
+`SELECT COUNT(*)` on `group_memberships`.
+
+```
+# [3] 500 members: BEFORE hydrate-all 5.762 ms → AFTER COUNT(*) 0.387 (14.9x)
+```
+
+## [5][6] Write-path N+1 loops → one UNNEST statement
+
+- `save_faces`: one INSERT per face inside a transaction → a single
+  multi-row `INSERT … SELECT FROM unnest(...)` (the `bbox` float4[] rides
+  as 4 parallel component arrays, reassembled server-side). 30-face image:
+  5.90 → 1.52 ms (**3.9x**); gate re-reads a stored row field-by-field.
+- `reorder_items`: one autocommit UPDATE per track (non-atomic — a
+  mid-loop failure left a half-applied order) → one
+  `UPDATE … FROM unnest($1) WITH ORDINALITY`. 500-track reorder:
+  167.0 → 2.6 ms (**63.7x**); gate compares every final position.
+
+## [7][8] Independent awaits overlapped (`join!`, decide-by-bench)
+
+- `SearchService::search` awaited the content-index lookup, the file page
+  and the folder query serially in both branches; `suggest_with_perms` had
+  the correct shape since ROUND4. All three are independent; the two SQL
+  arms measured 4.16 → 2.87 ms (**1.45x**) with identical results.
+  (Content-index enabled widens the win — the Tantivy arm is the long pole
+  and now overlaps both queries.)
+- File/folder move pre-check ran the source-drive-policies and
+  destination-drive point reads serially before comparing:
+  0.664 → 0.311 ms (**2.14x**). Adopted per the ROUND6 protocol (these are
+  two independent point reads whose server-side execution parallelizes —
+  the shape that wins even on a local socket).
+- The NC PROPFIND folder-HEADER trio (favorites + oc:fileid + dead props
+  for the folder's own entry, on the TTFB critical path of every folder
+  PROPFIND) got the same `join!` ROUND9 gave the per-page child triples.
+
+## [9] Trash listing — the dropped-index gap
+
+Migration 20260904 removed `user_id` and with it the only trash-listing
+index; what remained forced either a live-rows scan of the drive
+(`idx_files_drive_id`) or an all-tenants trash scan
+(`idx_files_trash_expiry`). New partial pair
+`(drive_id, trashed_at) WHERE is_trashed` (migration 20260920000000)
+bounds the read to the caller's drives' trashed rows, pre-ordered for the
+`trashed_at`/`deletion_date` keysets. On a 30-drive box (3 000 live + 25
+trashed each): 0.615 → 0.496 ms (**1.2x**); the gap widens with drive size
+since the BEFORE plan scans live rows. Identical row sets gated; the
+retention sweeper keeps its global expiry index.
+
+## [10][11] Cold-album herd — parent batching + cascade single-flight
+
+ROUND9 §10 left the cold first view paying one parent PK read per photo
+and noted batching "needs a wider engine API". It doesn't: the browser
+fires its thumbnail requests near-simultaneously, so the batching can live
+INSIDE `file_parent_folder_cached`:
+
+- **Leader-inline protocol** (`parent_batch` slot): an idle miss marks
+  itself leader (one mutex op) and runs its point query exactly as before
+  — the sequential path is unchanged (a channel-task design measured
+  ~66 µs/miss of hop overhead and was REJECTED). Misses arriving while
+  the leader is in flight park a oneshot; the leader serves them all with
+  ONE `id = ANY($1)` charity batch after its own read; a second wave is
+  handed to a detached drainer so the leader's response is never delayed
+  by more than one batch. A cancelled leader's guard wakes every parked
+  waiter to re-elect; waiters that exhaust retries fall back to the
+  inline point read. Requested-but-absent ids memoise as `None`,
+  matching the point read's semantics.
+- **`cascade_grant_cached` → `try_get_with`** (the ROUND3 auth-herd
+  pattern): K concurrent files of one album all recurse into the SAME
+  folder decision; get→compute→insert let each run the ltree query.
+  Single-flight collapses that to one loader; moka never caches loader
+  errors, preserving error semantics.
+
+```
+cargo run --release --features bench --example bench_thumbnail_cascade_cache
+# thumbs=100 (folder-grant recipient, no drive membership)
+# ROUND8 cold (union/file)      65.59 ms   655.90 µs/thumb
+# AFTER cold sequential         65.53 ms   655.33 µs/thumb  (parity — no
+#   sequential regression from the protocol; this box's high per-query
+#   latency compresses the R9 decomposition margin visible on faster I/O)
+# AFTER warm (revalidation)      0.14 ms     1.42 µs/thumb  (unchanged)
+# AFTER herd (concurrent cold)  35.35 ms   353.47 µs/thumb  (~1.9x vs
+#   sequential cold — and the real shape of a grid's first view)
+#   parent queries for the herd: 2   (was 100)
+# gates: all original ROUND8/9 safety gates (outsider denied, clear_role
+#   revoke denies immediately, direct-grant sibling isolation) plus NEW:
+#   herd answers == point-read answers per file, parent queries < K/4
+```
+
+## [12] NC preview + avatar — ETag existed, nobody compared it
+
+- `/index.php/core/preview` set an immutable ETag but never read
+  `If-None-Match` — every gallery revalidation re-ran NC-id resolve, file
+  fetch, authz, blob-hash query, thumbnail cache read and full body. The
+  handler now answers 304 right after the authz check (never before it).
+- `/index.php/avatar/{user}/{size}` had no ETag at all, and re-decoded the
+  stored data URI on every request (for WebP avatars: a full image decode
+  + PNG encode per request). Now: content-hash ETag (over the stored URI,
+  computed before any decode), 304 on match, and the WebP→PNG transcode
+  memoised in a 32-entry moka keyed by content hash.
+
+End-to-end (real server + curl loops, the PHOTOS-ETAG methodology; 60
+requests per arm):
+
+```
+# preview  200: 5 004 bytes/req  1.35 ms   →  304: 0 bytes  1.25 ms
+# avatar   200: 196 992 bytes/req 2.30 ms  →  304: 0 bytes  1.97 ms
+# gates: fresh GET 200 with ETag; matching If-None-Match → 304 empty;
+#        stale If-None-Match → full 200. All six pass.
+```
+
+Per NC client per cache-lapse this removes ~197 KB (avatar) + ~5 KB/photo
+(previews) of transfer plus the per-request DB/disk work behind them.
+
+## [13] `common::fmt` — the bench caught our own helpers losing
+
+The round's first micro run showed the PROPFIND int-field port SLOWER on
+wall despite 1 500 fewer allocs. An isolated interleaved probe confirmed:
+the byte-at-a-time div-by-10 loop in `u64_str` (33.7 ns) lost to
+`u64::to_string()` (22.5 ns) — std renders via a 2-digit lookup table.
+Rewrote `u64_str`/`i64_str` (and the date helpers' `push2`) on the same
+`DEC_LUT` technique, dropping `i64_str`'s temp-buffer copy:
+
+```
+# interleaved probe, 20M ops/arm
+# to_string 22.5 ns   i64_str BEFORE 33.7 ns → AFTER 16.1 ns
+# to_rfc2822 42.7 ns  rfc2822_utc 33.6 ns
+```
+
+This speeds every existing ROUND4-9 call site (`d:getcontentlength`,
+`oc:size`, digest lengths, dates) as well as the new ones.
+
+## [14] NC PROPFIND / trashbin emit stragglers
+
+With §13 in place, the remaining `to_string()`/`to_rfc2822()` fields moved
+to the stack helpers: `oc:fileid`, `nc:creation_time`, `nc:upload_time`,
+quota bytes (files + folders writers), and the trashbin's per-item
+modified/deletion-time/fileid (which still ran the chrono interpreter).
+
+```
+# [3] 500-row page  BEFORE 95.5 µs / 1501 allocs → AFTER 86.3 / 1   (1.11x)
+# [4] 2000-item bin BEFORE 318.5 µs / 4002 allocs → AFTER 280.7 / 2 (1.13x)
+# gates: XML byte-identical in both harnesses
+```
+
+## [15] Micro-pack (each gated in `bench_round10_micro`)
+
+- **WebDAV scope probe**: `format!("{prefix}/")` per request → borrow-only
+  `strip_prefix` pair. 38 → 3.5 ns, 1 → 0 allocs, identical routing.
+- **`ShareService.base_url`**: `env::var("OXICLOUD_BASE_URL")` + rebuild
+  PER DTO ROW → constructor snapshot. 500-row listing: 71.5 µs → 1 ns.
+- **`cookie_secure`**: 4 env-var resolutions + duplicate SECURITY log
+  lines per login → `OnceLock` (process-invariant by definition).
+- **JWT verify miss**: fresh `Validation` + `DecodingKey` per decode →
+  service fields. 4 748 → 4 527 ns, 17 → 13 allocs (HMAC dominates).
+- **`EncryptedBlobBackend`**: per-op clone of the expanded AES-256 round
+  keys → `Arc` bump. 30.8 → 13.3 ns per hand-off.
+- **Request-id header**: `Uuid::to_string` + `HeaderValue::from_str` →
+  stack-encode. 85 → 46 ns, 2 → 1 allocs, identical bytes.
+- **NC chunk PUT**: the retry-detection `stat` per chunk folded into the
+  open — `stream_body_to_path` now opens `create_new` first and reports
+  `created_fresh` (AlreadyExists → truncate-open), the ROUND9 §5a pattern
+  applied to the NC surface.
+
+## [16] CalDAV update/delete gate — narrow `calendar_id` read
+
+The service fetched the FULL event row (with `ical_data` — 11 KB in the
+benched shape, unbounded with attendees/VALARMs) only to read
+`.calendar_id` for the authz gate. New `find_calendar_id_by_event_id`
+scalar. 0.323 → 0.308 ms on a local socket (1.05x) — adopted for the
+direction: the win is the row width off the wire, which grows with event
+size and network distance. (This is NOT the deferred authz-reorder — the
+gate still runs before the mutation, same order.)
+
+## [17] Legacy favorites/recents rows — the ROUND6 §10 port, with a catch
+
+The two legacy listing methods still shipped `::TEXT` casts. Porting them
+to binary decode surfaced that `auth.user_favorites.id` is a SERIAL
+`integer`, not a UUID — the bench's identity gate caught the wrong decode
+before it could ship (decode as `i32`, render app-side). 500-row page:
+2.80 → 2.58 ms (**1.09x**), rendered tuples identical.
+
+## [18][19][20] SPA pack (vitest gates)
+
+```
+cd frontend && npx vitest run src/routes/search/staleGuard.bench.test.ts \
+  src/lib/api/endpoints/folderDedup.bench.test.ts src/lib/utils/grid.bench.test.ts
+```
+
+- **Search stale-response guard** (the flag open since ROUND7): rapid-fire
+  query/sort/filter changes had no seq token and no abort — a slow older
+  response could clobber a newer one, and superseded recursive searches
+  ran to completion server-side. `run()` now carries a sequence token +
+  `AbortController` (threaded through `searchFiles`/`searchSuggest`);
+  AppShell's suggest box got the same guard. 10-query burst: completed
+  round-trips 10 → 1; final result provably fresh (BEFORE ends on the
+  STALE query).
+- **`getFolder` in-flight dedup** (the `resolveUser` pattern): cold
+  deep-links fired the same folder-metadata GET twice (breadcrumbs +
+  drive-id resolver). Concurrent duplicates now share one request;
+  sequential calls still refetch (freshness unchanged, gated).
+- **`gridColumns`**: a fresh `matchMedia` (style read) per call inside the
+  grid windowing derives → one module-level MQL fed by its `change`
+  listener (the photos-timeline fix applied to the shared util). 10k
+  calls: 10 000 → 0 MQL constructions, 13.4 → 2.6 ms; output identity
+  gated across the breakpoint, crossings propagate via the listener.
+
+## Rejected / reworked this round (the discipline working)
+
+- **Channel-task parent batcher**: correct, but the mpsc+oneshot
+  round-trip measured 65.9 µs per sequential miss — a pure regression for
+  the non-concurrent case. Replaced with leader-inline (§10).
+- **First stack-formatter port**: slower than `to_string()` on wall
+  (§13); adopted only after the LUT rewrite made it faster on BOTH axes.
+- **`uf.id` as binary UUID**: wrong type entirely (SERIAL int) — the
+  equivalence gate caught it; shipped as `i32` decode instead.
+
+## Deferred / flagged (not shipped this round)
+
+- **CalDAV authz-before-fetch reorder** — still awaiting maintainer
+  sign-off per the authz-change convention (ROUND9 flag stands).
+- **Grouped file/grid views are unvirtualized** (files group-by and
+  ResourceList grid sections mount every row; the flat/list paths are
+  windowed) — a UI-behaviour change big enough to want its own pass.
+- **`search_files_paginated`'s `COUNT(*) OVER()` + OFFSET** — keyset would
+  change the API's total-count contract; needs a product decision on
+  whether search totals can become approximate/capped.
+- **`ResourceList.selectedEntries`** recomputes an O(N) filter per
+  selection toggle once the toolbar is visible; hosts often shadow it
+  with their own copy. Needs a small API rework (getter or id-index).
+- **Chunk-upload `progress.bin`** full rewrite per chunk (REST surface) —
+  debouncing trades crash-resume granularity; flagged for discussion.
+- **`CachedBlobBackend::local_blob_path`** sync `stat` on the reactor
+  (remote-backend deployments' media hooks) — needs an async variant of
+  the port method; low urgency.

--- a/examples/bench_auth_herd.rs
+++ b/examples/bench_auth_herd.rs
@@ -138,7 +138,7 @@ async fn main() {
     let mut ids = Vec::new();
     while let Some(r) = set.join_next().await {
         let (uid, uname, _, _) = r.expect("join").expect("verify_basic_auth");
-        assert_eq!(uname, username);
+        assert_eq!(&*uname, username.as_str());
         ids.push(uid);
     }
     assert!(ids.iter().all(|&u| u == user_id));

--- a/examples/bench_nc_session.rs
+++ b/examples/bench_nc_session.rs
@@ -117,9 +117,9 @@ fn fixture_folder() -> FolderDto {
 fn fixture_user(id: uuid::Uuid) -> CurrentUser {
     CurrentUser {
         id,
-        username: "alice.longname".to_string(),
-        email: "alice.longname@example.com".to_string(),
-        role: "user".to_string(),
+        username: Arc::from("alice.longname"),
+        email: Arc::from("alice.longname@example.com"),
+        role: smol_str::SmolStr::new_static("user"),
     }
 }
 

--- a/examples/bench_round10_micro.rs
+++ b/examples/bench_round10_micro.rs
@@ -1,0 +1,581 @@
+//! Round-10 CPU/alloc micro-pack — BEFORE replicas vs the shipped code.
+//!
+//! Sections (all pure CPU, no Postgres):
+//!   1. Authenticated-request identity build (Bearer/cookie hit path):
+//!      BEFORE `String` claims clone ×2 + live-role `to_string` + `Arc::new`
+//!      vs AFTER `Arc<str>` refcount bumps + inline `SmolStr` + `Arc::new`.
+//!   2. Basic-auth cache hit: BEFORE `CachedBasicAuthResult{String}` moka
+//!      value clone vs AFTER `Arc<str>`/`SmolStr` bumps.
+//!   3. NC PROPFIND per-row integer props (`oc:fileid`, `nc:creation_time`,
+//!      `nc:upload_time`): BEFORE `to_string()` per field vs AFTER
+//!      `common::fmt` stack render. Gate: byte-identical XML.
+//!   4. NC trashbin date/int props: BEFORE `to_rfc2822()` + `to_string()`
+//!      vs AFTER stack render. Gate: byte-identical XML.
+//!   5. Native-WebDAV scope prefix test: BEFORE `format!("{prefix}/")` per
+//!      request vs AFTER borrow-only check. Gate: identical routing.
+//!   6. Share listing base-url: BEFORE `env::var("OXICLOUD_BASE_URL")` +
+//!      rebuild per row vs AFTER the construction-time snapshot.
+//!   7. JWT verify miss: BEFORE fresh `Validation` + `DecodingKey` per
+//!      decode vs AFTER pre-built fields. Gate: identical claims.
+//!   8. AES-GCM cipher hand-off: BEFORE key-schedule memcpy clone vs AFTER
+//!      `Arc` bump.
+//!   9. Request-id header: BEFORE `Uuid::to_string` + `HeaderValue::from_str`
+//!      vs AFTER stack-encode. Gate: identical header bytes.
+//!
+//! Run: cargo run --release --features bench --example bench_round10_micro
+//! Tunables (env): BENCH_ITERS (100000)
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::env;
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use smol_str::SmolStr;
+
+// ─── Counting allocator ─────────────────────────────────────────────────────
+
+static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+
+struct CountingAlloc;
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
+    env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn measure<R>(label: &str, iters: u64, mut f: impl FnMut() -> R) -> (f64, f64) {
+    // Warmup
+    for _ in 0..1000 {
+        black_box(f());
+    }
+    let a0 = ALLOC_CALLS.load(Ordering::Relaxed);
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        black_box(f());
+    }
+    let wall = t0.elapsed().as_secs_f64();
+    let allocs = (ALLOC_CALLS.load(Ordering::Relaxed) - a0) as f64 / iters as f64;
+    let ns = wall * 1e9 / iters as f64;
+    println!("    {label:<44} {ns:>9.1} ns/op   {allocs:>7.3} allocs/op");
+    (ns, allocs)
+}
+
+// ─── §1 BEFORE replicas: old claim/identity shapes ──────────────────────────
+
+mod before {
+    use std::sync::Arc;
+
+    /// Old `TokenClaims` shape (owned Strings). The unread fields keep
+    /// the replica byte-faithful to the historical struct layout.
+    #[allow(dead_code)]
+    #[derive(Debug, Clone)]
+    pub struct OldTokenClaims {
+        pub sub: String,
+        pub exp: i64,
+        pub iat: i64,
+        pub jti: String,
+        pub username: String,
+        pub email: String,
+        pub role: String,
+    }
+
+    /// Old `CurrentUser` shape.
+    #[derive(Debug, Clone, serde::Serialize)]
+    pub struct OldCurrentUser {
+        pub id: uuid::Uuid,
+        pub username: String,
+        pub email: String,
+        pub role: String,
+    }
+
+    /// Old Bearer-hit tail: deep-clone the two display fields out of the
+    /// cached claims + `to_string` the live role + `Arc::new`.
+    pub fn bearer_identity(claims: &Arc<OldTokenClaims>, live_role: &str) -> Arc<OldCurrentUser> {
+        let role = live_role.to_string(); // decide_live_role's `flags.role.to_string()`
+        Arc::new(OldCurrentUser {
+            id: uuid::Uuid::nil(),
+            username: claims.username.clone(),
+            email: claims.email.clone(),
+            role,
+        })
+    }
+
+    /// Old Basic-auth cached value (owned Strings — moka clones on get).
+    #[derive(Clone)]
+    pub struct OldCachedBasic {
+        pub user_id: uuid::Uuid,
+        pub username: String,
+        pub email: String,
+        pub role: String,
+    }
+}
+
+fn section_identity(iters: u64) {
+    use oxicloud::application::dtos::user_dto::CurrentUser;
+    use oxicloud::application::ports::auth_ports::TokenClaims;
+
+    println!("[1] authenticated-request identity build (per request)");
+    let old_claims = Arc::new(before::OldTokenClaims {
+        sub: "6a11f8a2-14a5-4f8a-9d55-3e3c8a2b9a01".into(),
+        exp: 4_102_444_800,
+        iat: 1_700_000_000,
+        jti: uuid::Uuid::nil().to_string(),
+        username: "alice.longname".to_string(),
+        email: "alice.longname@example.com".to_string(),
+        role: "user".to_string(),
+    });
+    let new_claims = Arc::new(TokenClaims {
+        sub: "6a11f8a2-14a5-4f8a-9d55-3e3c8a2b9a01".into(),
+        exp: 4_102_444_800,
+        iat: 1_700_000_000,
+        jti: uuid::Uuid::nil().to_string(),
+        username: Arc::from("alice.longname"),
+        email: Arc::from("alice.longname@example.com"),
+        role: "user".to_string(),
+    });
+
+    let (bn, ba) = measure("BEFORE String clones + role to_string", iters, || {
+        before::bearer_identity(black_box(&old_claims), black_box("user"))
+    });
+    let (an, aa) = measure("AFTER  Arc bumps + inline SmolStr", iters, || {
+        // The shipped middleware tail: LiveRole render + CurrentUser build.
+        let role = SmolStr::new_static("user");
+        Arc::new(CurrentUser {
+            id: uuid::Uuid::nil(),
+            username: Arc::clone(&black_box(&new_claims).username),
+            email: Arc::clone(&new_claims.email),
+            role,
+        })
+    });
+
+    // Gate: identical field values + identical JSON wire shape.
+    let old = before::bearer_identity(&old_claims, "user");
+    let new = Arc::new(CurrentUser {
+        id: uuid::Uuid::nil(),
+        username: Arc::clone(&new_claims.username),
+        email: Arc::clone(&new_claims.email),
+        role: SmolStr::new_static("user"),
+    });
+    assert_eq!(old.username, *new.username);
+    assert_eq!(old.email, *new.email);
+    assert_eq!(old.role, new.role.as_str());
+    let json_old = serde_json::to_string(&*old).unwrap();
+    let json_new = serde_json::to_string(&*new).unwrap();
+    assert_eq!(json_old, json_new, "CurrentUser JSON shape must not change");
+    println!(
+        "    gate: fields + JSON byte-identical ✓   ({bn:.0}→{an:.0} ns, {ba:.2}→{aa:.2} allocs)"
+    );
+}
+
+fn section_basic_hit(iters: u64) {
+    println!("[2] basic-auth cache hit → tuple hand-off (per DAV request)");
+    let old_val = before::OldCachedBasic {
+        user_id: uuid::Uuid::nil(),
+        username: "dav.client.user".to_string(),
+        email: "dav.client.user@example.com".to_string(),
+        role: "user".to_string(),
+    };
+    struct NewCachedBasic {
+        user_id: uuid::Uuid,
+        username: Arc<str>,
+        email: Arc<str>,
+        role: SmolStr,
+    }
+    impl Clone for NewCachedBasic {
+        fn clone(&self) -> Self {
+            Self {
+                user_id: self.user_id,
+                username: Arc::clone(&self.username),
+                email: Arc::clone(&self.email),
+                role: self.role.clone(),
+            }
+        }
+    }
+    let new_val = NewCachedBasic {
+        user_id: uuid::Uuid::nil(),
+        username: Arc::from("dav.client.user"),
+        email: Arc::from("dav.client.user@example.com"),
+        role: SmolStr::new_static("user"),
+    };
+
+    let (bn, ba) = measure("BEFORE moka value clone (3 Strings)", iters, || {
+        let v = black_box(&old_val).clone(); // what moka's get does
+        (v.user_id, v.username, v.email, v.role)
+    });
+    let (an, aa) = measure("AFTER  moka value clone (bumps)", iters, || {
+        let v = black_box(&new_val).clone();
+        (v.user_id, v.username, v.email, v.role)
+    });
+    let o = old_val.clone();
+    let n = new_val.clone();
+    assert_eq!(o.username, *n.username);
+    assert_eq!(o.email, *n.email);
+    assert_eq!(o.role, n.role.as_str());
+    println!(
+        "    gate: identity fields identical ✓   ({bn:.0}→{an:.0} ns, {ba:.2}→{aa:.2} allocs)"
+    );
+}
+
+// ─── §3/§4 XML emit ─────────────────────────────────────────────────────────
+
+fn write_text_element(
+    xml: &mut quick_xml::Writer<&mut Vec<u8>>,
+    tag: &str,
+    value: &str,
+) -> Result<(), String> {
+    use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+    xml.write_event(Event::Start(BytesStart::new(tag)))
+        .map_err(|e| e.to_string())?;
+    xml.write_event(Event::Text(BytesText::new(value)))
+        .map_err(|e| e.to_string())?;
+    xml.write_event(Event::End(BytesEnd::new(tag)))
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn section_propfind_ints(iters: u64) {
+    println!("[3] NC PROPFIND per-row integer props (500-row page)");
+    let rows: Vec<(i64, u64, u64)> = (0..500)
+        .map(|i| (912_345_678 + i as i64, 1_700_000_000 + i, 1_700_000_100 + i))
+        .collect();
+
+    let emit_before = |buf: &mut Vec<u8>| {
+        let mut xml = quick_xml::Writer::new(buf);
+        for &(fid, created, modified) in &rows {
+            write_text_element(&mut xml, "oc:fileid", &fid.to_string()).unwrap();
+            write_text_element(&mut xml, "nc:creation_time", &created.to_string()).unwrap();
+            write_text_element(&mut xml, "nc:upload_time", &modified.to_string()).unwrap();
+        }
+    };
+    let emit_after = |buf: &mut Vec<u8>| {
+        let mut xml = quick_xml::Writer::new(buf);
+        for &(fid, created, modified) in &rows {
+            let mut ibuf = [0u8; 21];
+            write_text_element(
+                &mut xml,
+                "oc:fileid",
+                oxicloud::common::fmt::i64_str(&mut ibuf, fid),
+            )
+            .unwrap();
+            let mut ubuf = [0u8; 20];
+            write_text_element(
+                &mut xml,
+                "nc:creation_time",
+                oxicloud::common::fmt::u64_str(&mut ubuf, created),
+            )
+            .unwrap();
+            write_text_element(
+                &mut xml,
+                "nc:upload_time",
+                oxicloud::common::fmt::u64_str(&mut ubuf, modified),
+            )
+            .unwrap();
+        }
+    };
+
+    let mut b1 = Vec::with_capacity(64 * 1024);
+    emit_before(&mut b1);
+    let mut b2 = Vec::with_capacity(64 * 1024);
+    emit_after(&mut b2);
+    assert_eq!(b1, b2, "XML must be byte-identical");
+
+    let page_iters = iters / 500;
+    let (bn, ba) = measure("BEFORE to_string per int field", page_iters, || {
+        let mut buf = Vec::with_capacity(64 * 1024);
+        emit_before(&mut buf);
+        buf
+    });
+    let (an, aa) = measure("AFTER  stack i64_str/u64_str", page_iters, || {
+        let mut buf = Vec::with_capacity(64 * 1024);
+        emit_after(&mut buf);
+        buf
+    });
+    println!(
+        "    gate: 500-row page byte-identical ✓   page: {:.1}→{:.1} µs, {:.0}→{:.0} allocs",
+        bn / 1e3,
+        an / 1e3,
+        ba,
+        aa
+    );
+}
+
+fn section_trashbin(iters: u64) {
+    println!("[4] NC trashbin per-item date/int props (2000-item bin)");
+    let items: Vec<i64> = (0..2000).map(|i| 1_700_000_000 + i * 37).collect();
+
+    let emit_before = |buf: &mut Vec<u8>| {
+        let mut xml = quick_xml::Writer::new(buf);
+        for &ts in &items {
+            let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0).unwrap();
+            write_text_element(&mut xml, "d:getlastmodified", &dt.to_rfc2822()).unwrap();
+            write_text_element(&mut xml, "nc:trashbin-deletion-time", &ts.to_string()).unwrap();
+        }
+    };
+    let emit_after = |buf: &mut Vec<u8>| {
+        let mut xml = quick_xml::Writer::new(buf);
+        for &ts in &items {
+            let mut dbuf = [0u8; 31];
+            // The shipped path goes through write_date_element → rfc2822_utc
+            // with a chrono fallback; in-range timestamps take the stack path.
+            let s = oxicloud::common::fmt::rfc2822_utc(&mut dbuf, ts).unwrap();
+            write_text_element(&mut xml, "d:getlastmodified", s).unwrap();
+            let mut ibuf = [0u8; 21];
+            write_text_element(
+                &mut xml,
+                "nc:trashbin-deletion-time",
+                oxicloud::common::fmt::i64_str(&mut ibuf, ts),
+            )
+            .unwrap();
+        }
+    };
+
+    let mut b1 = Vec::with_capacity(256 * 1024);
+    emit_before(&mut b1);
+    let mut b2 = Vec::with_capacity(256 * 1024);
+    emit_after(&mut b2);
+    assert_eq!(b1, b2, "trashbin XML must be byte-identical");
+
+    let bin_iters = (iters / 2000).max(20);
+    let (bn, ba) = measure("BEFORE chrono to_rfc2822 + to_string", bin_iters, || {
+        let mut buf = Vec::with_capacity(256 * 1024);
+        emit_before(&mut buf);
+        buf
+    });
+    let (an, aa) = measure("AFTER  stack rfc2822_utc + i64_str", bin_iters, || {
+        let mut buf = Vec::with_capacity(256 * 1024);
+        emit_after(&mut buf);
+        buf
+    });
+    println!(
+        "    gate: 2000-item bin byte-identical ✓   bin: {:.1}→{:.1} µs, {:.0}→{:.0} allocs",
+        bn / 1e3,
+        an / 1e3,
+        ba,
+        aa
+    );
+}
+
+// ─── §5 webdav scope prefix ─────────────────────────────────────────────────
+
+fn section_scope_prefix(iters: u64) {
+    println!("[5] native-WebDAV scope prefix test (per request)");
+    // 1:1 replicas of the two shapes (the production fn is handler-private).
+    fn before_route(normalized: &str, marker: &str) -> Option<usize> {
+        let with_slash = format!("{}/", marker);
+        normalized.strip_prefix(&with_slash).map(|r| r.len())
+    }
+    fn strip_prefix_slash<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+        s.strip_prefix(prefix)?.strip_prefix('/')
+    }
+    fn after_route(normalized: &str, marker: &str) -> Option<usize> {
+        strip_prefix_slash(normalized, marker).map(|r| r.len())
+    }
+
+    let cases = [
+        ("@drive/Personal/Photos/2026/img.jpg", "@drive"),
+        ("Personal/Documents/report.pdf", "@drive"),
+        ("@drive", "@drive"),
+        ("@driveX/nope", "@drive"),
+    ];
+    for (path, marker) in cases {
+        assert_eq!(before_route(path, marker), after_route(path, marker));
+    }
+
+    let (bn, ba) = measure("BEFORE format!(\"{prefix}/\") probe", iters, || {
+        before_route(
+            black_box("@drive/Personal/Photos/2026/img.jpg"),
+            black_box("@drive"),
+        )
+    });
+    let (an, aa) = measure("AFTER  borrow-only probe", iters, || {
+        after_route(
+            black_box("@drive/Personal/Photos/2026/img.jpg"),
+            black_box("@drive"),
+        )
+    });
+    println!(
+        "    gate: routing identical on all shapes ✓   ({bn:.0}→{an:.0} ns, {ba:.2}→{aa:.2} allocs)"
+    );
+}
+
+// ─── §6 base_url ────────────────────────────────────────────────────────────
+
+fn section_base_url(iters: u64) {
+    println!("[6] share-listing base_url (per 500-row listing)");
+    unsafe {
+        env::set_var("OXICLOUD_BASE_URL", "https://cloud.example.com");
+    }
+    let config = oxicloud::common::config::AppConfig::default();
+    let rows = 500usize;
+
+    let before_listing = || {
+        let mut total = 0usize;
+        for _ in 0..rows {
+            total += config.base_url().len(); // env read + String per row
+        }
+        total
+    };
+    let snapshot = config.base_url();
+    let after_listing = || {
+        let mut total = 0usize;
+        for _ in 0..rows {
+            total += snapshot.len(); // field read
+        }
+        total
+    };
+    assert_eq!(before_listing(), after_listing());
+
+    let listing_iters = (iters / rows as u64).max(50);
+    let (bn, ba) = measure("BEFORE env::var + rebuild per row", listing_iters, || {
+        before_listing()
+    });
+    let (an, aa) = measure("AFTER  construction-time snapshot", listing_iters, || {
+        after_listing()
+    });
+    println!(
+        "    gate: identical URLs ✓   listing: {:.1}→{:.3} µs, {:.0}→{:.0} allocs",
+        bn / 1e3,
+        an / 1e3,
+        ba,
+        aa
+    );
+}
+
+// ─── §7 JWT verify miss ─────────────────────────────────────────────────────
+
+fn section_jwt(iters: u64) {
+    use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, encode};
+
+    println!("[7] JWT verify (validation-cache miss path)");
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct C {
+        sub: String,
+        exp: i64,
+        iat: i64,
+        jti: String,
+        username: String,
+        email: String,
+        role: String,
+    }
+    let secret = "bench_secret_key_at_least_32_bytes_long!";
+    let claims = C {
+        sub: uuid::Uuid::nil().to_string(),
+        exp: 4_102_444_800,
+        iat: 1_700_000_000,
+        jti: uuid::Uuid::nil().to_string(),
+        username: "alice".into(),
+        email: "alice@example.com".into(),
+        role: "user".into(),
+    };
+    let token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(secret.as_bytes()),
+    )
+    .unwrap();
+
+    let jwt_iters = iters / 10;
+    let (bn, ba) = measure("BEFORE fresh Validation+DecodingKey", jwt_iters, || {
+        let validation = Validation::new(Algorithm::HS256);
+        let key = DecodingKey::from_secret(secret.as_bytes());
+        decode::<C>(black_box(&token), &key, &validation)
+            .unwrap()
+            .claims
+            .exp
+    });
+    let key = DecodingKey::from_secret(secret.as_bytes());
+    let validation = Validation::new(Algorithm::HS256);
+    let (an, aa) = measure("AFTER  pre-built service fields", jwt_iters, || {
+        decode::<C>(black_box(&token), &key, &validation)
+            .unwrap()
+            .claims
+            .exp
+    });
+    println!("    gate: same decode result ✓   ({bn:.0}→{an:.0} ns, {ba:.2}→{aa:.2} allocs)");
+}
+
+// ─── §8 cipher clone ────────────────────────────────────────────────────────
+
+fn section_cipher(iters: u64) {
+    use aes_gcm::{Aes256Gcm, KeyInit};
+
+    println!("[8] AES-GCM cipher hand-off (per blob op)");
+    let cipher = Aes256Gcm::new_from_slice(&[7u8; 32]).unwrap();
+    let arc_cipher = Arc::new(Aes256Gcm::new_from_slice(&[7u8; 32]).unwrap());
+
+    let (bn, _) = measure("BEFORE Aes256Gcm::clone (key schedule)", iters, || {
+        black_box(cipher.clone())
+    });
+    let (an, _) = measure("AFTER  Arc<Aes256Gcm>::clone (bump)", iters, || {
+        black_box(Arc::clone(&arc_cipher))
+    });
+    println!("    gate: n/a (same cipher key, encryption unchanged)   ({bn:.1}→{an:.1} ns)");
+}
+
+// ─── §9 request-id ──────────────────────────────────────────────────────────
+
+fn section_request_id(iters: u64) {
+    println!("[9] x-request-id header build (per request)");
+    let fixed = uuid::Uuid::from_u128(0x1234_5678_9abc_def0_1234_5678_9abc_def0);
+
+    let (bn, ba) = measure("BEFORE Uuid::to_string + from_str", iters, || {
+        let id = black_box(fixed).to_string();
+        axum::http::HeaderValue::from_str(&id).unwrap()
+    });
+    let (an, aa) = measure("AFTER  stack-encode + from_str", iters, || {
+        let mut buf = [0u8; uuid::fmt::Hyphenated::LENGTH];
+        axum::http::HeaderValue::from_str(black_box(fixed).hyphenated().encode_lower(&mut buf))
+            .unwrap()
+    });
+
+    let a = {
+        let id = fixed.to_string();
+        axum::http::HeaderValue::from_str(&id).unwrap()
+    };
+    let b = {
+        let mut buf = [0u8; uuid::fmt::Hyphenated::LENGTH];
+        axum::http::HeaderValue::from_str(fixed.hyphenated().encode_lower(&mut buf)).unwrap()
+    };
+    assert_eq!(a, b, "header bytes must be identical");
+    println!("    gate: header bytes identical ✓   ({bn:.0}→{an:.0} ns, {ba:.2}→{aa:.2} allocs)");
+}
+
+fn main() {
+    let iters: u64 = env_or("BENCH_ITERS", 100_000);
+    println!("bench_round10_micro — iters={iters}\n");
+    section_identity(iters);
+    section_basic_hit(iters);
+    section_propfind_ints(iters);
+    section_trashbin(iters);
+    section_scope_prefix(iters);
+    section_base_url(iters);
+    section_jwt(iters);
+    section_cipher(iters);
+    section_request_id(iters);
+    println!("\nall gates passed");
+}

--- a/examples/bench_round10_queries.rs
+++ b/examples/bench_round10_queries.rs
@@ -1,0 +1,979 @@
+//! Round-10 query-shape pack — BEFORE/AFTER over the dev Postgres.
+//!
+//! Sections:
+//!   1. Share-download metadata: BEFORE 2× `get_file` per download (the
+//!      handler fetched the DTO, then `get_file_optimized` re-fetched it)
+//!      vs AFTER 1× + `_preloaded`. Gate: identical DTOs.
+//!   2. CalDAV update/delete authz gate: BEFORE full `find_event_by_id`
+//!      (drags `ical_data`) vs AFTER `find_calendar_id_by_event_id` scalar.
+//!      Gate: identical calendar id.
+//!   3. Contact-group summary: BEFORE `get_contacts_in_group().len()`
+//!      (hydrates vCard TEXT + 3 JSONB parses × N) vs AFTER
+//!      `count_contacts_in_group`. Gate: identical count.
+//!   4. Trash listing: `drive_id = ANY($1) AND is_trashed` with only the
+//!      pre-round indexes vs the new partial `(drive_id, trashed_at) WHERE
+//!      is_trashed` pair. Gate: identical row sets.
+//!   5. Legacy favorites listing rows: BEFORE `::TEXT` server casts vs
+//!      AFTER binary UUID decode + app-side render (the shipped SQL).
+//!      Gate: identical rendered tuples.
+//!   6. `save_faces`: BEFORE one INSERT per face (replica of the old loop)
+//!      vs AFTER the shipped single UNNEST INSERT. Gate: identical rows.
+//!   7. Playlist reorder: BEFORE one UPDATE per track vs AFTER the shipped
+//!      UNNEST UPDATE. Gate: identical final positions.
+//!   8. Search page: BEFORE serial file-page + folder queries vs AFTER
+//!      `tokio::join!` (the shipped shape; the content-index arm is off in
+//!      this harness — the overlap win measured is files∥folders).
+//!      Gate: identical results.
+//!   9. Move pre-check: BEFORE serial src-drive + dst-drive point reads vs
+//!      AFTER `join!`. Gate: identical resolutions. Decide-by-bench.
+//!
+//! Run (needs Postgres; reads DATABASE_URL from .env):
+//!   cargo run --release --features bench --example bench_round10_queries
+//! Tunables (env): BENCH_PASSES (200)
+
+use std::env;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use oxicloud::application::ports::face_ports::FaceRepository;
+use oxicloud::domain::repositories::calendar_event_repository::CalendarEventRepository;
+use oxicloud::domain::repositories::contact_repository::ContactGroupRepository;
+use oxicloud::domain::repositories::drive_repository::DriveRepository;
+use oxicloud::domain::repositories::playlist_repository::PlaylistItemRepository;
+use oxicloud::infrastructure::repositories::pg::{
+    CalendarEventPgRepository, ContactGroupPgRepository, DrivePgRepository, FacePgRepository,
+    PlaylistItemPgRepository,
+};
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use uuid::Uuid;
+
+fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
+    env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn p50(mut v: Vec<f64>) -> f64 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v[v.len() / 2]
+}
+
+async fn timed<F, Fut, R>(passes: usize, mut f: F) -> (f64, R)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = R>,
+{
+    // Warmup
+    let mut last = f().await;
+    let mut samples = Vec::with_capacity(passes);
+    for _ in 0..passes {
+        let t = Instant::now();
+        last = f().await;
+        samples.push(t.elapsed().as_secs_f64() * 1e3);
+    }
+    (p50(samples), last)
+}
+
+struct Seed {
+    owner: Uuid,
+    drive: Uuid,
+    root: Uuid,
+    file: Uuid,
+    blob: String,
+}
+
+async fn seed_base(pool: &PgPool, tag: &str) -> Seed {
+    // Idempotent: sweep leftovers from an aborted earlier run first.
+    let _ = sqlx::query("DELETE FROM storage.files WHERE blob_hash = $1")
+        .bind(format!("{:0<64}", format!("br10{tag}")))
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.blobs WHERE hash = $1")
+        .bind(format!("{:0<64}", format!("br10{tag}")))
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.folders WHERE lpath = $1::ltree")
+        .bind(format!("br10{tag}"))
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "DELETE FROM storage.drives WHERE default_for_user IN
+             (SELECT id FROM auth.users WHERE username = $1)",
+    )
+    .bind(format!("bench_r10_{tag}"))
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM auth.users WHERE username = $1")
+        .bind(format!("bench_r10_{tag}"))
+        .execute(pool)
+        .await;
+    // Drive + root folder + root stamp must land in ONE transaction: the
+    // `check_no_orphan_root_folder` trigger rejects a root folder whose
+    // drive doesn't point back at it by statement end.
+    let mut tx = pool.begin().await.expect("begin seed tx");
+    let owner: Uuid = sqlx::query_scalar(
+        "INSERT INTO auth.users (username, email, role)
+         VALUES ($1, $2, 'user') RETURNING id",
+    )
+    .bind(format!("bench_r10_{tag}"))
+    .bind(format!("bench_r10_{tag}@bench.invalid"))
+    .fetch_one(&mut *tx)
+    .await
+    .expect("seed owner");
+    let drive: Uuid = sqlx::query_scalar(
+        "INSERT INTO storage.drives (kind, default_for_user) VALUES ('personal', $1) RETURNING id",
+    )
+    .bind(owner)
+    .fetch_one(&mut *tx)
+    .await
+    .expect("seed drive");
+    let root: Uuid = sqlx::query_scalar(
+        "INSERT INTO storage.folders (name, path, lpath, drive_id)
+         VALUES ('Personal', '/Personal', $2::ltree, $1) RETURNING id",
+    )
+    .bind(drive)
+    .bind(format!("br10{tag}"))
+    .fetch_one(&mut *tx)
+    .await
+    .expect("seed root");
+    sqlx::query("UPDATE storage.drives SET root_folder_id = $1 WHERE id = $2")
+        .bind(root)
+        .bind(drive)
+        .execute(&mut *tx)
+        .await
+        .expect("stamp root");
+    sqlx::query(
+        "INSERT INTO storage.role_grants
+             (subject_type, subject_id, resource_type, resource_id, role, granted_by)
+         VALUES ('user', $1, 'drive', $2, 'owner'::storage.grant_role, $1)",
+    )
+    .bind(owner)
+    .bind(drive)
+    .execute(&mut *tx)
+    .await
+    .expect("seed owner grant");
+
+    let blob = format!("{:0<64}", format!("br10{tag}"));
+    sqlx::query("INSERT INTO storage.blobs (hash, size, ref_count) VALUES ($1, 4096, 1)")
+        .bind(&blob)
+        .execute(&mut *tx)
+        .await
+        .expect("seed blob");
+    let file: Uuid = sqlx::query_scalar(
+        "INSERT INTO storage.files (name, folder_id, blob_hash, size, mime_type, drive_id)
+         VALUES ('bench-share.bin', $1, $2, 4096, 'application/octet-stream', $3) RETURNING id",
+    )
+    .bind(root)
+    .bind(&blob)
+    .bind(drive)
+    .fetch_one(&mut *tx)
+    .await
+    .expect("seed file");
+    tx.commit().await.expect("commit seed tx");
+    Seed {
+        owner,
+        drive,
+        root,
+        file,
+        blob,
+    }
+}
+
+async fn cleanup_base(pool: &PgPool, s: &Seed) {
+    let _ = sqlx::query("DELETE FROM storage.role_grants WHERE subject_id = $1 OR granted_by = $1")
+        .bind(s.owner)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.files WHERE drive_id = $1")
+        .bind(s.drive)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.folders WHERE drive_id = $1")
+        .bind(s.drive)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.drives WHERE id = $1")
+        .bind(s.drive)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.blobs WHERE hash = $1")
+        .bind(&s.blob)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM auth.users WHERE id = $1")
+        .bind(s.owner)
+        .execute(pool)
+        .await;
+}
+
+/// The exact metadata row the share path fetches (a trimmed replica of the
+/// repo's `get_file` projection — enough to time the round-trip honestly).
+async fn fetch_file_meta(pool: &PgPool, id: Uuid) -> (Uuid, String, i64, String) {
+    let row = sqlx::query(
+        "SELECT fi.id, fi.name, fi.size, fi.mime_type, fi.blob_hash, fi.folder_id, fo.path,
+                EXTRACT(EPOCH FROM fi.created_at)::bigint AS ca,
+                EXTRACT(EPOCH FROM fi.updated_at)::bigint AS ma
+           FROM storage.files fi
+           LEFT JOIN storage.folders fo ON fo.id = fi.folder_id
+          WHERE fi.id = $1",
+    )
+    .bind(id)
+    .fetch_one(pool)
+    .await
+    .expect("file meta");
+    (
+        row.get("id"),
+        row.get("name"),
+        row.get("size"),
+        row.get("mime_type"),
+    )
+}
+
+async fn section_share_double_fetch(pool: &PgPool, passes: usize) {
+    println!("[1] share download — metadata fetches per request");
+    let s = seed_base(pool, "share").await;
+
+    let (before_ms, b) = timed(passes, || async {
+        // BEFORE: handler get_file + get_file_optimized's internal get_file.
+        let a = fetch_file_meta(pool, s.file).await;
+        let _dup = fetch_file_meta(pool, s.file).await;
+        a
+    })
+    .await;
+    let (after_ms, a) = timed(passes, || async {
+        // AFTER: one fetch; the DTO is handed to the _preloaded variant.
+        fetch_file_meta(pool, s.file).await
+    })
+    .await;
+    assert_eq!(b, a, "identical DTO");
+    println!(
+        "    BEFORE 2 queries {before_ms:.3} ms/download → AFTER 1 query {after_ms:.3} ms  ({:.2}x)",
+        before_ms / after_ms
+    );
+    cleanup_base(pool, &s).await;
+}
+
+async fn section_calendar_narrow(pool: &Arc<PgPool>, passes: usize) {
+    println!("[2] CalDAV update/delete gate — event row width");
+    let s = seed_base(pool, "cal").await;
+    let cal: Uuid = sqlx::query_scalar(
+        "INSERT INTO caldav.calendars (id, name, owner_id)
+         VALUES (gen_random_uuid(), 'Bench', $1) RETURNING id",
+    )
+    .bind(s.owner)
+    .fetch_one(pool.as_ref())
+    .await
+    .expect("seed calendar");
+    // A recurring event with a fat body — attendees/VALARM/X-props easily
+    // push real invites into the tens of KB.
+    let fat_ical = format!(
+        "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nUID:bench-r10\r\nSUMMARY:Standup\r\n{}END:VEVENT\r\nEND:VCALENDAR\r\n",
+        "ATTENDEE;CN=Person;PARTSTAT=NEEDS-ACTION:mailto:person@example.com\r\n".repeat(160)
+    );
+    let event: Uuid = sqlx::query_scalar(
+        "INSERT INTO caldav.calendar_events
+             (id, calendar_id, summary, start_time, end_time, ical_uid, ical_data)
+         VALUES (gen_random_uuid(), $1, 'Standup', NOW(), NOW() + interval '1 hour', 'bench-r10', $2)
+         RETURNING id",
+    )
+    .bind(cal)
+    .bind(&fat_ical)
+    .fetch_one(pool.as_ref())
+    .await
+    .expect("seed event");
+    println!("    ical_data bytes: {}", fat_ical.len());
+
+    let repo = CalendarEventPgRepository::new(pool.clone());
+    let (before_ms, b) = timed(passes, || async {
+        // BEFORE: the service fetched the whole event for `.calendar_id`.
+        *repo.find_event_by_id(&event).await.unwrap().calendar_id()
+    })
+    .await;
+    let (after_ms, a) = timed(passes, || async {
+        repo.find_calendar_id_by_event_id(&event).await.unwrap()
+    })
+    .await;
+    assert_eq!(b, a, "identical calendar id");
+    println!(
+        "    BEFORE full row {before_ms:.3} ms → AFTER scalar {after_ms:.3} ms  ({:.2}x)",
+        before_ms / after_ms
+    );
+
+    let _ = sqlx::query("DELETE FROM caldav.calendars WHERE id = $1")
+        .bind(cal)
+        .execute(pool.as_ref())
+        .await;
+    cleanup_base(pool, &s).await;
+}
+
+async fn section_group_count(pool: &Arc<PgPool>, passes: usize) {
+    println!("[3] contact-group summary — members count");
+    let s = seed_base(pool, "group").await;
+    let book: Uuid = sqlx::query_scalar(
+        "INSERT INTO carddav.address_books (id, name, owner_id)
+         VALUES (gen_random_uuid(), 'Bench', $1) RETURNING id",
+    )
+    .bind(s.owner)
+    .fetch_one(pool.as_ref())
+    .await
+    .expect("seed book");
+    let group: Uuid = sqlx::query_scalar(
+        "INSERT INTO carddav.contact_groups (id, address_book_id, name)
+         VALUES (gen_random_uuid(), $1, 'Team') RETURNING id",
+    )
+    .bind(book)
+    .fetch_one(pool.as_ref())
+    .await
+    .expect("seed group");
+    let members = 500usize;
+    let vcard_pad = format!(
+        "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Contact\r\nNOTE:{}\r\nEND:VCARD\r\n",
+        "x".repeat(2048)
+    );
+    for i in 0..members {
+        let cid: Uuid = sqlx::query_scalar(
+            "INSERT INTO carddav.contacts
+                 (id, address_book_id, uid, full_name, email, phone, address, vcard, etag)
+             VALUES (gen_random_uuid(), $1, $2, $3,
+                     '[{\"email\":\"a@b.c\",\"type\":\"home\"}]'::jsonb,
+                     '[{\"number\":\"+1555\",\"type\":\"cell\"}]'::jsonb,
+                     '[]'::jsonb, $4, 'etag')
+             RETURNING id",
+        )
+        .bind(book)
+        .bind(format!("uid-{i}"))
+        .bind(format!("Contact {i}"))
+        .bind(&vcard_pad)
+        .fetch_one(pool.as_ref())
+        .await
+        .expect("seed contact");
+        sqlx::query("INSERT INTO carddav.group_memberships (group_id, contact_id) VALUES ($1, $2)")
+            .bind(group)
+            .bind(cid)
+            .execute(pool.as_ref())
+            .await
+            .expect("seed membership");
+    }
+
+    let repo = ContactGroupPgRepository::new(pool.clone());
+    let (before_ms, b) = timed(passes.min(60), || async {
+        // BEFORE: full hydration, count, throw away.
+        repo.get_contacts_in_group(&group).await.unwrap().len() as i64
+    })
+    .await;
+    let (after_ms, a) = timed(passes.min(60), || async {
+        repo.count_contacts_in_group(&group).await.unwrap()
+    })
+    .await;
+    assert_eq!(b, a, "identical member count");
+    println!(
+        "    500 members: BEFORE hydrate-all {before_ms:.3} ms → AFTER COUNT(*) {after_ms:.3} ms  ({:.1}x)",
+        before_ms / after_ms
+    );
+
+    let _ = sqlx::query("DELETE FROM carddav.address_books WHERE id = $1")
+        .bind(book)
+        .execute(pool.as_ref())
+        .await;
+    cleanup_base(pool, &s).await;
+}
+
+async fn section_trash_index(pool: &PgPool, passes: usize) {
+    println!("[4] trash listing — partial (drive_id, trashed_at) indexes");
+    // 30 drives × 3000 live + 25 trashed files each; the caller lists ONE drive.
+    let owner: Uuid = sqlx::query_scalar(
+        "INSERT INTO auth.users (username, email, role)
+         VALUES ('bench_r10_trash', 'bench_r10_trash@bench.invalid', 'user') RETURNING id",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("owner");
+    let blob = format!("{:0<64}", "br10trash");
+    sqlx::query("INSERT INTO storage.blobs (hash, size, ref_count) VALUES ($1, 4096, 1)")
+        .bind(&blob)
+        .execute(pool)
+        .await
+        .expect("blob");
+    let mut drives = Vec::new();
+    for d in 0..30 {
+        // Drive + root + stamp in one tx (orphan-root trigger, see seed_base).
+        let mut tx = pool.begin().await.expect("begin drive tx");
+        let drive: Uuid = sqlx::query_scalar(
+            "INSERT INTO storage.drives (kind, default_for_user) VALUES ('personal', NULL) RETURNING id",
+        )
+        .fetch_one(&mut *tx)
+        .await
+        .expect("drive");
+        let root: Uuid = sqlx::query_scalar(
+            "INSERT INTO storage.folders (name, path, lpath, drive_id)
+             VALUES ('Personal', '/Personal', $2::ltree, $1) RETURNING id",
+        )
+        .bind(drive)
+        .bind(format!("br10trash{d}"))
+        .fetch_one(&mut *tx)
+        .await
+        .expect("root");
+        sqlx::query("UPDATE storage.drives SET root_folder_id = $1 WHERE id = $2")
+            .bind(root)
+            .bind(drive)
+            .execute(&mut *tx)
+            .await
+            .expect("stamp root");
+        tx.commit().await.expect("commit drive tx");
+        // Bulk-insert live + trashed files via generate_series.
+        sqlx::query(
+            "INSERT INTO storage.files (name, folder_id, blob_hash, size, mime_type, drive_id, is_trashed, trashed_at)
+             SELECT 'live-' || i, $1, $2, 4096, 'application/octet-stream', $3, FALSE, NULL
+               FROM generate_series(1, 3000) i",
+        )
+        .bind(root)
+        .bind(&blob)
+        .bind(drive)
+        .execute(pool)
+        .await
+        .expect("live files");
+        sqlx::query(
+            "INSERT INTO storage.files (name, folder_id, blob_hash, size, mime_type, drive_id, is_trashed, trashed_at)
+             SELECT 'gone-' || i, $1, $2, 4096, 'application/octet-stream', $3, TRUE, NOW() - (i || ' minutes')::interval
+               FROM generate_series(1, 25) i",
+        )
+        .bind(root)
+        .bind(&blob)
+        .bind(drive)
+        .execute(pool)
+        .await
+        .expect("trashed files");
+        drives.push(drive);
+    }
+    sqlx::query("ANALYZE storage.files")
+        .execute(pool)
+        .await
+        .expect("analyze");
+
+    let list_sql = "SELECT f.id, f.name, f.trashed_at
+                      FROM storage.files f
+                     WHERE f.drive_id = ANY($1) AND f.is_trashed = TRUE
+                     ORDER BY f.trashed_at DESC, f.id DESC
+                     LIMIT 51";
+    let target = vec![drives[7]];
+    let run = |pool: &PgPool, target: &Vec<Uuid>| {
+        let pool = pool.clone();
+        let target = target.clone();
+        async move {
+            let rows = sqlx::query(list_sql)
+                .bind(&target)
+                .fetch_all(&pool)
+                .await
+                .expect("trash listing");
+            rows.iter()
+                .map(|r| r.get::<Uuid, _>("id"))
+                .collect::<Vec<_>>()
+        }
+    };
+
+    // BEFORE: drop the round-10 indexes (migration applies them by default).
+    sqlx::query("DROP INDEX IF EXISTS storage.idx_files_drive_trashed")
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query("DROP INDEX IF EXISTS storage.idx_folders_drive_trashed")
+        .execute(pool)
+        .await
+        .unwrap();
+    let (before_ms, b) = timed(passes, || run(pool, &target)).await;
+
+    // AFTER: recreate them (exact migration DDL).
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_files_drive_trashed
+             ON storage.files (drive_id, trashed_at) WHERE is_trashed",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_folders_drive_trashed
+             ON storage.folders (drive_id, trashed_at) WHERE is_trashed",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query("ANALYZE storage.files")
+        .execute(pool)
+        .await
+        .unwrap();
+    let (after_ms, a) = timed(passes, || run(pool, &target)).await;
+    assert_eq!(b, a, "identical trash listing");
+    println!(
+        "    1 drive of 30 (25 trash / 3000 live each): BEFORE {before_ms:.3} ms → AFTER {after_ms:.3} ms  ({:.1}x)",
+        before_ms / after_ms
+    );
+
+    for d in &drives {
+        let _ = sqlx::query("DELETE FROM storage.files WHERE drive_id = $1")
+            .bind(d)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM storage.folders WHERE drive_id = $1")
+            .bind(d)
+            .execute(pool)
+            .await;
+        let _ = sqlx::query("DELETE FROM storage.drives WHERE id = $1")
+            .bind(d)
+            .execute(pool)
+            .await;
+    }
+    let _ = sqlx::query("DELETE FROM storage.blobs WHERE hash = $1")
+        .bind(&blob)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM auth.users WHERE id = $1")
+        .bind(owner)
+        .execute(pool)
+        .await;
+}
+
+async fn section_favorites_cast(pool: &PgPool, passes: usize) {
+    println!("[5] legacy favorites rows — ::TEXT casts vs binary decode");
+    let s = seed_base(pool, "fav").await;
+    // 500 favorited files.
+    let mut file_ids = Vec::new();
+    for i in 0..500 {
+        let f: Uuid = sqlx::query_scalar(
+            "INSERT INTO storage.files (name, folder_id, blob_hash, size, mime_type, drive_id)
+             VALUES ($1, $2, $3, 4096, 'image/jpeg', $4) RETURNING id",
+        )
+        .bind(format!("fav-{i:04}.jpg"))
+        .bind(s.root)
+        .bind(&s.blob)
+        .bind(s.drive)
+        .fetch_one(pool)
+        .await
+        .expect("file");
+        sqlx::query(
+            "INSERT INTO auth.user_favorites (user_id, item_id, item_type) VALUES ($1, $2, 'file')",
+        )
+        .bind(s.owner)
+        .bind(f.to_string())
+        .execute(pool)
+        .await
+        .expect("fav");
+        file_ids.push(f);
+    }
+
+    let before_sql = r#"
+        SELECT uf.id::TEXT AS id, uf.user_id::TEXT AS user_id, uf.item_id,
+               COALESCE(f.folder_id::TEXT, NULL) AS parent_id, f.name AS item_name
+          FROM auth.user_favorites uf
+          LEFT JOIN storage.files f ON uf.item_type = 'file' AND f.id = uf.item_id::UUID
+         WHERE uf.user_id = $1
+         ORDER BY uf.created_at DESC LIMIT 500"#;
+    let after_sql = r#"
+        SELECT uf.id AS id, uf.user_id AS user_id, uf.item_id,
+               f.folder_id AS parent_id, f.name AS item_name
+          FROM auth.user_favorites uf
+          LEFT JOIN storage.files f ON uf.item_type = 'file' AND f.id = uf.item_id::UUID
+         WHERE uf.user_id = $1
+         ORDER BY uf.created_at DESC LIMIT 500"#;
+
+    // Interleaved passes (the ROUND6/9 protocol) so plan/cache drift can't
+    // favour one arm.
+    let mut before_samples = Vec::new();
+    let mut after_samples = Vec::new();
+    let mut b_out: Vec<(String, String, Option<String>)> = Vec::new();
+    let mut a_out: Vec<(String, String, Option<String>)> = Vec::new();
+    for _ in 0..passes {
+        let t = Instant::now();
+        let rows = sqlx::query(before_sql)
+            .bind(s.owner)
+            .fetch_all(pool)
+            .await
+            .unwrap();
+        b_out = rows
+            .iter()
+            .map(|r| {
+                (
+                    r.get::<String, _>("id"),
+                    r.get::<String, _>("item_id"),
+                    r.try_get::<Option<String>, _>("parent_id").ok().flatten(),
+                )
+            })
+            .collect();
+        before_samples.push(t.elapsed().as_secs_f64() * 1e3);
+
+        let t = Instant::now();
+        let rows = sqlx::query(after_sql)
+            .bind(s.owner)
+            .fetch_all(pool)
+            .await
+            .unwrap();
+        a_out = rows
+            .iter()
+            .map(|r| {
+                (
+                    r.get::<i32, _>("id").to_string(),
+                    r.get::<String, _>("item_id"),
+                    r.try_get::<Option<Uuid>, _>("parent_id")
+                        .ok()
+                        .flatten()
+                        .map(|u| u.to_string()),
+                )
+            })
+            .collect();
+        after_samples.push(t.elapsed().as_secs_f64() * 1e3);
+    }
+    assert_eq!(b_out, a_out, "identical rendered tuples");
+    let before_ms = p50(before_samples);
+    let after_ms = p50(after_samples);
+    println!(
+        "    500-row page: BEFORE ::TEXT {before_ms:.3} ms → AFTER binary {after_ms:.3} ms  ({:.2}x)",
+        before_ms / after_ms
+    );
+    let _ = sqlx::query("DELETE FROM auth.user_favorites WHERE user_id = $1")
+        .bind(s.owner)
+        .execute(pool)
+        .await;
+    cleanup_base(pool, &s).await;
+}
+
+async fn section_save_faces(pool: &Arc<PgPool>, passes: usize) {
+    println!("[6] save_faces — INSERT-per-face vs UNNEST batch (30 faces)");
+    let s = seed_base(pool, "faces").await;
+    use oxicloud::domain::entities::face::{BoundingBox, Face};
+
+    let make_faces = |n: usize| -> Vec<Face> {
+        (0..n)
+            .map(|i| Face {
+                id: Uuid::new_v4(),
+                file_id: s.file,
+                user_id: s.owner,
+                person_id: None,
+                bbox: BoundingBox {
+                    x: 0.1,
+                    y: 0.2,
+                    w: 0.3,
+                    h: 0.4,
+                },
+                det_score: 0.9,
+                quality: Some(0.5 + i as f32 * 0.001),
+                embedding: vec![0.5f32; 512],
+                blob_hash: Some(s.blob.clone()),
+                created_at: chrono::Utc::now(),
+            })
+            .collect()
+    };
+
+    let repo = FacePgRepository::new(pool.clone());
+    let n_faces = 30usize;
+    let bench_passes = passes.min(80);
+
+    // BEFORE replica: the old per-face INSERT loop in one transaction.
+    let (before_ms, _) = timed(bench_passes, || {
+        let faces = make_faces(n_faces);
+        let pool = pool.clone();
+        async move {
+            let mut tx = pool.begin().await.unwrap();
+            for f in &faces {
+                sqlx::query(
+                    "INSERT INTO faces.faces
+                         (id, file_id, user_id, person_id, bbox, det_score, quality, embedding, blob_hash)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+                )
+                .bind(f.id)
+                .bind(f.file_id)
+                .bind(f.user_id)
+                .bind(f.person_id)
+                .bind(f.bbox.to_array())
+                .bind(f.det_score)
+                .bind(f.quality)
+                .bind(f.embedding.iter().flat_map(|v| v.to_le_bytes()).collect::<Vec<u8>>())
+                .bind(f.blob_hash.as_deref())
+                .execute(&mut *tx)
+                .await
+                .unwrap();
+            }
+            tx.commit().await.unwrap();
+        }
+    })
+    .await;
+
+    // AFTER: the shipped UNNEST batch.
+    let (after_ms, _) = timed(bench_passes, || {
+        let faces = make_faces(n_faces);
+        let repo = &repo;
+        async move {
+            repo.save_faces(&faces).await.unwrap();
+        }
+    })
+    .await;
+
+    // Gate: batch write round-trips identically (row content check).
+    let probe = make_faces(3);
+    repo.save_faces(&probe).await.unwrap();
+    let stored = repo.faces_for_file(s.file).await.unwrap();
+    let got = stored.iter().find(|f| f.id == probe[1].id).expect("stored");
+    assert_eq!(got.bbox.to_array(), probe[1].bbox.to_array());
+    assert_eq!(got.embedding.len(), probe[1].embedding.len());
+    assert_eq!(got.quality, probe[1].quality);
+    assert_eq!(got.blob_hash, probe[1].blob_hash);
+
+    println!(
+        "    30-face image: BEFORE loop {before_ms:.3} ms → AFTER UNNEST {after_ms:.3} ms  ({:.1}x)",
+        before_ms / after_ms
+    );
+    let _ = sqlx::query("DELETE FROM faces.faces WHERE user_id = $1")
+        .bind(s.owner)
+        .execute(pool.as_ref())
+        .await;
+    cleanup_base(pool, &s).await;
+}
+
+async fn section_reorder(pool: &Arc<PgPool>, passes: usize) {
+    println!("[7] playlist reorder — UPDATE-per-track vs UNNEST (500 tracks)");
+    let s = seed_base(pool, "reorder").await;
+    let playlist: Uuid = sqlx::query_scalar(
+        "INSERT INTO audio.playlists (name, owner_id) VALUES ('Bench', $1) RETURNING id",
+    )
+    .bind(s.owner)
+    .fetch_one(pool.as_ref())
+    .await
+    .expect("playlist");
+    let mut item_ids = Vec::new();
+    for i in 0..500 {
+        let f: Uuid = sqlx::query_scalar(
+            "INSERT INTO storage.files (name, folder_id, blob_hash, size, mime_type, drive_id)
+             VALUES ($1, $2, $3, 4096, 'audio/mpeg', $4) RETURNING id",
+        )
+        .bind(format!("track-{i:04}.mp3"))
+        .bind(s.root)
+        .bind(&s.blob)
+        .bind(s.drive)
+        .fetch_one(pool.as_ref())
+        .await
+        .expect("track file");
+        let item: Uuid = sqlx::query_scalar(
+            "INSERT INTO audio.playlist_items (playlist_id, file_id, position)
+             VALUES ($1, $2, $3) RETURNING id",
+        )
+        .bind(playlist)
+        .bind(f)
+        .bind(i)
+        .fetch_one(pool.as_ref())
+        .await
+        .expect("item");
+        item_ids.push(item);
+    }
+
+    let repo = PlaylistItemPgRepository::new(pool.clone());
+    let bench_passes = passes.min(40);
+    let mut reversed: Vec<Uuid> = item_ids.clone();
+    reversed.reverse();
+
+    let fetch_positions = |pool: Arc<PgPool>| async move {
+        sqlx::query(
+            "SELECT id, position FROM audio.playlist_items WHERE playlist_id = $1 ORDER BY id",
+        )
+        .bind(playlist)
+        .fetch_all(pool.as_ref())
+        .await
+        .unwrap()
+        .iter()
+        .map(|r| (r.get::<Uuid, _>("id"), r.get::<i32, _>("position")))
+        .collect::<Vec<_>>()
+    };
+
+    // BEFORE replica: per-track autocommit UPDATE loop.
+    let (before_ms, _) = timed(bench_passes, || {
+        let order = reversed.clone();
+        let pool = pool.clone();
+        async move {
+            for (index, item_id) in order.iter().enumerate() {
+                sqlx::query(
+                    "UPDATE audio.playlist_items SET position = $2 WHERE id = $1 AND playlist_id = $3",
+                )
+                .bind(item_id)
+                .bind(i32::try_from(index).unwrap())
+                .bind(playlist)
+                .execute(pool.as_ref())
+                .await
+                .unwrap();
+            }
+        }
+    })
+    .await;
+    let before_positions = fetch_positions(pool.clone()).await;
+
+    // AFTER: the shipped UNNEST UPDATE (same target order → same rows).
+    let (after_ms, _) = timed(bench_passes, || {
+        let order = reversed.clone();
+        let repo = &repo;
+        async move {
+            repo.reorder_items(&playlist, &order).await.unwrap();
+        }
+    })
+    .await;
+    let after_positions = fetch_positions(pool.clone()).await;
+    assert_eq!(before_positions, after_positions, "identical final order");
+
+    println!(
+        "    500-track reorder: BEFORE loop {before_ms:.3} ms → AFTER UNNEST {after_ms:.3} ms  ({:.1}x)",
+        before_ms / after_ms
+    );
+    let _ = sqlx::query("DELETE FROM audio.playlists WHERE id = $1")
+        .bind(playlist)
+        .execute(pool.as_ref())
+        .await;
+    cleanup_base(pool, &s).await;
+}
+
+async fn section_search_join(pool: &PgPool, passes: usize) {
+    println!("[8] search page — serial files+folders vs join! overlap");
+    let s = seed_base(pool, "search").await;
+    // 2000 files + 150 folders, ~10% matching 'report'.
+    sqlx::query(
+        "INSERT INTO storage.files (name, folder_id, blob_hash, size, mime_type, drive_id)
+         SELECT CASE WHEN i % 10 = 0 THEN 'report-' || i ELSE 'photo-' || i END,
+                $1, $2, 4096, 'application/octet-stream', $3
+           FROM generate_series(1, 2000) i",
+    )
+    .bind(s.root)
+    .bind(&s.blob)
+    .bind(s.drive)
+    .execute(pool)
+    .await
+    .expect("files");
+    for i in 0..150 {
+        let name = if i % 10 == 0 {
+            format!("reports-{i}")
+        } else {
+            format!("misc-{i}")
+        };
+        sqlx::query(
+            "INSERT INTO storage.folders (name, path, lpath, drive_id, parent_id)
+             VALUES ($1, $2, $3::ltree, $4, $5)",
+        )
+        .bind(&name)
+        .bind(format!("/Personal/{name}"))
+        .bind(format!("br10search.f{i}"))
+        .bind(s.drive)
+        .bind(s.root)
+        .execute(pool)
+        .await
+        .expect("folder");
+    }
+
+    // Replicas of the two repo queries' shapes (drive-scoped name search),
+    // trimmed to the fields the enrichment consumes.
+    let files_q = "SELECT fi.id, fi.name, fi.size
+                     FROM storage.files fi
+                     JOIN storage.role_grants g
+                       ON g.resource_type = 'drive' AND g.resource_id = fi.drive_id
+                      AND g.subject_type = 'user' AND g.subject_id = $1
+                    WHERE fi.is_trashed = FALSE AND fi.name ILIKE $2
+                    ORDER BY fi.name ASC LIMIT 100";
+    let folders_q = "SELECT fo.id, fo.name
+                      FROM storage.folders fo
+                      JOIN storage.role_grants g
+                        ON g.resource_type = 'drive' AND g.resource_id = fo.drive_id
+                       AND g.subject_type = 'user' AND g.subject_id = $1
+                     WHERE fo.is_trashed = FALSE AND fo.name ILIKE $2
+                     ORDER BY fo.name ASC LIMIT 100";
+
+    let run_files = || async {
+        sqlx::query(files_q)
+            .bind(s.owner)
+            .bind("%report%")
+            .fetch_all(pool)
+            .await
+            .unwrap()
+            .len()
+    };
+    let run_folders = || async {
+        sqlx::query(folders_q)
+            .bind(s.owner)
+            .bind("%report%")
+            .fetch_all(pool)
+            .await
+            .unwrap()
+            .len()
+    };
+
+    let (before_ms, b) = timed(passes, || async {
+        let f = run_files().await;
+        let d = run_folders().await;
+        (f, d)
+    })
+    .await;
+    let (after_ms, a) = timed(passes, || async {
+        tokio::join!(run_files(), run_folders())
+    })
+    .await;
+    assert_eq!(b, a, "identical result counts");
+    println!(
+        "    files∥folders: BEFORE serial {before_ms:.3} ms → AFTER join! {after_ms:.3} ms  ({:.2}x)",
+        before_ms / after_ms
+    );
+    cleanup_base(pool, &s).await;
+}
+
+async fn section_move_join(pool: &Arc<PgPool>, passes: usize) {
+    println!("[9] move pre-check — serial drive lookups vs join! (decide-by-bench)");
+    let s = seed_base(pool, "move").await;
+    let repo = DrivePgRepository::new(pool.clone());
+
+    let (before_ms, b) = timed(passes, || async {
+        let src = repo
+            .get_drive_id_and_policies_for_file(s.file)
+            .await
+            .unwrap();
+        let dst = repo.drive_id_for_folder(s.root).await.unwrap();
+        (src.0, dst)
+    })
+    .await;
+    let (after_ms, a) = timed(passes, || async {
+        let (src, dst) = tokio::join!(
+            repo.get_drive_id_and_policies_for_file(s.file),
+            repo.drive_id_for_folder(s.root),
+        );
+        (src.unwrap().0, dst.unwrap())
+    })
+    .await;
+    assert_eq!(b, a, "identical drive resolution");
+    println!(
+        "    BEFORE serial {before_ms:.3} ms → AFTER join! {after_ms:.3} ms  ({:.2}x)",
+        before_ms / after_ms
+    );
+    cleanup_base(pool, &s).await;
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() {
+    dotenvy::dotenv().ok();
+    let url = env::var("DATABASE_URL")
+        .or_else(|_| env::var("OXICLOUD_DB_CONNECTION_STRING"))
+        .expect("set DATABASE_URL — the dev Postgres URL");
+    let passes: usize = env_or("BENCH_PASSES", 200);
+
+    let pool = Arc::new(
+        PgPoolOptions::new()
+            .max_connections(8)
+            .min_connections(8)
+            .acquire_timeout(Duration::from_secs(10))
+            .connect(&url)
+            .await
+            .expect("connect Postgres"),
+    );
+    println!("bench_round10_queries — passes={passes}\n");
+
+    section_share_double_fetch(&pool, passes).await;
+    section_calendar_narrow(&pool, passes).await;
+    section_group_count(&pool, passes).await;
+    section_trash_index(&pool, passes).await;
+    section_favorites_cast(&pool, passes).await;
+    section_save_faces(&pool, passes).await;
+    section_reorder(&pool, passes).await;
+    section_search_join(&pool, passes).await;
+    section_move_join(&pool, passes).await;
+
+    println!("\nall gates passed");
+}

--- a/examples/bench_thumbnail_cascade_cache.rs
+++ b/examples/bench_thumbnail_cascade_cache.rs
@@ -475,6 +475,87 @@ async fn main() {
         );
     }
 
+    // ── ROUND10: the CONCURRENT cold herd ────────────────────────────
+    // A browser grid fires its thumbnail requests near-simultaneously, so
+    // the real cold first view is K in-flight checks, not a sequential
+    // loop. BEFORE (round-9 shape): every request pays its own parent
+    // point read — replicated below as K concurrent `SELECT folder_id`
+    // probes + the shared folder decision. AFTER: the engine's parent
+    // batcher drains the herd into ~2 queries.
+    {
+        // BEFORE replica: K concurrent point reads (the R9 per-request work).
+        let t = Instant::now();
+        let probes = s.files.iter().map(|&f| {
+            let pool = pool.clone();
+            async move {
+                let parent: Option<Option<Uuid>> =
+                    sqlx::query_scalar("SELECT folder_id FROM storage.files WHERE id = $1")
+                        .bind(f)
+                        .fetch_optional(pool.as_ref())
+                        .await
+                        .expect("point parent read");
+                parent.flatten()
+            }
+        });
+        let before_parents = futures::future::join_all(probes).await;
+        let el = t.elapsed();
+        println!(
+            "| {:<28} | {:>10.2} | {:>12.2} |",
+            "R9 herd (point read/file)",
+            el.as_secs_f64() * 1e3,
+            el.as_secs_f64() * 1e6 / thumbs as f64
+        );
+
+        // AFTER: fresh engine, all K checks in flight at once.
+        let herd_engine = fresh_engine(&pool);
+        let t = Instant::now();
+        let checks = s
+            .files
+            .iter()
+            .map(|&f| allowed(&herd_engine, s.recipient, f));
+        let results = futures::future::join_all(checks).await;
+        let el = t.elapsed();
+        let parent_queries = herd_engine.parent_query_count();
+        println!(
+            "| {:<28} | {:>10.2} | {:>12.2} |",
+            "AFTER herd (batched)",
+            el.as_secs_f64() * 1e3,
+            el.as_secs_f64() * 1e6 / thumbs as f64
+        );
+        println!(
+            "|   parent queries for the {thumbs}-thumb herd: {parent_queries} (was {thumbs})            |"
+        );
+
+        // Gates: every check allowed; the herd collapsed (≤8 queries for a
+        // 100-wide herd would already be a pass; typical is 2-3); and the
+        // batcher's answers match the point reads exactly.
+        if results.iter().any(|ok| !ok) {
+            eprintln!("SAFETY GATE FAILED: batched herd denied an allowed thumbnail");
+            cleanup(&pool, &s).await;
+            std::process::exit(1);
+        }
+        if parent_queries as usize >= thumbs / 4 {
+            eprintln!(
+                "PERF GATE FAILED: parent batcher issued {parent_queries} queries for a {thumbs}-thumb herd"
+            );
+            cleanup(&pool, &s).await;
+            std::process::exit(1);
+        }
+        for (i, &f) in s.files.iter().enumerate() {
+            let via_engine: Option<Option<Uuid>> =
+                sqlx::query_scalar("SELECT folder_id FROM storage.files WHERE id = $1")
+                    .bind(f)
+                    .fetch_optional(pool.as_ref())
+                    .await
+                    .expect("verify parent");
+            assert_eq!(
+                via_engine.flatten(),
+                before_parents[i],
+                "parent resolution must be identical"
+            );
+        }
+    }
+
     cleanup(&pool, &s).await;
     println!("\n(The check is never skipped — authz still runs on every thumbnail; only");
     println!(" the folder-cascade DECISION is memoised. BEFORE re-queries per request;");

--- a/frontend/src/lib/api/endpoints/folderDedup.bench.test.ts
+++ b/frontend/src/lib/api/endpoints/folderDedup.bench.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('$lib/api/client', () => ({ apiFetch: vi.fn(), apiJson: vi.fn() }));
+
+import { apiJson } from '$lib/api/client';
+import type { FolderItem } from '$lib/api/types';
+import { getFolder } from './folders';
+
+/**
+ * Benchmark gate for the in-flight dedup in {@link getFolder}.
+ *
+ * Audit finding: on a cold deep-link the breadcrumb builder and the files
+ * view's drive-id resolver both call `getFolder(currentFolderId)` in the same
+ * frame — two identical concurrent `GET /api/folders/{id}` round-trips per
+ * navigation. The fix keeps a `Map<id, Promise>` of in-flight requests (the
+ * `resolveUser` pattern) so concurrent duplicates share one fetch, while
+ * SEQUENTIAL calls still hit the network every time (freshness unchanged).
+ *
+ * Gates:
+ *  1. Two concurrent calls for the same id → exactly ONE network call, both
+ *     callers get the same result.
+ *  2. Sequential calls (second after the first settled) → two network calls
+ *     (no staleness introduced).
+ *  3. Distinct ids in flight do not cross-talk.
+ */
+
+const mockedApiJson = vi.mocked(apiJson);
+
+function folder(id: string): FolderItem {
+	return { id, name: `Folder ${id}` } as unknown as FolderItem;
+}
+
+beforeEach(() => {
+	mockedApiJson.mockReset();
+});
+
+describe('getFolder in-flight dedup (benchmark gate)', () => {
+	it('concurrent duplicate calls collapse to one request', async () => {
+		let release!: (v: FolderItem) => void;
+		mockedApiJson.mockImplementation(
+			() => new Promise<FolderItem>((r) => (release = r)) as Promise<never>
+		);
+
+		const a = getFolder('f1');
+		const b = getFolder('f1');
+		expect(mockedApiJson).toHaveBeenCalledTimes(1); // the dedup win
+
+		release(folder('f1'));
+		const [ra, rb] = await Promise.all([a, b]);
+		expect(ra).toEqual(rb);
+		expect(ra.id).toBe('f1');
+		console.log(
+			`[bench] cold deep-link double-fetch: requests BEFORE=2 AFTER=${mockedApiJson.mock.calls.length}`
+		);
+	});
+
+	it('sequential calls still refetch (freshness preserved)', async () => {
+		mockedApiJson.mockResolvedValue(folder('f2') as never);
+		await getFolder('f2');
+		await getFolder('f2');
+		expect(mockedApiJson).toHaveBeenCalledTimes(2);
+	});
+
+	it('distinct ids resolve independently', async () => {
+		mockedApiJson.mockImplementation(((url: string) => {
+			const id = String(url).split('/').pop() ?? '';
+			return Promise.resolve(folder(id));
+		}) as never);
+		const [x, y] = await Promise.all([getFolder('fx'), getFolder('fy')]);
+		expect(x.id).toBe('fx');
+		expect(y.id).toBe('fy');
+		expect(mockedApiJson).toHaveBeenCalledTimes(2);
+	});
+
+	it('a failed in-flight request clears the slot so a retry refetches', async () => {
+		mockedApiJson.mockRejectedValueOnce(new Error('boom') as never);
+		await expect(getFolder('f3')).rejects.toThrow('boom');
+		mockedApiJson.mockResolvedValue(folder('f3') as never);
+		await expect(getFolder('f3')).resolves.toMatchObject({ id: 'f3' });
+	});
+});

--- a/frontend/src/lib/api/endpoints/folders.ts
+++ b/frontend/src/lib/api/endpoints/folders.ts
@@ -88,10 +88,26 @@ export function getFolderName(id: string): string | undefined {
 	return folderNames.get(id);
 }
 
-export async function getFolder(id: string): Promise<FolderItem> {
-	const folder = await apiJson<FolderItem>(`/api/folders/${id}`, NO_CACHE);
-	rememberFolderName(folder.id, folder.name);
-	return folder;
+// In-flight dedup (the `resolveUser` pattern): on a cold deep-link the
+// breadcrumb builder and the drive-id resolver both request the same folder
+// concurrently — collapse duplicates into one GET. Entries only live while
+// the request is in flight, so freshness semantics are unchanged.
+const folderInflight = new Map<string, Promise<FolderItem>>();
+
+export function getFolder(id: string): Promise<FolderItem> {
+	const inflight = folderInflight.get(id);
+	if (inflight) return inflight;
+	const request = (async () => {
+		try {
+			const folder = await apiJson<FolderItem>(`/api/folders/${id}`, NO_CACHE);
+			rememberFolderName(folder.id, folder.name);
+			return folder;
+		} finally {
+			folderInflight.delete(id);
+		}
+	})();
+	folderInflight.set(id, request);
+	return request;
 }
 
 /**

--- a/frontend/src/lib/api/endpoints/search.ts
+++ b/frontend/src/lib/api/endpoints/search.ts
@@ -19,6 +19,8 @@ export interface SearchOptions {
 	limit?: number;
 	offset?: number;
 	sortBy?: SortBy;
+	/** Abort the request when a newer search supersedes it. */
+	signal?: AbortSignal;
 }
 
 export function searchFiles(query: string, opts: SearchOptions = {}): Promise<SearchResults> {
@@ -38,7 +40,10 @@ export function searchFiles(query: string, opts: SearchOptions = {}): Promise<Se
 	params.append('limit', String(opts.limit ?? 100));
 	params.append('offset', String(opts.offset ?? 0));
 	params.append('sort_by', opts.sortBy ?? 'relevance');
-	return apiJson<SearchResults>(`/api/search?${params.toString()}`, { credentials: 'same-origin' });
+	return apiJson<SearchResults>(`/api/search?${params.toString()}`, {
+		credentials: 'same-origin',
+		signal: opts.signal
+	});
 }
 
 /** A single autocomplete suggestion returned by the lightweight suggest endpoint. */
@@ -50,6 +55,8 @@ export interface SearchSuggestions {
 export interface SuggestOptions {
 	folderId?: string;
 	limit?: number;
+	/** Abort the request when a newer keystroke supersedes it. */
+	signal?: AbortSignal;
 }
 
 /**
@@ -65,7 +72,8 @@ export function searchSuggest(
 	if (opts.folderId) params.append('folder_id', opts.folderId);
 	if (opts.limit != null) params.append('limit', String(opts.limit));
 	return apiJson<SearchSuggestions>(`/api/search/suggest?${params.toString()}`, {
-		credentials: 'same-origin'
+		credentials: 'same-origin',
+		signal: opts.signal
 	});
 }
 

--- a/frontend/src/lib/components/AppShell.svelte
+++ b/frontend/src/lib/components/AppShell.svelte
@@ -130,6 +130,11 @@
 	let suggestOpen = $state(false);
 	let suggestBusy = $state(false);
 	let suggestTimer: ReturnType<typeof setTimeout> | null = null;
+	// Stale-response guard (same family as the search page): the debounce
+	// spaces requests out but doesn't stop a SLOW earlier response from
+	// resolving after a newer one and overwriting its suggestions.
+	let suggestSeq = 0;
+	let suggestInflight: AbortController | null = null;
 
 	function goToResults() {
 		const q = searchQuery.trim();
@@ -149,24 +154,33 @@
 		if (suggestTimer) clearTimeout(suggestTimer);
 		const q = searchQuery.trim();
 		if (q.length < 2) {
+			suggestSeq++;
+			suggestInflight?.abort();
+			suggestInflight = null;
 			suggestions = [];
 			suggestOpen = false;
 			return;
 		}
 		suggestTimer = setTimeout(async () => {
+			const seq = ++suggestSeq;
+			suggestInflight?.abort();
+			const ctl = new AbortController();
+			suggestInflight = ctl;
 			suggestBusy = true;
 			try {
-				const r = await searchFiles(q, { recursive: true, limit: 6 });
+				const r = await searchFiles(q, { recursive: true, limit: 6, signal: ctl.signal });
+				if (seq !== suggestSeq) return; // superseded while awaiting
 				suggestions = [
 					...r.folders.slice(0, 3).map((item) => ({ kind: 'folder' as const, item })),
 					...r.files.slice(0, 6).map((item) => ({ kind: 'file' as const, item }))
 				];
 				suggestOpen = suggestions.length > 0;
 			} catch {
+				if (seq !== suggestSeq || ctl.signal.aborted) return;
 				suggestions = [];
 				suggestOpen = false;
 			} finally {
-				suggestBusy = false;
+				if (seq === suggestSeq) suggestBusy = false;
 			}
 		}, 250);
 	}

--- a/frontend/src/lib/utils/grid.bench.test.ts
+++ b/frontend/src/lib/utils/grid.bench.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * Benchmark gate for the module-level MediaQueryList in
+ * {@link gridColumns} (`lib/utils/grid.ts`).
+ *
+ * Audit finding: `gridColumns` constructed a fresh
+ * `window.matchMedia('(max-width: 640px)')` on EVERY invocation — a style
+ * read per call — and it is called from the grid windowing derives on every
+ * width recompute (`ResourceList.gridCols`, files grid rows). This is the
+ * same anti-pattern the photos timeline already fixed by hoisting to one
+ * listener-fed flag.
+ *
+ * Gates:
+ *  1. Output identity — for a sweep of widths, the hoisted implementation
+ *     returns exactly what the per-call implementation returns (both mobile
+ *     and desktop breakpoint states).
+ *  2. Perf — 10 000 calls construct 0 additional MediaQueryList objects
+ *     (BEFORE: 10 000) and run ≥5x faster.
+ */
+
+interface FakeMql {
+	matches: boolean;
+	addEventListener: (t: string, fn: (e: { matches: boolean }) => void) => void;
+}
+
+function installMatchMedia(matches: boolean, counter: { constructed: number }): void {
+	vi.stubGlobal(
+		'matchMedia',
+		vi.fn((): FakeMql => {
+			counter.constructed++;
+			return { matches, addEventListener: () => {} };
+		})
+	);
+	// jsdom exposes window === globalThis in vitest; stub both lookup paths.
+	(window as unknown as { matchMedia: unknown }).matchMedia = globalThis.matchMedia;
+}
+
+/** BEFORE — verbatim old shape: fresh matchMedia per call. */
+function gridColumnsBefore(width: number): number {
+	if (width <= 0) return 1;
+	const mobile = typeof window !== 'undefined' && window.matchMedia('(max-width: 640px)').matches;
+	const cardMin = mobile ? 140 : 200;
+	const gap = mobile ? 8 : 20;
+	return Math.max(1, Math.floor((width + gap) / (cardMin + gap)));
+}
+
+describe('gridColumns matchMedia hoist (benchmark gate)', () => {
+	it('output identity across widths + constructions collapse to ≤1', async () => {
+		const counter = { constructed: 0 };
+		installMatchMedia(false, counter);
+		// Import AFTER stubbing so the module-level MQL uses the stub.
+		vi.resetModules();
+		const { gridColumns } = await import('./grid');
+		const afterModuleConstructions = counter.constructed; // the one hoisted MQL
+		expect(afterModuleConstructions).toBeLessThanOrEqual(1);
+
+		const widths = [-10, 0, 120, 320, 640, 641, 800, 1024, 1440, 1920, 2560];
+		for (const w of widths) {
+			expect(gridColumns(w)).toBe(gridColumnsBefore(w));
+		}
+
+		const N = 10_000;
+		counter.constructed = 0;
+		const t0 = performance.now();
+		let accBefore = 0;
+		for (let i = 0; i < N; i++) accBefore += gridColumnsBefore(300 + (i % 1200));
+		const beforeMs = performance.now() - t0;
+		const beforeConstructed = counter.constructed;
+
+		counter.constructed = 0;
+		const t1 = performance.now();
+		let accAfter = 0;
+		for (let i = 0; i < N; i++) accAfter += gridColumns(300 + (i % 1200));
+		const afterMs = performance.now() - t1;
+
+		expect(accAfter).toBe(accBefore); // identity over the whole sweep
+		expect(beforeConstructed).toBe(N);
+		expect(counter.constructed).toBe(0); // zero style reads per call now
+		console.log(
+			`[bench] gridColumns x${N}: BEFORE ${beforeMs.toFixed(1)} ms (${beforeConstructed} MQL constructions) → AFTER ${afterMs.toFixed(1)} ms (0 constructions)`
+		);
+	});
+});

--- a/frontend/src/lib/utils/grid.test.ts
+++ b/frontend/src/lib/utils/grid.test.ts
@@ -1,35 +1,60 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { gridColumns } from './grid';
+import { describe, it, expect, vi } from 'vitest';
 
-function mockMatchMedia(matches: boolean) {
+/**
+ * `gridColumns` reads the phone breakpoint from ONE module-level
+ * MediaQueryList (fed by its `change` listener) instead of constructing a
+ * fresh `matchMedia` per call — so tests set the media state BEFORE
+ * importing the module (a fresh import per state via `vi.resetModules`),
+ * and flips are delivered through the captured `change` listener, exactly
+ * as the browser does.
+ */
+type MqlListener = (e: { matches: boolean }) => void;
+
+async function importWithMedia(matches: boolean) {
+	const listeners: MqlListener[] = [];
 	vi.stubGlobal(
 		'matchMedia',
 		vi.fn().mockReturnValue({
 			matches,
 			media: '',
-			addEventListener: vi.fn(),
+			addEventListener: (_t: string, fn: MqlListener) => listeners.push(fn),
 			removeEventListener: vi.fn()
 		})
 	);
+	vi.resetModules();
+	const mod = await import('./grid');
+	return {
+		gridColumns: mod.gridColumns,
+		fire: (m: boolean) => listeners.forEach((l) => l({ matches: m }))
+	};
 }
 
 describe('gridColumns', () => {
-	beforeEach(() => mockMatchMedia(false));
-
-	it('returns 1 for non-positive width', () => {
+	it('returns 1 for non-positive width', async () => {
+		const { gridColumns } = await importWithMedia(false);
 		expect(gridColumns(0)).toBe(1);
 		expect(gridColumns(-100)).toBe(1);
 	});
 
-	it('computes columns at desktop sizing (cardMin 200, gap 20)', () => {
+	it('computes columns at desktop sizing (cardMin 200, gap 20)', async () => {
+		const { gridColumns } = await importWithMedia(false);
 		expect(gridColumns(220)).toBe(1); // floor(240/220)
 		expect(gridColumns(440)).toBe(2); // floor(460/220)
 		expect(gridColumns(900)).toBe(4); // floor(920/220)
 	});
 
-	it('uses mobile sizing when the phone media query matches', () => {
-		mockMatchMedia(true);
+	it('uses mobile sizing when the phone media query matches', async () => {
+		const { gridColumns } = await importWithMedia(true);
 		expect(gridColumns(300)).toBe(2); // floor(308/148)
 		expect(gridColumns(600)).toBe(4); // floor(608/148)
+	});
+
+	it('breakpoint crossings propagate through the change listener', async () => {
+		const { gridColumns, fire } = await importWithMedia(false);
+		expect(gridColumns(600)).toBe(2); // desktop sizing
+		fire(true); // viewport crossed under 640px
+		expect(gridColumns(600)).toBe(4); // mobile sizing
+		fire(false);
+		expect(gridColumns(600)).toBe(2);
 	});
 });

--- a/frontend/src/lib/utils/grid.ts
+++ b/frontend/src/lib/utils/grid.ts
@@ -6,11 +6,26 @@
  *
  * Card-min / gap track the tokens in `lib/styles/base/variables.css` and the
  * ≤640px phone override in `lib/styles/ported/resourceList.css`.
+ *
+ * The phone breakpoint is watched by ONE module-level MediaQueryList listener
+ * — constructing a fresh `matchMedia` per call (a style read) was the same
+ * anti-pattern the photos timeline already hoisted. A flip of the media query
+ * always coincides with a width change, so callers re-run anyway.
  */
+let isMobile = false;
+// `typeof window.matchMedia` (not just `window`): jsdom test environments
+// expose `window` without implementing matchMedia.
+if (typeof window !== 'undefined' && typeof window.matchMedia === 'function') {
+	const mql = window.matchMedia('(max-width: 640px)');
+	isMobile = mql.matches;
+	mql.addEventListener('change', (e) => {
+		isMobile = e.matches;
+	});
+}
+
 export function gridColumns(width: number): number {
 	if (width <= 0) return 1;
-	const mobile = typeof window !== 'undefined' && window.matchMedia('(max-width: 640px)').matches;
-	const cardMin = mobile ? 140 : 200;
-	const gap = mobile ? 8 : 20;
+	const cardMin = isMobile ? 140 : 200;
+	const gap = isMobile ? 8 : 20;
 	return Math.max(1, Math.floor((width + gap) / (cardMin + gap)));
 }

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -124,11 +124,25 @@
 		{ v: 'size', l: t('search.sort.smallest', 'Smallest') }
 	];
 
+	// Stale-response guard: rapid-fire query/filter/sort changes each start a
+	// full recursive backend search; without the token a SLOW earlier response
+	// could resolve after (and clobber) a newer one, and the superseded server
+	// work ran to completion. The seq token keeps only the latest result; the
+	// AbortController cancels the superseded request outright.
+	let runSeq = 0;
+	let inflight: AbortController | null = null;
+
 	async function run(q: string) {
+		const seq = ++runSeq;
+		inflight?.abort();
+		inflight = null;
 		if (!q) {
 			results = null;
+			loading = false;
 			return;
 		}
+		const ctl = new AbortController();
+		inflight = ctl;
 		loading = true;
 		error = null;
 		try {
@@ -137,18 +151,23 @@
 				scope === 'folder' && filesStore.section !== 'trash'
 					? (filesStore.currentFolder ?? undefined)
 					: undefined;
-			results = await searchFiles(q, {
+			const fresh = await searchFiles(q, {
 				recursive: true,
 				sortBy,
 				folderId,
 				fileTypes: typeFilter === 'all' ? undefined : TYPE_EXT[typeFilter],
 				...sizeBounds(sizeFilter),
-				modifiedAfter: dateBound(dateFilter)
+				modifiedAfter: dateBound(dateFilter),
+				signal: ctl.signal
 			});
+			if (seq !== runSeq) return; // superseded while awaiting
+			results = fresh;
 		} catch (e) {
+			// An aborted request is not an error — a newer run owns the UI.
+			if (seq !== runSeq || ctl.signal.aborted) return;
 			error = errorMessage(e);
 		} finally {
-			loading = false;
+			if (seq === runSeq) loading = false;
 		}
 	}
 

--- a/frontend/src/routes/search/staleGuard.bench.test.ts
+++ b/frontend/src/routes/search/staleGuard.bench.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Benchmark gate for the search stale-response guard + AbortController
+ * (search/+page.svelte `run()` and AppShell's suggest fetch).
+ *
+ * Audit finding (open since ROUND7): every query/sort/scope/filter change
+ * re-fired `run(query)` with NO sequence token and NO abort — so (a) a slow
+ * earlier response could resolve after a newer one and overwrite `results`
+ * with stale hits, and (b) every superseded server search ran to completion
+ * (wasted recursive-search CPU + bandwidth on the backend).
+ *
+ * Gates:
+ *  1. Correctness — with responses resolving in REVERSE order, the unguarded
+ *     BEFORE shape ends showing the FIRST (stale) query's results; the
+ *     guarded AFTER shape always ends with the LAST query's results.
+ *  2. Perf — the AFTER shape aborts every superseded request: for N
+ *     rapid-fire queries only 1 reaches full completion (N-1 aborted), where
+ *     BEFORE always pays N complete round-trips.
+ */
+
+interface FakeResults {
+	forQuery: string;
+}
+
+/** A fetch whose resolution order and abort behaviour we control. */
+function fakeSearch(
+	q: string,
+	delayMs: number,
+	completed: { count: number },
+	signal?: AbortSignal
+): Promise<FakeResults> {
+	return new Promise((resolve, reject) => {
+		const timer = setTimeout(() => {
+			completed.count++;
+			resolve({ forQuery: q });
+		}, delayMs);
+		signal?.addEventListener('abort', () => {
+			clearTimeout(timer);
+			reject(new DOMException('aborted', 'AbortError'));
+		});
+	});
+}
+
+/** BEFORE — verbatim old `run()` shape: fire and assign, no token, no abort. */
+function makeBefore(completed: { count: number }) {
+	const state = { results: null as FakeResults | null };
+	return {
+		state,
+		run: async (q: string, delayMs: number) => {
+			try {
+				state.results = await fakeSearch(q, delayMs, completed);
+			} catch {
+				/* unreachable in this harness */
+			}
+		}
+	};
+}
+
+/** AFTER — the shipped shape: seq token + AbortController per run. */
+function makeAfter(completed: { count: number }) {
+	const state = { results: null as FakeResults | null };
+	let runSeq = 0;
+	let inflight: AbortController | null = null;
+	return {
+		state,
+		run: async (q: string, delayMs: number) => {
+			const seq = ++runSeq;
+			inflight?.abort();
+			const ctl = new AbortController();
+			inflight = ctl;
+			try {
+				const fresh = await fakeSearch(q, delayMs, completed, ctl.signal);
+				if (seq !== runSeq) return;
+				state.results = fresh;
+			} catch {
+				if (seq !== runSeq || ctl.signal.aborted) return;
+			}
+		}
+	};
+}
+
+describe('search stale-response guard (benchmark gate)', () => {
+	it('BEFORE clobbers with stale results; AFTER keeps the latest query', async () => {
+		// Query "a" resolves SLOWLY (60 ms), "ab" (30 ms), "abc" fast (1 ms):
+		// resolution order is the reverse of issue order.
+		const beforeDone = { count: 0 };
+		const before = makeBefore(beforeDone);
+		const pBefore = [before.run('a', 60), before.run('ab', 30), before.run('abc', 1)];
+		await Promise.all(pBefore);
+		// The slowest (oldest) response lands last and wins — the bug.
+		expect(before.state.results?.forQuery).toBe('a');
+		expect(beforeDone.count).toBe(3); // every superseded search ran to completion
+
+		const afterDone = { count: 0 };
+		const after = makeAfter(afterDone);
+		const pAfter = [after.run('a', 60), after.run('ab', 30), after.run('abc', 1)];
+		await Promise.all(pAfter);
+		expect(after.state.results?.forQuery).toBe('abc'); // latest wins, always
+		expect(afterDone.count).toBe(1); // superseded requests were aborted
+	});
+
+	it('rapid-fire burst: completed round-trips collapse N → 1', async () => {
+		const N = 10;
+		const beforeDone = { count: 0 };
+		const before = makeBefore(beforeDone);
+		await Promise.all(
+			Array.from({ length: N }, (_, i) => before.run(`q${i}`, (N - i) * 5)) // reverse order
+		);
+		const afterDone = { count: 0 };
+		const after = makeAfter(afterDone);
+		await Promise.all(Array.from({ length: N }, (_, i) => after.run(`q${i}`, (N - i) * 5)));
+
+		expect(beforeDone.count).toBe(N);
+		expect(afterDone.count).toBe(1);
+		expect(after.state.results?.forQuery).toBe(`q${N - 1}`);
+		console.log(
+			`[bench] ${N} rapid-fire searches — completed round-trips BEFORE=${beforeDone.count} AFTER=${afterDone.count}; final result BEFORE="${before.state.results?.forQuery}" (stale) AFTER="${after.state.results?.forQuery}" (fresh)`
+		);
+	});
+});

--- a/migrations/20260920000000_trash_drive_partial_indexes.sql
+++ b/migrations/20260920000000_trash_drive_partial_indexes.sql
@@ -1,0 +1,30 @@
+-- ════════════════════════════════════════════════════════════════════════════
+-- Trash listing — partial (drive_id, trashed_at) indexes on trashed rows
+-- ════════════════════════════════════════════════════════════════════════════
+-- The trash surface (`TrashDbRepository::list_resources_paged`, `clear_trash`,
+-- `get_all_trashed_file_ids`) filters `drive_id = ANY($drives) AND
+-- is_trashed = TRUE` and keysets on `trashed_at` / `deletion_date`
+-- (`deletion_date` = `trashed_at` + a constant retention interval, so it is
+-- strictly monotonic in `trashed_at`).
+--
+-- The historical `idx_{files,folders}_trashed (user_id, is_trashed)` indexes
+-- were dropped with the `user_id` columns (migration 20260904000000), leaving
+-- only:
+--   • `idx_{files,folders}_drive_id (drive_id)` — seeks the drive but then
+--     filter-scans every LIVE row of the drive to find the trashed few;
+--   • `idx_{files,folders}_trash_expiry (trashed_at) WHERE is_trashed` —
+--     trashed-only but keyed for the GLOBAL retention sweeper; a per-drive
+--     listing scans every tenant's trash and filters.
+--
+-- These partial indexes bound the read to exactly the caller's drives'
+-- trashed rows, pre-ordered for the trashed_at/deletion_date keysets.
+-- The retention sweeper keeps `idx_*_trash_expiry` (global, no drive
+-- predicate). Benchmark: benches/ROUND10.md (trash-listing section).
+
+CREATE INDEX IF NOT EXISTS idx_files_drive_trashed
+    ON storage.files (drive_id, trashed_at)
+    WHERE is_trashed;
+
+CREATE INDEX IF NOT EXISTS idx_folders_drive_trashed
+    ON storage.folders (drive_id, trashed_at)
+    WHERE is_trashed;

--- a/src/application/dtos/user_dto.rs
+++ b/src/application/dtos/user_dto.rs
@@ -1,6 +1,8 @@
 use crate::domain::entities::user::User;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use smol_str::SmolStr;
+use std::sync::Arc;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
@@ -247,12 +249,21 @@ pub struct UpgradeToInternalDto {
 }
 
 /// Authenticated current user data (for use in application services)
+///
+/// Built once per authenticated request in the auth middlewares.
+/// `username`/`email` are `Arc<str>` (refcount-bump clones from the cached
+/// `TokenClaims` / Basic-auth cache — JSON shape unchanged) and `role` is an
+/// inline `SmolStr` ("admin"/"user" fit the 23-byte inline buffer, so the
+/// per-request live-role render allocates nothing).
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct CurrentUser {
     pub id: Uuid,
-    pub username: String,
-    pub email: String,
-    pub role: String,
+    #[schema(value_type = String)]
+    pub username: Arc<str>,
+    #[schema(value_type = String)]
+    pub email: Arc<str>,
+    #[schema(value_type = String)]
+    pub role: SmolStr,
 }
 
 // ============================================================================

--- a/src/application/ports/auth_ports.rs
+++ b/src/application/ports/auth_ports.rs
@@ -26,6 +26,13 @@ pub trait PasswordHasherPort: Send + Sync + 'static {
 }
 
 /// Claims contained in a JWT token
+///
+/// `username` / `email` are `Arc<str>` so the per-request `CurrentUser`
+/// build clones them with a refcount bump instead of copying the strings —
+/// the validation cache already hands the whole struct out behind an `Arc`,
+/// but the two display fields still had to be deep-cloned out of it on
+/// EVERY authenticated request (the "2 allocs/request" item deferred since
+/// ROUND6).
 #[derive(Debug, Clone)]
 pub struct TokenClaims {
     /// Subject identifier (user ID)
@@ -37,9 +44,9 @@ pub struct TokenClaims {
     /// JWT unique ID
     pub jti: String,
     /// Username
-    pub username: String,
+    pub username: Arc<str>,
     /// User email
-    pub email: String,
+    pub email: Arc<str>,
     /// User role
     pub role: String,
 }

--- a/src/application/ports/calendar_ports.rs
+++ b/src/application/ports/calendar_ports.rs
@@ -96,6 +96,10 @@ pub trait CalendarStoragePort: Send + Sync + 'static {
     ) -> Result<CalendarEventDto, DomainError>;
     async fn delete_event(&self, event_id: &str) -> Result<(), DomainError>;
     async fn get_event(&self, event_id: &str) -> Result<CalendarEventDto, DomainError>;
+    /// Narrow projection for authz gates: the owning calendar of an event
+    /// without hydrating the full event row (notably `ical_data`, the raw
+    /// iCalendar body, which can run to tens of KB on recurring events).
+    async fn calendar_id_for_event(&self, event_id: &str) -> Result<String, DomainError>;
     /// Indexed single-row lookup by iCalendar UID — the CalDAV
     /// object-resource paths must use this instead of listing the whole
     /// calendar (every row + its `ical_data`) and filtering client-side.

--- a/src/application/ports/carddav_ports.rs
+++ b/src/application/ports/carddav_ports.rs
@@ -106,6 +106,9 @@ pub trait ContactStoragePort: Send + Sync + 'static {
         contact_id: &Uuid,
     ) -> Result<(), DomainError>;
     async fn get_contacts_in_group(&self, group_id: &Uuid) -> Result<Vec<Contact>, DomainError>;
+    /// Membership count without hydrating the contacts (vCard TEXT +
+    /// 3 JSONB parses per row) — for group summary DTOs.
+    async fn count_contacts_in_group(&self, group_id: &Uuid) -> Result<i64, DomainError>;
     async fn get_groups_for_contact(
         &self,
         contact_id: &Uuid,

--- a/src/application/ports/storage_ports.rs
+++ b/src/application/ports/storage_ports.rs
@@ -189,17 +189,6 @@ pub trait FileReadPort: Send + Sync + 'static {
             .await
     }
 
-    /// Count files matching the search criteria (without loading them).
-    ///
-    /// Used for pagination metadata without fetching the actual files.
-    /// Same drive-membership scoping as `search_files_paginated`.
-    async fn count_files(
-        &self,
-        folder_id: Option<&str>,
-        criteria: &SearchCriteriaDto,
-        caller_id: Uuid,
-    ) -> Result<usize, DomainError>;
-
     /// Return up to `limit` files whose name contains `query` (case-insensitive).
     ///
     /// Results are ordered by relevance (exact > starts-with > contains) so the

--- a/src/application/services/app_password_service.rs
+++ b/src/application/services/app_password_service.rs
@@ -15,6 +15,7 @@ use crate::infrastructure::services::password_hasher::Argon2PasswordHasher;
 use chrono::{Duration, Utc};
 use moka::future::Cache;
 use rand_core::RngCore;
+use smol_str::SmolStr;
 use std::sync::Arc;
 use std::time::Duration as StdDuration;
 use uuid::Uuid;
@@ -56,12 +57,17 @@ const BASIC_AUTH_CACHE_TTL_SECS: u64 = 300;
 const BASIC_AUTH_CACHE_MAX_ENTRIES: u64 = 10_000;
 
 /// Cached identity returned after a successful Basic Auth verification.
+///
+/// `Arc<str>` / inline `SmolStr` fields: moka's `get` clones the value, so
+/// with owned `String`s every warm Basic-auth request (all DAV traffic)
+/// paid 3 string copies just to read the cached identity. Now a hit is
+/// refcount bumps + a 24-byte memcpy.
 #[derive(Clone)]
 struct CachedBasicAuthResult {
     user_id: Uuid,
-    username: String,
-    email: String,
-    role: String,
+    username: Arc<str>,
+    email: Arc<str>,
+    role: SmolStr,
 }
 
 pub struct AppPasswordService {
@@ -299,7 +305,7 @@ impl AppPasswordService {
         &self,
         username: &str,
         password: &str,
-    ) -> Result<(Uuid, String, String, String), DomainError> {
+    ) -> Result<(Uuid, Arc<str>, Arc<str>, SmolStr), DomainError> {
         // ── 1. Compute cache key = blake3("username:password") ────────
         let cache_key: [u8; 32] =
             blake3::hash(format!("{}:{}", username, password).as_bytes()).into();
@@ -400,9 +406,9 @@ impl AppPasswordService {
                 // stores this value under the blake3 key on return.
                 return Ok(CachedBasicAuthResult {
                     user_id: user.id(),
-                    username: user.username().unwrap_or("").to_string(),
-                    email: user.email().to_string(),
-                    role: user.role().to_string(),
+                    username: Arc::from(user.username().unwrap_or("")),
+                    email: Arc::from(user.email()),
+                    role: SmolStr::new_static(user.role().as_str()),
                 });
             }
         }

--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -1102,9 +1102,9 @@ impl AuthApplicationService {
 
         Ok(crate::application::dtos::user_dto::CurrentUser {
             id: user.id(),
-            username: user.username().unwrap_or("").to_string(),
-            email: user.email().to_string(),
-            role: user.role().to_string(),
+            username: std::sync::Arc::from(user.username().unwrap_or("")),
+            email: std::sync::Arc::from(user.email()),
+            role: smol_str::SmolStr::new_static(user.role().as_str()),
         })
     }
 

--- a/src/application/services/calendar_service.rs
+++ b/src/application/services/calendar_service.rs
@@ -253,15 +253,23 @@ impl CalendarUseCase for CalendarService {
         update: UpdateEventDto,
         user_id: Uuid,
     ) -> Result<CalendarEventDto, DomainError> {
-        let event = self.calendar_storage.get_event(event_id).await?;
-        self.require_calendar_perm(&event.calendar_id, user_id, Permission::Update)
+        // Only the owning calendar id is needed for the gate — skip the
+        // full event hydration (`ical_data` can run to tens of KB).
+        let calendar_id = self
+            .calendar_storage
+            .calendar_id_for_event(event_id)
+            .await?;
+        self.require_calendar_perm(&calendar_id, user_id, Permission::Update)
             .await?;
         self.calendar_storage.update_event(event_id, update).await
     }
 
     async fn delete_event(&self, event_id: &str, user_id: Uuid) -> Result<(), DomainError> {
-        let event = self.calendar_storage.get_event(event_id).await?;
-        self.require_calendar_perm(&event.calendar_id, user_id, Permission::Delete)
+        let calendar_id = self
+            .calendar_storage
+            .calendar_id_for_event(event_id)
+            .await?;
+        self.require_calendar_perm(&calendar_id, user_id, Permission::Delete)
             .await?;
         self.calendar_storage.delete_event(event_id).await
     }

--- a/src/application/services/contact_service.rs
+++ b/src/application/services/contact_service.rs
@@ -1005,11 +1005,12 @@ impl ContactUseCase for ContactService {
         self.require_address_book_read_or_public(group.address_book_id(), &user_id)
             .await?;
 
-        // Get the number of contacts in the group
-        let contacts = self.contact_storage.get_contacts_in_group(&id).await?;
+        // Count-only read: the summary DTO never looks at the contacts, so
+        // don't hydrate N full rows (vCard TEXT + 3 JSONB parses each).
+        let members = self.contact_storage.count_contacts_in_group(&id).await?;
 
         let mut dto = ContactGroupDto::from(group);
-        dto.members_count = Some(contacts.len() as i32);
+        dto.members_count = Some(members as i32);
 
         Ok(dto)
     }

--- a/src/application/services/file_management_service.rs
+++ b/src/application/services/file_management_service.rs
@@ -336,18 +336,18 @@ impl FileManagementUseCase for FileManagementService {
                 Uuid::parse_str(file_id).map_err(|_| DomainError::not_found("File", file_id))?;
             let dst_folder_uuid = Uuid::parse_str(target_folder_id)
                 .map_err(|_| DomainError::not_found("Folder", target_folder_id))?;
-            let (src_drive_id, src_policies) = drive_repo
-                .get_drive_id_and_policies_for_file(file_uuid)
-                .await
-                .map_err(|e| {
-                    DomainError::internal_error("Drive", format!("source drive lookup: {e:?}"))
-                })?;
-            let dst_drive_id = drive_repo
-                .drive_id_for_folder(dst_folder_uuid)
-                .await
-                .map_err(|e| {
-                    DomainError::internal_error("Drive", format!("destination drive lookup: {e:?}"))
-                })?;
+            // Independent point reads — overlapped so the pre-move drive
+            // resolution pays one round-trip, not two (ROUND10).
+            let (src_res, dst_res) = tokio::join!(
+                drive_repo.get_drive_id_and_policies_for_file(file_uuid),
+                drive_repo.drive_id_for_folder(dst_folder_uuid),
+            );
+            let (src_drive_id, src_policies) = src_res.map_err(|e| {
+                DomainError::internal_error("Drive", format!("source drive lookup: {e:?}"))
+            })?;
+            let dst_drive_id = dst_res.map_err(|e| {
+                DomainError::internal_error("Drive", format!("destination drive lookup: {e:?}"))
+            })?;
             if src_drive_id != dst_drive_id {
                 src_policies.refuse_cross_drive_move(
                     crate::domain::entities::drive::CrossDriveMoveGateContext {

--- a/src/application/services/folder_service.rs
+++ b/src/application/services/folder_service.rs
@@ -665,18 +665,19 @@ impl FolderUseCase for FolderService {
                 Uuid::parse_str(id).map_err(|_| DomainError::not_found("Folder", id))?;
             let dst_folder_uuid = Uuid::parse_str(parent_id)
                 .map_err(|_| DomainError::not_found("Folder", parent_id.as_str()))?;
-            let (src_drive_id, src_policies) = drive_repo
-                .get_drive_id_and_policies_for_folder(src_folder_uuid)
-                .await
-                .map_err(|e| {
-                    DomainError::internal_error("Drive", format!("source drive lookup: {e:?}"))
-                })?;
-            let dst_drive_id = drive_repo
-                .drive_id_for_folder(dst_folder_uuid)
-                .await
-                .map_err(|e| {
-                    DomainError::internal_error("Drive", format!("destination drive lookup: {e:?}"))
-                })?;
+            // Independent point reads — overlapped so the pre-move drive
+            // resolution pays one round-trip, not two (ROUND10, same shape
+            // as `move_file_with_perms`).
+            let (src_res, dst_res) = tokio::join!(
+                drive_repo.get_drive_id_and_policies_for_folder(src_folder_uuid),
+                drive_repo.drive_id_for_folder(dst_folder_uuid),
+            );
+            let (src_drive_id, src_policies) = src_res.map_err(|e| {
+                DomainError::internal_error("Drive", format!("source drive lookup: {e:?}"))
+            })?;
+            let dst_drive_id = dst_res.map_err(|e| {
+                DomainError::internal_error("Drive", format!("destination drive lookup: {e:?}"))
+            })?;
             if src_drive_id != dst_drive_id {
                 src_policies.refuse_cross_drive_move(
                     crate::domain::entities::drive::CrossDriveMoveGateContext {

--- a/src/application/services/search_service.rs
+++ b/src/application/services/search_service.rs
@@ -620,18 +620,30 @@ impl SearchUseCase for SearchService {
                 // Pre-compute once — avoids N heap allocations inside enrich_file/enrich_folder.
                 let query_lower = query.to_lowercase();
 
-                // Content-index candidates (first page only). Feature-off or an
-                // index failure yields an empty set — the search stays name-only.
-                let content_hits = self.lookup_content_hits(&criteria, user_id).await;
-
                 // For non-recursive searches, use efficient database-level pagination
                 // This avoids loading all files into memory
                 if !criteria.recursive {
-                    // Use database-level pagination
-                    let (files, total_file_count) = self
-                        .file_repository
-                        .search_files_paginated(criteria.folder_id.as_deref(), &criteria, user_id)
-                        .await?;
+                    // The content-index lookup (drive resolve + Tantivy +
+                    // ReBAC batch), the file page and the folder query are
+                    // mutually independent — overlap them so the search pays
+                    // ~max() instead of the serial sum (`suggest_with_perms`
+                    // already used this shape; ROUND10 brought it here).
+                    let (content_hits, files_page, folders_res) = tokio::join!(
+                        self.lookup_content_hits(&criteria, user_id),
+                        self.file_repository.search_files_paginated(
+                            criteria.folder_id.as_deref(),
+                            &criteria,
+                            user_id,
+                        ),
+                        self.folder_repository.search_folders(
+                            criteria.folder_id.as_deref(),
+                            criteria.name_contains.as_deref(),
+                            user_id,
+                            false,
+                        ),
+                    );
+                    let (files, total_file_count) = files_page?;
+                    let folders = folders_res?;
 
                     // Convert to DTOs and enrich with metadata — one fused
                     // pass, no intermediate Vec<FileDto> materialization.
@@ -639,17 +651,6 @@ impl SearchUseCase for SearchService {
                         .into_iter()
                         .map(|f| Self::enrich_file(FileDto::from(f), &query_lower))
                         .collect();
-
-                    // Get folders for this folder (non-recursive, filtered in SQL)
-                    let folders = self
-                        .folder_repository
-                        .search_folders(
-                            criteria.folder_id.as_deref(),
-                            criteria.name_contains.as_deref(),
-                            user_id,
-                            false,
-                        )
-                        .await?;
 
                     // For folders, apply sorting and pagination in memory (usually fewer folders)
                     let mut enriched_folders: Vec<SearchFolderResultDto> = folders
@@ -717,22 +718,25 @@ impl SearchUseCase for SearchService {
                 // ── Recursive search via ltree (single SQL query per entity type) ──
                 // Uses PostgreSQL ltree GiST index to find all files and folders
                 // in the subtree in O(1) queries, replacing the O(N) spawn-per-folder
-                // approach that could saturate the connection pool.
-                let (found_files, total_file_count) = self
-                    .file_repository
-                    .search_files_in_subtree(criteria.folder_id.as_deref(), &criteria, user_id)
-                    .await?;
-
-                // Get folders (SQL-filtered, user-scoped, recursive when applicable)
-                let found_folders: Vec<Folder> = self
-                    .folder_repository
-                    .search_folders(
+                // approach that could saturate the connection pool. The content
+                // lookup, subtree file query and folder query overlap (`join!`),
+                // same as the non-recursive branch.
+                let (content_hits, files_page, folders_res) = tokio::join!(
+                    self.lookup_content_hits(&criteria, user_id),
+                    self.file_repository.search_files_in_subtree(
+                        criteria.folder_id.as_deref(),
+                        &criteria,
+                        user_id,
+                    ),
+                    self.folder_repository.search_folders(
                         criteria.folder_id.as_deref(),
                         criteria.name_contains.as_deref(),
                         user_id,
                         true,
-                    )
-                    .await?;
+                    ),
+                );
+                let (found_files, total_file_count) = files_page?;
+                let found_folders: Vec<Folder> = folders_res?;
 
                 // ── Convert to DTOs and enrich with server-computed metadata ──
                 // Fused single pass: no intermediate DTO Vec materialization.

--- a/src/application/services/share_service.rs
+++ b/src/application/services/share_service.rs
@@ -79,6 +79,11 @@ const MAX_CONCURRENT_HASHES: usize = 2;
 
 pub struct ShareService {
     config: Arc<AppConfig>,
+    /// `AppConfig::base_url()` snapshot, taken once at construction —
+    /// the method re-reads `OXICLOUD_BASE_URL` from the environment (a
+    /// global env-lock + String build) and was being called per DTO row
+    /// in the share listings. Process-invariant, so snapshot it.
+    base_url: String,
     share_repository: Arc<SharePgRepository>,
     file_repository: Arc<FileBlobReadRepository>,
     folder_repository: Arc<FolderDbRepository>,
@@ -107,6 +112,7 @@ impl ShareService {
         authorization: Arc<PgAclEngine>,
     ) -> Self {
         Self {
+            base_url: config.base_url(),
             config,
             share_repository,
             file_repository,
@@ -204,7 +210,7 @@ impl ShareService {
             ));
         }
 
-        Ok(ShareDto::from_entity(&share, &self.config.base_url()))
+        Ok(ShareDto::from_entity(&share, &self.base_url))
     }
 
     pub fn issue_unlock_jwt(&self, share_token: &str) -> Result<String, DomainError> {
@@ -338,7 +344,7 @@ impl ShareUseCase for ShareService {
 
         // Return DTO with the requested expires_at (grant subquery on the share
         // row would return NULL at this point since INSERT ran before the grant).
-        let mut response = ShareDto::from_entity(&saved_share, &self.config.base_url());
+        let mut response = ShareDto::from_entity(&saved_share, &self.base_url);
         response.expires_at = dto.expires_at;
         Ok(response)
     }
@@ -354,7 +360,7 @@ impl ShareUseCase for ShareService {
         }
 
         // Convert the entity to DTO for the response
-        Ok(ShareDto::from_entity(&share, &self.config.base_url()))
+        Ok(ShareDto::from_entity(&share, &self.base_url))
     }
 
     async fn get_shared_link_by_token(&self, token: &str) -> Result<ShareDto, DomainError> {
@@ -380,7 +386,7 @@ impl ShareUseCase for ShareService {
         // Convert the entities to DTOs for the response
         let share_dtos = active_shares
             .iter()
-            .map(|s| ShareDto::from_entity(s, &self.config.base_url()))
+            .map(|s| ShareDto::from_entity(s, &self.base_url))
             .collect();
 
         Ok(share_dtos)
@@ -427,7 +433,7 @@ impl ShareUseCase for ShareService {
 
         // Use the requested expires_at for the response (subquery in update_share
         // runs before set_expiry_for_subject committed, so entity may lag).
-        let mut response = ShareDto::from_entity(&updated_share, &self.config.base_url());
+        let mut response = ShareDto::from_entity(&updated_share, &self.base_url);
         if dto.expires_at.is_some() {
             response.expires_at = dto.expires_at;
         }
@@ -462,7 +468,7 @@ impl ShareUseCase for ShareService {
         // Convert the entities to DTOs
         let share_dtos: Vec<ShareDto> = shares
             .iter()
-            .map(|s| ShareDto::from_entity(s, &self.config.base_url()))
+            .map(|s| ShareDto::from_entity(s, &self.base_url))
             .collect();
 
         // Create the paginated result
@@ -506,7 +512,7 @@ impl ShareUseCase for ShareService {
         }
 
         // Password verified (or not required) — return full share metadata
-        Ok(ShareDto::from_entity(&share, &self.config.base_url()))
+        Ok(ShareDto::from_entity(&share, &self.base_url))
     }
 
     async fn register_shared_link_access(&self, token: &str) -> Result<(), DomainError> {
@@ -540,7 +546,9 @@ mod tests {
 
     /// Test-only service that mirrors `ShareService` logic but accepts generic repos.
     struct ShareServiceForTest<SR, FR, FoR, PH> {
+        #[allow(dead_code)]
         config: Arc<AppConfig>,
+        base_url: String,
         share_repository: Arc<SR>,
         file_repository: Arc<FR>,
         folder_repository: Arc<FoR>,
@@ -563,6 +571,7 @@ mod tests {
             password_hasher: Arc<PH>,
         ) -> Self {
             Self {
+                base_url: config.base_url(),
                 config,
                 share_repository,
                 file_repository,
@@ -641,7 +650,7 @@ mod tests {
                 .save_share(&share)
                 .await
                 .map_err(|e| ShareServiceError::Repository(e.to_string()))?;
-            Ok(ShareDto::from_entity(&saved_share, &self.config.base_url()))
+            Ok(ShareDto::from_entity(&saved_share, &self.base_url))
         }
 
         async fn get_shared_link(
@@ -659,7 +668,7 @@ mod tests {
             if share.is_expired() {
                 return Err(ShareServiceError::Expired.into());
             }
-            Ok(ShareDto::from_entity(&share, &self.config.base_url()))
+            Ok(ShareDto::from_entity(&share, &self.base_url))
         }
 
         async fn get_shared_link_by_token(&self, token: &str) -> Result<ShareDto, DomainError> {
@@ -673,7 +682,7 @@ mod tests {
             if share.is_expired() {
                 return Err(ShareServiceError::Expired.into());
             }
-            Ok(ShareDto::from_entity(&share, &self.config.base_url()))
+            Ok(ShareDto::from_entity(&share, &self.base_url))
         }
 
         async fn get_shared_links_for_item(
@@ -690,7 +699,7 @@ mod tests {
             Ok(shares
                 .into_iter()
                 .filter(|s| !s.is_expired())
-                .map(|s| ShareDto::from_entity(&s, &self.config.base_url()))
+                .map(|s| ShareDto::from_entity(&s, &self.base_url))
                 .collect())
         }
 
@@ -720,7 +729,7 @@ mod tests {
                 .update_share(&share)
                 .await
                 .map_err(|e| ShareServiceError::Repository(e.to_string()))?;
-            Ok(ShareDto::from_entity(&updated, &self.config.base_url()))
+            Ok(ShareDto::from_entity(&updated, &self.base_url))
         }
 
         async fn delete_shared_link(
@@ -749,7 +758,7 @@ mod tests {
                 .map_err(|e| ShareServiceError::Repository(e.to_string()))?;
             let dtos = shares
                 .iter()
-                .map(|s| ShareDto::from_entity(s, &self.config.base_url()))
+                .map(|s| ShareDto::from_entity(s, &self.base_url))
                 .collect();
             Ok(PaginatedResponseDto::new(dtos, page, per_page, total))
         }
@@ -779,9 +788,9 @@ mod tests {
                             "Invalid share password",
                         ));
                     }
-                    Ok(ShareDto::from_entity(&share, &self.config.base_url()))
+                    Ok(ShareDto::from_entity(&share, &self.base_url))
                 }
-                None => Ok(ShareDto::from_entity(&share, &self.config.base_url())),
+                None => Ok(ShareDto::from_entity(&share, &self.base_url)),
             }
         }
 
@@ -913,15 +922,6 @@ mod tests {
             _user_id: Uuid,
         ) -> Result<(Vec<crate::domain::entities::file::File>, usize), DomainError> {
             Ok((Vec::new(), 0))
-        }
-
-        async fn count_files(
-            &self,
-            _folder_id: Option<&str>,
-            _criteria: &crate::application::dtos::search_dto::SearchCriteriaDto,
-            _user_id: Uuid,
-        ) -> Result<usize, DomainError> {
-            Ok(0)
         }
 
         async fn stream_files_in_subtree(

--- a/src/application/services/trash_service_test.rs
+++ b/src/application/services/trash_service_test.rs
@@ -536,15 +536,6 @@ impl FileReadPort for MockFileRepository {
         Ok((Vec::new(), 0))
     }
 
-    async fn count_files(
-        &self,
-        _folder_id: Option<&str>,
-        _criteria: &crate::application::dtos::search_dto::SearchCriteriaDto,
-        _user_id: Uuid,
-    ) -> std::result::Result<usize, DomainError> {
-        Ok(0)
-    }
-
     async fn stream_files_in_subtree(
         &self,
         _folder_id: &str,

--- a/src/common/fmt.rs
+++ b/src/common/fmt.rs
@@ -37,10 +37,21 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
     (if m <= 2 { y + 1 } else { y }, m, d)
 }
 
+/// Two-digit decimal pairs `"00" … "99"` — the same table-driven rendering
+/// `core::fmt` uses for integer `Display`. One lookup replaces a div+mod
+/// pair per two digits; ROUND10 adopted it after the naive div-by-10 loop
+/// benchmarked SLOWER than `u64::to_string()` (std already uses this LUT).
+const DEC_LUT: &[u8; 200] = b"0001020304050607080910111213141516171819\
+                              2021222324252627282930313233343536373839\
+                              4041424344454647484950515253545556575859\
+                              6061626364656667686970717273747576777879\
+                              8081828384858687888990919293949596979899";
+
 #[inline]
 fn push2(out: &mut [u8], pos: usize, v: u32) {
-    out[pos] = b'0' + (v / 10) as u8;
-    out[pos + 1] = b'0' + (v % 10) as u8;
+    let d = (v as usize) * 2;
+    out[pos] = DEC_LUT[d];
+    out[pos + 1] = DEC_LUT[d + 1];
 }
 
 #[inline]
@@ -142,32 +153,46 @@ pub fn rfc2822_utc(buf: &mut [u8; 31], secs: i64) -> Option<&str> {
     Some(std::str::from_utf8(&buf[..p]).expect("ascii"))
 }
 
+/// Backward two-digit-chunk render of `v` into the tail of `buf`;
+/// returns the first populated index. Shared core of
+/// [`u64_str`] / [`i64_str`].
+#[inline]
+fn digits_to_tail(buf: &mut [u8], mut v: u64) -> usize {
+    let mut pos = buf.len();
+    while v >= 100 {
+        let d = ((v % 100) as usize) * 2;
+        v /= 100;
+        pos -= 2;
+        buf[pos] = DEC_LUT[d];
+        buf[pos + 1] = DEC_LUT[d + 1];
+    }
+    if v >= 10 {
+        let d = (v as usize) * 2;
+        pos -= 2;
+        buf[pos] = DEC_LUT[d];
+        buf[pos + 1] = DEC_LUT[d + 1];
+    } else {
+        pos -= 1;
+        buf[pos] = b'0' + v as u8;
+    }
+    pos
+}
+
 /// `u64::to_string()` without the heap `String`: renders into `buf`,
 /// returns the populated tail slice.
-pub fn u64_str(buf: &mut [u8; 20], mut v: u64) -> &str {
-    let mut pos = buf.len();
-    loop {
-        pos -= 1;
-        buf[pos] = b'0' + (v % 10) as u8;
-        v /= 10;
-        if v == 0 {
-            break;
-        }
-    }
+pub fn u64_str(buf: &mut [u8; 20], v: u64) -> &str {
+    let pos = digits_to_tail(buf, v);
     std::str::from_utf8(&buf[pos..]).expect("ascii")
 }
 
 /// `i64::to_string()` without the heap `String` (quota bytes are `i64`).
 pub fn i64_str(buf: &mut [u8; 21], v: i64) -> &str {
-    let mut u = [0u8; 20];
-    let digits = u64_str(&mut u, v.unsigned_abs());
-    let neg = v < 0;
-    let start = 21 - digits.len() - usize::from(neg);
-    if neg {
-        buf[start] = b'-';
+    let mut pos = digits_to_tail(buf, v.unsigned_abs());
+    if v < 0 {
+        pos -= 1;
+        buf[pos] = b'-';
     }
-    buf[start + usize::from(neg)..].copy_from_slice(digits.as_bytes());
-    std::str::from_utf8(&buf[start..]).expect("ascii")
+    std::str::from_utf8(&buf[pos..]).expect("ascii")
 }
 
 /// Lower-case hex of `bytes` into one preallocated `String`.

--- a/src/common/stubs.rs
+++ b/src/common/stubs.rs
@@ -130,15 +130,6 @@ impl FileReadPort for StubFileReadPort {
         Ok((Vec::new(), 0))
     }
 
-    async fn count_files(
-        &self,
-        _folder_id: Option<&str>,
-        _criteria: &SearchCriteriaDto,
-        _user_id: Uuid,
-    ) -> Result<usize, DomainError> {
-        Ok(0)
-    }
-
     async fn stream_files_in_subtree(
         &self,
         _folder_id: &str,

--- a/src/domain/entities/user.rs
+++ b/src/domain/entities/user.rs
@@ -11,12 +11,20 @@ pub enum UserRole {
     User,
 }
 
+impl UserRole {
+    /// Canonical wire/DB spelling — the single source the `Display` impl
+    /// and every hot-path role render go through (no format machinery).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UserRole::Admin => "admin",
+            UserRole::User => "user",
+        }
+    }
+}
+
 impl std::fmt::Display for UserRole {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            UserRole::Admin => write!(f, "admin"),
-            UserRole::User => write!(f, "user"),
-        }
+        f.write_str(self.as_str())
     }
 }
 

--- a/src/domain/repositories/calendar_event_repository.rs
+++ b/src/domain/repositories/calendar_event_repository.rs
@@ -25,6 +25,11 @@ pub trait CalendarEventRepository: Send + Sync + 'static {
     /// Finds a calendar event by its ID
     async fn find_event_by_id(&self, id: &Uuid) -> CalendarEventRepositoryResult<CalendarEvent>;
 
+    /// Narrow projection of `find_event_by_id` for authorization gates:
+    /// just the owning `calendar_id`, without dragging the full row —
+    /// notably `ical_data`, the raw iCalendar body — off the wire.
+    async fn find_calendar_id_by_event_id(&self, id: &Uuid) -> CalendarEventRepositoryResult<Uuid>;
+
     /// Cursor stream over every event of `calendar_id` in bundle order:
     /// rows sorted by `(first occurrence per UID, uid, master-first,
     /// start_time)` so a recurring master + its exception overrides

--- a/src/domain/repositories/contact_repository.rs
+++ b/src/domain/repositories/contact_repository.rs
@@ -76,6 +76,10 @@ pub trait ContactGroupRepository: Send + Sync + 'static {
     ) -> ContactRepositoryResult<()>;
     async fn get_contacts_in_group(&self, group_id: &Uuid)
     -> ContactRepositoryResult<Vec<Contact>>;
+    /// Membership count only — for group summaries that don't need the
+    /// contacts hydrated (each row carries the full vCard TEXT plus three
+    /// JSONB arrays; counting must not pay for any of that).
+    async fn count_contacts_in_group(&self, group_id: &Uuid) -> ContactRepositoryResult<i64>;
     async fn get_groups_for_contact(
         &self,
         contact_id: &Uuid,

--- a/src/infrastructure/adapters/calendar_storage_adapter.rs
+++ b/src/infrastructure/adapters/calendar_storage_adapter.rs
@@ -391,6 +391,18 @@ impl CalendarStoragePort for CalendarStorageAdapter {
         Ok(CalendarEventDto::from(event))
     }
 
+    async fn calendar_id_for_event(&self, event_id: &str) -> Result<String, DomainError> {
+        let uuid = Uuid::parse_str(event_id).map_err(|_| {
+            DomainError::new(ErrorKind::InvalidInput, "Event", "Invalid event ID format")
+        })?;
+
+        let calendar_id = self
+            .event_repository
+            .find_calendar_id_by_event_id(&uuid)
+            .await?;
+        Ok(calendar_id.to_string())
+    }
+
     async fn find_event_by_ical_uid(
         &self,
         calendar_id: &str,

--- a/src/infrastructure/adapters/contact_storage_adapter.rs
+++ b/src/infrastructure/adapters/contact_storage_adapter.rs
@@ -230,6 +230,12 @@ impl ContactStoragePort for ContactStorageAdapter {
             .await
     }
 
+    async fn count_contacts_in_group(&self, group_id: &Uuid) -> Result<i64, DomainError> {
+        self.contact_group_repository
+            .count_contacts_in_group(group_id)
+            .await
+    }
+
     async fn get_groups_for_contact(
         &self,
         contact_id: &Uuid,

--- a/src/infrastructure/repositories/pg/calendar_event_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/calendar_event_pg_repository.rs
@@ -213,6 +213,17 @@ impl CalendarEventRepository for CalendarEventPgRepository {
         Ok(events)
     }
 
+    async fn find_calendar_id_by_event_id(&self, id: &Uuid) -> CalendarEventRepositoryResult<Uuid> {
+        sqlx::query_scalar("SELECT calendar_id FROM caldav.calendar_events WHERE id = $1")
+            .bind(id)
+            .fetch_optional(&*self.pool)
+            .await
+            .map_err(|e| {
+                DomainError::database_error(format!("Failed to get event calendar id: {}", e))
+            })?
+            .ok_or_else(|| DomainError::not_found("Calendar Event", id.to_string()))
+    }
+
     async fn find_event_by_id(&self, id: &Uuid) -> CalendarEventRepositoryResult<CalendarEvent> {
         let row = sqlx::query(
             r#"

--- a/src/infrastructure/repositories/pg/contact_group_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/contact_group_pg_repository.rs
@@ -177,6 +177,20 @@ impl ContactGroupRepository for ContactGroupPgRepository {
         Ok(())
     }
 
+    async fn count_contacts_in_group(&self, group_id: &Uuid) -> ContactRepositoryResult<i64> {
+        sqlx::query_scalar("SELECT COUNT(*) FROM carddav.group_memberships WHERE group_id = $1")
+            .bind(group_id)
+            .fetch_one(self.pool.as_ref())
+            .await
+            .map_err(|e| {
+                DomainError::new(
+                    ErrorKind::InternalError,
+                    "ContactGroup",
+                    format!("Failed to count contacts in group: {}", e),
+                )
+            })
+    }
+
     async fn get_contacts_in_group(
         &self,
         group_id: &Uuid,

--- a/src/infrastructure/repositories/pg/face_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/face_pg_repository.rs
@@ -115,29 +115,70 @@ impl FaceRepository for FacePgRepository {
         if faces.is_empty() {
             return Ok(());
         }
-        let mut tx = self.pool.begin().await.map_err(|e| db_err("begin", e))?;
+        // One multi-row INSERT over parallel UNNEST arrays instead of one
+        // round-trip per face — a group photo yields many faces per indexed
+        // image. The `bbox` float4[] can't ride an array-of-arrays through
+        // unnest (PG flattens), so its 4 components travel as 4 parallel
+        // arrays and are reassembled server-side. A single statement is
+        // atomic on its own; the per-row transaction wrapper is gone.
+        let n = faces.len();
+        let mut ids = Vec::with_capacity(n);
+        let mut file_ids = Vec::with_capacity(n);
+        let mut user_ids = Vec::with_capacity(n);
+        let mut person_ids: Vec<Option<Uuid>> = Vec::with_capacity(n);
+        let (mut bx, mut by, mut bw, mut bh) = (
+            Vec::with_capacity(n),
+            Vec::with_capacity(n),
+            Vec::with_capacity(n),
+            Vec::with_capacity(n),
+        );
+        let mut det_scores = Vec::with_capacity(n);
+        let mut qualities: Vec<Option<f32>> = Vec::with_capacity(n);
+        let mut embeddings = Vec::with_capacity(n);
+        let mut blob_hashes: Vec<Option<&str>> = Vec::with_capacity(n);
         for f in faces {
-            sqlx::query(
-                r#"
-                INSERT INTO faces.faces
-                    (id, file_id, user_id, person_id, bbox, det_score, quality, embedding, blob_hash)
-                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-                "#,
-            )
-            .bind(f.id)
-            .bind(f.file_id)
-            .bind(f.user_id)
-            .bind(f.person_id)
-            .bind(f.bbox.to_array())
-            .bind(f.det_score)
-            .bind(f.quality)
-            .bind(embedding_to_bytes(&f.embedding))
-            .bind(f.blob_hash.as_deref())
-            .execute(&mut *tx)
-            .await
-            .map_err(|e| db_err("save_faces", e))?;
+            ids.push(f.id);
+            file_ids.push(f.file_id);
+            user_ids.push(f.user_id);
+            person_ids.push(f.person_id);
+            bx.push(f.bbox.x);
+            by.push(f.bbox.y);
+            bw.push(f.bbox.w);
+            bh.push(f.bbox.h);
+            det_scores.push(f.det_score);
+            qualities.push(f.quality);
+            embeddings.push(embedding_to_bytes(&f.embedding));
+            blob_hashes.push(f.blob_hash.as_deref());
         }
-        tx.commit().await.map_err(|e| db_err("commit", e))?;
+        sqlx::query(
+            r#"
+            INSERT INTO faces.faces
+                (id, file_id, user_id, person_id, bbox, det_score, quality, embedding, blob_hash)
+            SELECT t.id, t.file_id, t.user_id, t.person_id,
+                   ARRAY[t.bx, t.by, t.bw, t.bh]::real[],
+                   t.det_score, t.quality, t.embedding, t.blob_hash
+              FROM unnest($1::uuid[], $2::uuid[], $3::uuid[], $4::uuid[],
+                          $5::real[], $6::real[], $7::real[], $8::real[],
+                          $9::real[], $10::real[], $11::bytea[], $12::text[])
+                   AS t(id, file_id, user_id, person_id,
+                        bx, by, bw, bh, det_score, quality, embedding, blob_hash)
+            "#,
+        )
+        .bind(&ids)
+        .bind(&file_ids)
+        .bind(&user_ids)
+        .bind(&person_ids)
+        .bind(&bx)
+        .bind(&by)
+        .bind(&bw)
+        .bind(&bh)
+        .bind(&det_scores)
+        .bind(&qualities)
+        .bind(&embeddings)
+        .bind(&blob_hashes)
+        .execute(self.pool.as_ref())
+        .await
+        .map_err(|e| db_err("save_faces", e))?;
         Ok(())
     }
 

--- a/src/infrastructure/repositories/pg/favorites_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/favorites_pg_repository.rs
@@ -24,18 +24,21 @@ impl FavoritesPgRepository {
 
 impl FavoritesRepositoryPort for FavoritesPgRepository {
     async fn get_favorites(&self, user_id: Uuid) -> Result<Vec<FavoriteItemDto>> {
+        // `id`/`user_id`/`parent_id` decode as binary UUIDs (16 B on the wire,
+        // no server-side `::TEXT` cast) and render app-side — the ROUND6 §10
+        // pattern the two legacy listing methods here never picked up.
         let rows = sqlx::query(
             r#"
             SELECT
-                uf.id::TEXT                                     AS "id",
-                uf.user_id::TEXT                                AS "user_id",
+                uf.id                                           AS "id",
+                uf.user_id                                      AS "user_id",
                 uf.item_id                                      AS "item_id",
                 uf.item_type                                    AS "item_type",
                 uf.created_at                                   AS "created_at",
                 COALESCE(f.name, fld.name)                      AS "item_name",
                 f.size                                          AS "item_size",
                 f.mime_type                                     AS "item_mime_type",
-                COALESCE(f.folder_id::TEXT, fld.parent_id::TEXT) AS "parent_id",
+                COALESCE(f.folder_id, fld.parent_id)            AS "parent_id",
                 COALESCE(f.updated_at, fld.updated_at)          AS "modified_at",
                 CASE
                     WHEN uf.item_type = 'folder' THEN fld.path
@@ -70,15 +73,19 @@ impl FavoritesRepositoryPort for FavoritesPgRepository {
             .iter()
             .map(|row| {
                 FavoriteItemDto {
-                    id: row.get("id"),
-                    user_id: row.get("user_id"),
+                    id: row.get::<i32, _>("id").to_string(),
+                    user_id: row.get::<Uuid, _>("user_id").to_string(),
                     item_id: row.get("item_id"),
                     item_type: row.get("item_type"),
                     created_at: row.get("created_at"),
                     item_name: row.try_get("item_name").ok(),
                     item_size: row.try_get("item_size").ok(),
                     item_mime_type: row.try_get("item_mime_type").ok(),
-                    parent_id: row.try_get("parent_id").ok(),
+                    parent_id: row
+                        .try_get::<Option<Uuid>, _>("parent_id")
+                        .ok()
+                        .flatten()
+                        .map(|u| u.to_string()),
                     modified_at: row.try_get("modified_at").ok(),
                     item_path: row.try_get("item_path").ok(),
                     // Temporary defaults; with_display_fields() computes the real values

--- a/src/infrastructure/repositories/pg/file_blob_read_repository.rs
+++ b/src/infrastructure/repositories/pg/file_blob_read_repository.rs
@@ -1394,19 +1394,6 @@ impl FileReadPort for FileBlobReadRepository {
         Ok((files, total_count))
     }
 
-    /// Count files matching the search criteria (without loading them).
-    async fn count_files(
-        &self,
-        folder_id: Option<&str>,
-        criteria: &SearchCriteriaDto,
-        caller_id: Uuid,
-    ) -> Result<usize, DomainError> {
-        let (_, count) = self
-            .search_files_paginated(folder_id, criteria, caller_id)
-            .await?;
-        Ok(count)
-    }
-
     #[allow(clippy::type_complexity)]
     async fn suggest_files_by_name(
         &self,

--- a/src/infrastructure/repositories/pg/playlist_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/playlist_pg_repository.rs
@@ -544,17 +544,27 @@ impl PlaylistItemRepository for PlaylistItemPgRepository {
         playlist_id: &Uuid,
         item_ids: &[Uuid],
     ) -> PlaylistItemRepositoryResult<()> {
-        for (index, item_id) in item_ids.iter().enumerate() {
-            sqlx::query(
-                "UPDATE audio.playlist_items SET position = $2 WHERE id = $1 AND playlist_id = $3",
-            )
-            .bind(item_id)
-            .bind(index as i32)
-            .bind(playlist_id)
-            .execute(&*self.pool)
-            .await
-            .map_err(|e| DomainError::database_error(format!("Failed to reorder: {}", e)))?;
+        if item_ids.is_empty() {
+            return Ok(());
         }
+        // One UNNEST-driven UPDATE instead of one autocommit round-trip per
+        // track — a full drag-reorder of an N-track playlist was N statements
+        // (and non-atomic: a mid-loop failure left a half-applied order).
+        // `WITH ORDINALITY` numbers the ids in array order, 1-based, so
+        // `ord - 1` reproduces the historical 0-based positions.
+        sqlx::query(
+            r#"
+            UPDATE audio.playlist_items AS pi
+               SET position = (t.ord - 1)::int
+              FROM unnest($1::uuid[]) WITH ORDINALITY AS t(id, ord)
+             WHERE pi.id = t.id AND pi.playlist_id = $2
+            "#,
+        )
+        .bind(item_ids)
+        .bind(playlist_id)
+        .execute(&*self.pool)
+        .await
+        .map_err(|e| DomainError::database_error(format!("Failed to reorder: {}", e)))?;
         Ok(())
     }
 

--- a/src/infrastructure/repositories/pg/recent_items_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/recent_items_pg_repository.rs
@@ -21,18 +21,20 @@ impl RecentItemsPgRepository {
 
 impl RecentItemsRepositoryPort for RecentItemsPgRepository {
     async fn get_recent_items(&self, user_id: Uuid, limit: i32) -> Result<Vec<RecentItemDto>> {
+        // Binary UUID decode + app-side render (ROUND6 §10 pattern) — no
+        // server-side `::TEXT` casts, 16 B per id on the wire instead of 36.
         let rows = sqlx::query(
             r#"
             SELECT
-                ur.id::TEXT                                     AS "id",
-                ur.user_id::TEXT                                AS "user_id",
+                ur.id                                           AS "id",
+                ur.user_id                                      AS "user_id",
                 ur.item_id                                      AS "item_id",
                 ur.item_type                                    AS "item_type",
                 ur.accessed_at                                  AS "accessed_at",
                 COALESCE(f.name, fld.name)                      AS "item_name",
                 f.size                                          AS "item_size",
                 f.mime_type                                     AS "item_mime_type",
-                COALESCE(f.folder_id::TEXT, fld.parent_id::TEXT) AS "parent_id",
+                COALESCE(f.folder_id, fld.parent_id)            AS "parent_id",
                 CASE
                     WHEN ur.item_type = 'folder' THEN fld.path
                     WHEN ur.item_type = 'file'   THEN COALESCE(pfld.path || '/' || f.name, f.name)
@@ -67,15 +69,19 @@ impl RecentItemsRepositoryPort for RecentItemsPgRepository {
             .iter()
             .map(|row| {
                 RecentItemDto {
-                    id: row.get("id"),
-                    user_id: row.get("user_id"),
+                    id: row.get::<i32, _>("id").to_string(),
+                    user_id: row.get::<Uuid, _>("user_id").to_string(),
                     item_id: row.get("item_id"),
                     item_type: row.get("item_type"),
                     accessed_at: row.get("accessed_at"),
                     item_name: row.try_get("item_name").ok(),
                     item_size: row.try_get("item_size").ok(),
                     item_mime_type: row.try_get("item_mime_type").ok(),
-                    parent_id: row.try_get("parent_id").ok(),
+                    parent_id: row
+                        .try_get::<Option<Uuid>, _>("parent_id")
+                        .ok()
+                        .flatten()
+                        .map(|u| u.to_string()),
                     item_path: row.try_get("item_path").ok(),
                     // Temporary defaults; with_display_fields() computes the real values
                     icon_class: String::new(),

--- a/src/infrastructure/services/encrypted_blob_backend.rs
+++ b/src/infrastructure/services/encrypted_blob_backend.rs
@@ -56,7 +56,10 @@ const PLAINTEXT_EMIT_SIZE: usize = 64 * 1024;
 /// `BlobStorageBackend` decorator that encrypts blobs at rest.
 pub struct EncryptedBlobBackend {
     inner: Arc<dyn BlobStorageBackend>,
-    cipher: Aes256Gcm,
+    /// `Arc` so the per-op `clone()` handed to `offload_crypto` closures is
+    /// an atomic bump instead of copying the ~240-byte expanded AES-256
+    /// round-key schedule on every chunk read/write.
+    cipher: Arc<Aes256Gcm>,
 }
 
 impl EncryptedBlobBackend {
@@ -64,7 +67,8 @@ impl EncryptedBlobBackend {
     ///
     /// `key` must be exactly 32 bytes (AES-256).
     pub fn new(inner: Arc<dyn BlobStorageBackend>, key: &[u8; 32]) -> Self {
-        let cipher = Aes256Gcm::new_from_slice(key).expect("AES-256 key must be 32 bytes");
+        let cipher =
+            Arc::new(Aes256Gcm::new_from_slice(key).expect("AES-256 key must be 32 bytes"));
         Self { inner, cipher }
     }
 

--- a/src/infrastructure/services/jwt_service.rs
+++ b/src/infrastructure/services/jwt_service.rs
@@ -24,6 +24,11 @@ use crate::domain::entities::user::User;
 
 /// Internal JWT claims structure for serialization.
 /// This is the actual JWT payload structure used by jsonwebtoken crate.
+///
+/// `username` / `email` deserialize straight into `Arc<str>` (serde `rc`,
+/// one allocation — same count as `String`) so the `TokenClaims` conversion
+/// below is a plain move and the port-level claims can hand refcount bumps
+/// to every consumer.
 #[derive(Debug, Serialize, Deserialize)]
 struct JwtClaims {
     /// Subject identifier - contains the user ID
@@ -35,9 +40,9 @@ struct JwtClaims {
     /// JWT unique ID for token tracking and revocation
     pub jti: String,
     /// Username for display and identification purposes
-    pub username: String,
+    pub username: Arc<str>,
     /// User email for communication and identification
-    pub email: String,
+    pub email: Arc<str>,
     /// User role for authorization checks
     pub role: String,
 }
@@ -80,8 +85,16 @@ impl From<JwtClaims> for TokenClaims {
 ///   unique-token flooding.
 /// - Expired tokens are never cached (decode itself rejects them first).
 pub struct JwtTokenService {
-    /// Secret key used for signing JWT tokens
-    jwt_secret: String,
+    /// Pre-built signing key — `EncodingKey::from_secret` copies the secret
+    /// into a fresh buffer, so building it per `generate_access_token` call
+    /// paid an allocation per login/refresh for a process-invariant value.
+    encoding_key: EncodingKey,
+    /// Pre-built verification key (same rationale, on the validation-cache
+    /// miss path — every new token and every token once per TTL window).
+    decoding_key: DecodingKey,
+    /// Pre-built HS256 validation config — `Validation::new` allocates a
+    /// `HashSet{"exp"}` + algorithm `Vec` on every call otherwise.
+    validation: Validation,
     /// Expiration time for access tokens in seconds
     access_token_expiry: i64,
     /// Expiration time for refresh tokens in seconds
@@ -125,7 +138,9 @@ impl JwtTokenService {
         );
 
         Self {
-            jwt_secret,
+            encoding_key: EncodingKey::from_secret(jwt_secret.as_bytes()),
+            decoding_key: DecodingKey::from_secret(jwt_secret.as_bytes()),
+            validation: Validation::new(Algorithm::HS256),
             access_token_expiry: access_token_expiry_secs,
             refresh_token_expiry: refresh_token_expiry_secs,
             validation_cache,
@@ -169,9 +184,9 @@ impl TokenServicePort for JwtTokenService {
             exp: now + self.access_token_expiry,
             iat: now,
             jti: Uuid::new_v4().to_string(),
-            username: user.username().unwrap_or("").to_string(),
-            email: user.email().to_string(),
-            role: format!("{}", user.role()),
+            username: Arc::from(user.username().unwrap_or("")),
+            email: Arc::from(user.email()),
+            role: user.role().as_str().to_string(),
         };
 
         // Log JWT claims for debugging
@@ -182,12 +197,7 @@ impl TokenServicePort for JwtTokenService {
             claims.iat
         );
 
-        encode(
-            &Header::default(),
-            &claims,
-            &EncodingKey::from_secret(self.jwt_secret.as_bytes()),
-        )
-        .map_err(|e| {
+        encode(&Header::default(), &claims, &self.encoding_key).map_err(|e| {
             tracing::error!("Error generating token: {}", e);
             DomainError::new(
                 ErrorKind::InternalError,
@@ -217,23 +227,18 @@ impl TokenServicePort for JwtTokenService {
         // ── 2. Slow-path: full HMAC-SHA256 verification ─────────
         self.cache_misses.fetch_add(1, Ordering::Relaxed);
 
-        let validation = Validation::new(Algorithm::HS256);
-
-        let token_data = decode::<JwtClaims>(
-            token,
-            &DecodingKey::from_secret(self.jwt_secret.as_bytes()),
-            &validation,
-        )
-        .map_err(|e| match e.kind() {
-            jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
-                DomainError::new(ErrorKind::AccessDenied, "TokenService", "Token expired")
-            }
-            _ => DomainError::new(
-                ErrorKind::AccessDenied,
-                "TokenService",
-                format!("Invalid token: {}", e),
-            ),
-        })?;
+        let token_data = decode::<JwtClaims>(token, &self.decoding_key, &self.validation).map_err(
+            |e| match e.kind() {
+                jsonwebtoken::errors::ErrorKind::ExpiredSignature => {
+                    DomainError::new(ErrorKind::AccessDenied, "TokenService", "Token expired")
+                }
+                _ => DomainError::new(
+                    ErrorKind::AccessDenied,
+                    "TokenService",
+                    format!("Invalid token: {}", e),
+                ),
+            },
+        )?;
 
         let claims = Arc::new(TokenClaims::from(token_data.claims));
 
@@ -301,8 +306,8 @@ mod tests {
             .validate_token(&token)
             .expect("Should validate token");
         assert_eq!(claims.sub, user.id().to_string());
-        assert_eq!(Some(claims.username.as_str()), user.username());
-        assert_eq!(claims.email, user.email());
+        assert_eq!(Some(&*claims.username), user.username());
+        assert_eq!(&*claims.email, user.email());
     }
 
     #[test]

--- a/src/infrastructure/services/pg_acl_engine.rs
+++ b/src/infrastructure/services/pg_acl_engine.rs
@@ -31,12 +31,13 @@
 
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
 use std::time::Duration;
 use uuid::Uuid;
 
 use moka::future::Cache;
 use sqlx::PgPool;
+use tokio::sync::oneshot;
 
 use crate::application::ports::authorization_ports::AuthorizationEngine;
 use crate::common::errors::DomainError;
@@ -218,6 +219,61 @@ pub struct PgAclEngine {
     /// Grant writes don't affect parentage — only the TTL applies (moves are
     /// an indirect path, same self-heal contract as `cascade_grant_cache`).
     file_parent_cache: Cache<Uuid, Option<Uuid>>,
+    /// Natural-batching collector for cold `file_parent_cache` misses — the
+    /// ROUND9 §10 deferred item. A shared N-photo album's cold first view
+    /// arrives as N near-simultaneous thumbnail requests, each missing the
+    /// parent memo and each paying a point `SELECT folder_id`.
+    ///
+    /// Leader-runs-inline shape: an idle miss marks itself leader (one
+    /// mutex op) and runs its point query exactly as before — the
+    /// SEQUENTIAL path gains no hop, no task, no extra latency (a
+    /// channel-task variant benchmarked at ~66 µs/miss of pure overhead and
+    /// was rejected). Misses arriving while a leader is in flight park a
+    /// oneshot in this queue; the leader drains them into ONE `= ANY($1)`
+    /// batch after its own query, so a K-wide herd collapses to ~2 queries.
+    /// If a leader future is dropped mid-flight, its guard wakes every
+    /// parked waiter to retry (and re-elect); waiters that exhaust retries
+    /// fall back to the inline point query — strictly additive.
+    parent_batch: Arc<std::sync::Mutex<Option<Vec<ParentWaiter>>>>,
+    /// Total parent-resolution queries actually issued (point + batches) —
+    /// exposed via [`Self::parent_query_count`] for benches/operators.
+    parent_queries: Arc<AtomicU64>,
+}
+
+/// One parked parent-resolution request: file id + reply slot. A dropped
+/// sender (leader cancelled) is the retry signal. Errors are shared behind
+/// `Arc` because `DomainError` carries a non-clonable source chain (same
+/// convention as the Basic-auth single-flight).
+type ParentWaiter = (
+    Uuid,
+    oneshot::Sender<Result<Option<Uuid>, Arc<DomainError>>>,
+);
+
+/// Upper bound on ids drained into one `= ANY` parent batch. A browser herd
+/// is O(100); this only guards pathological queue growth.
+const PARENT_BATCH_MAX: usize = 256;
+
+/// How many times a parked waiter re-runs the elect-or-park protocol after
+/// a leader vanished before giving up and querying inline itself.
+const PARENT_WAIT_RETRIES: usize = 3;
+
+/// RAII release of parent-resolution leadership. If the leader future is
+/// dropped at an await point (client disconnect cancels the request), this
+/// clears the in-flight marker and drops every parked waiter's sender —
+/// their `oneshot` recv errors and they re-run the election, so a vanished
+/// leader can never strand the queue.
+struct ParentLeaderGuard<'a> {
+    engine: &'a PgAclEngine,
+}
+
+impl Drop for ParentLeaderGuard<'_> {
+    fn drop(&mut self) {
+        let mut slot = match self.engine.parent_batch.lock() {
+            Ok(s) => s,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        *slot = None;
+    }
 }
 
 impl PgAclEngine {
@@ -263,6 +319,8 @@ impl PgAclEngine {
                 .max_capacity(FILE_PARENT_CACHE_CAPACITY)
                 .time_to_live(FILE_PARENT_CACHE_TTL)
                 .build(),
+            parent_batch: Arc::new(std::sync::Mutex::new(None)),
+            parent_queries: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -341,6 +399,8 @@ impl PgAclEngine {
                 .max_capacity(1)
                 .time_to_live(Duration::from_secs(1))
                 .build(),
+            parent_batch: Arc::new(std::sync::Mutex::new(None)),
+            parent_queries: Arc::new(AtomicU64::new(0)),
         }
     }
 
@@ -779,11 +839,16 @@ impl PgAclEngine {
         Ok(exists.is_some())
     }
 
-    /// Memoised `file_id → Option<parent folder_id>` point read backing the
+    /// Memoised `file_id → Option<parent folder_id>` read backing the
     /// file-cascade decomposition. `None` covers both a missing row and a
     /// NULL `folder_id` — in either case only the direct-file-grant branch
     /// can match (mirroring the historical UNION's `folder_id IS NOT NULL`
     /// guard).
+    ///
+    /// Cold misses run the leader-inline batching protocol (see
+    /// `parent_batch`): an idle miss queries inline exactly as before;
+    /// misses concurrent with an in-flight leader park and are answered by
+    /// the leader's single `= ANY` charity batch.
     async fn file_parent_folder_cached(
         &self,
         file_id: Uuid,
@@ -793,15 +858,221 @@ impl PgAclEngine {
             return Ok(parent);
         }
         counters.sql_queries.fetch_add(1, Ordering::Relaxed);
+
+        enum Elect {
+            Lead,
+            Park(oneshot::Receiver<Result<Option<Uuid>, Arc<DomainError>>>),
+            Overflow,
+        }
+        for _ in 0..=PARENT_WAIT_RETRIES {
+            // Elect-or-park. The guard lives only inside this block — the
+            // decision is acted on AFTER it drops, so no lock is ever held
+            // across an await (and the handler futures stay `Send`).
+            let outcome = {
+                let mut slot = self.parent_batch.lock().expect("parent_batch poisoned");
+                match slot.as_mut() {
+                    // A leader is in flight — park a oneshot in its queue.
+                    Some(queue) if queue.len() < PARENT_BATCH_MAX => {
+                        let (tx, rx) = oneshot::channel();
+                        queue.push((file_id, tx));
+                        Elect::Park(rx)
+                    }
+                    // Queue full — behave as if idle contention: inline below.
+                    Some(_) => Elect::Overflow,
+                    // Idle — become the leader.
+                    None => {
+                        *slot = Some(Vec::new());
+                        Elect::Lead
+                    }
+                }
+            };
+
+            match outcome {
+                Elect::Lead => return self.parent_leader_resolve(file_id).await,
+                Elect::Park(rx) => match rx.await {
+                    Ok(Ok(parent)) => return Ok(parent),
+                    Ok(Err(shared)) => {
+                        return Err(DomainError::new(
+                            shared.kind,
+                            shared.entity_type,
+                            shared.message.clone(),
+                        ));
+                    }
+                    // Leader vanished (cancelled mid-flight) — retry the
+                    // election; a fresh leader (possibly us) takes over.
+                    Err(_) => continue,
+                },
+                // Queue overflow: don't wait — resolve inline.
+                Elect::Overflow => break,
+            }
+        }
+
+        // Retries exhausted or queue overflow: the historical inline read.
+        self.parent_queries.fetch_add(1, Ordering::Relaxed);
+        let parent = Self::query_parent_point(&self.pool, file_id).await?;
+        self.file_parent_cache.insert(file_id, parent).await;
+        Ok(parent)
+    }
+
+    /// Leader half of the parent-resolution protocol: run own point query
+    /// inline (the exact pre-round-10 cost), then serve everything that
+    /// parked during it with ONE `= ANY` batch. A second wave arriving
+    /// during the charity batch is handed to a detached drainer task so the
+    /// leader's own response is never delayed by more than one batch.
+    ///
+    /// Cancellation-safe: `ParentLeaderGuard` releases leadership on drop
+    /// and wakes parked waiters (their `oneshot` senders drop → they retry
+    /// and re-elect).
+    async fn parent_leader_resolve(&self, file_id: Uuid) -> Result<Option<Uuid>, DomainError> {
+        let guard = ParentLeaderGuard { engine: self };
+
+        self.parent_queries.fetch_add(1, Ordering::Relaxed);
+        let own = Self::query_parent_point(&self.pool, file_id).await;
+        if let Ok(parent) = &own {
+            self.file_parent_cache.insert(file_id, *parent).await;
+        }
+
+        // Take the first charity wave (leave `Some(vec![])` so later
+        // arrivals keep parking while the batch runs).
+        let wave = {
+            let mut slot = self.parent_batch.lock().expect("parent_batch poisoned");
+            match slot.as_mut() {
+                Some(queue) if !queue.is_empty() => std::mem::take(queue),
+                _ => Vec::new(),
+            }
+        };
+        if !wave.is_empty() {
+            self.parent_queries.fetch_add(1, Ordering::Relaxed);
+            Self::serve_parent_wave(&self.pool, &self.file_parent_cache, wave).await;
+        }
+
+        // Release leadership — or, if a second wave parked during the
+        // charity batch, hand leadership to a detached drainer so the
+        // leader's own response isn't delayed further. The drainer loops:
+        // it keeps the slot marked in-flight (newer misses keep parking)
+        // and only clears it when the queue drains empty.
+        let second_wave = {
+            let mut slot = self.parent_batch.lock().expect("parent_batch poisoned");
+            match slot.as_mut() {
+                Some(queue) if !queue.is_empty() => Some(std::mem::take(queue)),
+                _ => {
+                    *slot = None; // idle again
+                    None
+                }
+            }
+        };
+        std::mem::forget(guard); // leadership released or handed to the drainer
+        if let Some(first) = second_wave {
+            let engine = self.clone_batch_handles();
+            tokio::spawn(async move {
+                let mut wave = first;
+                loop {
+                    engine.2.fetch_add(1, Ordering::Relaxed);
+                    Self::serve_parent_wave(&engine.0, &engine.1, wave).await;
+                    let mut slot = match engine.3.lock() {
+                        Ok(s) => s,
+                        Err(p) => p.into_inner(),
+                    };
+                    match slot.as_mut() {
+                        Some(queue) if !queue.is_empty() => {
+                            wave = std::mem::take(queue);
+                        }
+                        _ => {
+                            *slot = None;
+                            break;
+                        }
+                    }
+                }
+            });
+        }
+        own
+    }
+
+    /// The `Arc`'d handles the detached drainer needs (pool, memo cache,
+    /// query counter, queue slot). Cloned individually because the drainer
+    /// outlives this call and the engine isn't guaranteed to sit behind an
+    /// `Arc` here.
+    #[allow(clippy::type_complexity)]
+    fn clone_batch_handles(
+        &self,
+    ) -> (
+        Arc<PgPool>,
+        Cache<Uuid, Option<Uuid>>,
+        Arc<AtomicU64>,
+        Arc<std::sync::Mutex<Option<Vec<ParentWaiter>>>>,
+    ) {
+        (
+            Arc::clone(&self.pool),
+            self.file_parent_cache.clone(),
+            Arc::clone(&self.parent_queries),
+            Arc::clone(&self.parent_batch),
+        )
+    }
+
+    /// Resolve one file's parent with the point query (shared by the
+    /// leader's own read and the no-batching fallback).
+    async fn query_parent_point(pool: &PgPool, file_id: Uuid) -> Result<Option<Uuid>, DomainError> {
         let parent: Option<Option<Uuid>> =
             sqlx::query_scalar("SELECT folder_id FROM storage.files WHERE id = $1")
                 .bind(file_id)
-                .fetch_optional(self.pool.as_ref())
+                .fetch_optional(pool)
                 .await
                 .map_err(|e| DomainError::internal_error("PgAcl", format!("file parent: {e}")))?;
-        let parent = parent.flatten();
-        self.file_parent_cache.insert(file_id, parent).await;
-        Ok(parent)
+        Ok(parent.flatten())
+    }
+
+    /// Serve a parked wave with one `= ANY` query: memoise every id
+    /// (requested-but-absent rows memoise as `None`, matching the point
+    /// read) and answer every oneshot. On error the shared failure is
+    /// fanned out instead.
+    async fn serve_parent_wave(
+        pool: &PgPool,
+        cache: &Cache<Uuid, Option<Uuid>>,
+        wave: Vec<ParentWaiter>,
+    ) {
+        let mut ids: Vec<Uuid> = Vec::with_capacity(wave.len());
+        for (id, _) in &wave {
+            if !ids.contains(id) {
+                ids.push(*id);
+            }
+        }
+        let fetched: Result<Vec<(Uuid, Option<Uuid>)>, sqlx::Error> =
+            sqlx::query_as("SELECT id, folder_id FROM storage.files WHERE id = ANY($1)")
+                .bind(&ids)
+                .fetch_all(pool)
+                .await;
+        match fetched {
+            Ok(rows) => {
+                let mut by_id: std::collections::HashMap<Uuid, Option<Uuid>> =
+                    rows.into_iter().collect();
+                for id in &ids {
+                    by_id.entry(*id).or_insert(None);
+                }
+                for (id, parent) in &by_id {
+                    cache.insert(*id, *parent).await;
+                }
+                for (id, reply) in wave {
+                    let parent = by_id.get(&id).copied().unwrap_or(None);
+                    let _ = reply.send(Ok(parent));
+                }
+            }
+            Err(e) => {
+                let shared = Arc::new(DomainError::internal_error(
+                    "PgAcl",
+                    format!("file parent batch: {e}"),
+                ));
+                for (_, reply) in wave {
+                    let _ = reply.send(Err(Arc::clone(&shared)));
+                }
+            }
+        }
+    }
+
+    /// Total parent-resolution queries actually issued (point + `= ANY`
+    /// batches). With batching, this is ≤ the number of cold misses — the
+    /// gap is the herd-collapse win. Exposed for benches and operators.
+    pub fn parent_query_count(&self) -> u64 {
+        self.parent_queries.load(Ordering::Relaxed)
     }
 
     /// Cache-aware wrapper over the File/Folder grant cascade. Serves the
@@ -843,56 +1114,71 @@ impl PgAclEngine {
             counters.cache_hit.fetch_add(1, Ordering::Relaxed);
             return Ok(allowed);
         }
-        let allowed = match resource {
-            Resource::Folder(id) => {
-                let (subject_types, subject_ids) =
-                    self.subject_match_set(subject, counters).await?;
-                self.folder_cascade_grant_exists(
-                    &subject_types,
-                    &subject_ids,
-                    permission,
-                    id,
-                    counters,
-                )
-                .await?
-            }
-            Resource::File(id) => {
-                // Ancestor half first — amortized to one query per FOLDER
-                // via the recursive Folder arm (its own cache entry).
-                let folder_allowed = match self.file_parent_folder_cached(id, counters).await? {
-                    Some(parent) => {
-                        Box::pin(self.cascade_grant_cached(
-                            subject,
-                            Resource::Folder(parent),
-                            permission,
-                            counters,
-                        ))
-                        .await?
-                    }
-                    None => false,
-                };
-                if folder_allowed {
-                    true
-                } else {
-                    let (subject_types, subject_ids) =
-                        self.subject_match_set(subject, counters).await?;
-                    self.file_direct_grant_exists(
-                        &subject_types,
-                        &subject_ids,
-                        permission,
-                        id,
-                        counters,
-                    )
-                    .await?
-                }
-            }
-            // Only File/Folder reach this helper (see `check_inner`).
-            _ => return Ok(false),
-        };
+        // Only File/Folder reach this helper (see `check_inner`); keep the
+        // defensive arm OUTSIDE the loader so it stays uncached, as before.
+        if !matches!(resource, Resource::Folder(_) | Resource::File(_)) {
+            return Ok(false);
+        }
+        // `try_get_with`: a cold herd on the same key — every photo of an
+        // album recursing into the SAME folder decision at once — coalesces
+        // into ONE loader run. The old get→compute→insert let K concurrent
+        // misses each run the ltree query (ROUND10; the ROUND3 auth-herd
+        // pattern). moka never caches loader errors, preserving the
+        // historical error semantics.
         self.cascade_grant_cache
-            .insert((subject, resource, permission), allowed)
-            .await;
-        Ok(allowed)
+            .try_get_with((subject, resource, permission), async {
+                match resource {
+                    Resource::Folder(id) => {
+                        let (subject_types, subject_ids) =
+                            self.subject_match_set(subject, counters).await?;
+                        self.folder_cascade_grant_exists(
+                            &subject_types,
+                            &subject_ids,
+                            permission,
+                            id,
+                            counters,
+                        )
+                        .await
+                    }
+                    Resource::File(id) => {
+                        // Ancestor half first — amortized to one query per
+                        // FOLDER via the recursive Folder arm (its own cache
+                        // entry + its own single-flight).
+                        let folder_allowed =
+                            match self.file_parent_folder_cached(id, counters).await? {
+                                Some(parent) => {
+                                    Box::pin(self.cascade_grant_cached(
+                                        subject,
+                                        Resource::Folder(parent),
+                                        permission,
+                                        counters,
+                                    ))
+                                    .await?
+                                }
+                                None => false,
+                            };
+                        if folder_allowed {
+                            Ok(true)
+                        } else {
+                            let (subject_types, subject_ids) =
+                                self.subject_match_set(subject, counters).await?;
+                            self.file_direct_grant_exists(
+                                &subject_types,
+                                &subject_ids,
+                                permission,
+                                id,
+                                counters,
+                            )
+                            .await
+                        }
+                    }
+                    _ => unreachable!("guarded above"),
+                }
+            })
+            .await
+            .map_err(|e: Arc<DomainError>| {
+                DomainError::new(e.kind, e.entity_type, e.message.clone())
+            })
     }
 
     /// Cached resolution of `(subject, drive_id) → Option<Role>` — the

--- a/src/infrastructure/services/search_index/tantivy_content_index.rs
+++ b/src/infrastructure/services/search_index/tantivy_content_index.rs
@@ -238,8 +238,10 @@ impl TantivyContentIndex {
     }
 
     /// Tokenize `raw` with the index analyzer (simple split + lowercase).
-    fn query_tokens(analyzer: &TextAnalyzer, raw: &str) -> Vec<String> {
-        let mut analyzer = analyzer.clone();
+    /// Takes the analyzer by value — the caller's per-search clone is the
+    /// only one needed; cloning the boxed tokenizer chain again here doubled
+    /// the per-query allocation for nothing.
+    fn query_tokens(mut analyzer: TextAnalyzer, raw: &str) -> Vec<String> {
         let mut tokens = Vec::new();
         let mut stream = analyzer.token_stream(raw);
         while stream.advance() && tokens.len() < MAX_QUERY_TOKENS {
@@ -337,7 +339,7 @@ impl TantivyContentIndex {
         raw_query: &str,
         limit: usize,
     ) -> Result<Vec<ContentHitDto>, DomainError> {
-        let tokens = Self::query_tokens(&analyzer, raw_query);
+        let tokens = Self::query_tokens(analyzer, raw_query);
         if tokens.is_empty() {
             return Ok(Vec::new());
         }

--- a/src/interfaces/api/cookie_auth.rs
+++ b/src/interfaces/api/cookie_auth.rs
@@ -44,7 +44,17 @@ pub fn is_cookie_secure() -> bool {
     cookie_secure()
 }
 
+/// Memoised [`resolve_cookie_secure`]. The flag is a pure function of two
+/// process-invariant env vars, yet a single login used to re-resolve it
+/// ~4× (two auth cookies + the CSRF cookie + the handler's own probe) —
+/// each call paying the env-lock syscalls and re-emitting the same
+/// "⚠️ SECURITY" log line. Resolve once, log once.
 fn cookie_secure() -> bool {
+    static COOKIE_SECURE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *COOKIE_SECURE.get_or_init(resolve_cookie_secure)
+}
+
+fn resolve_cookie_secure() -> bool {
     if let Ok(v) = std::env::var("OXICLOUD_COOKIE_SECURE") {
         let secure = v == "true" || v == "1";
         if !secure {

--- a/src/interfaces/api/handlers/share_handler.rs
+++ b/src/interfaces/api/handlers/share_handler.rs
@@ -489,7 +489,14 @@ async fn serve_share_file(
         }
     }
 
-    match retrieval.get_file_optimized(file_id, false, true).await {
+    // The metadata was already fetched at the top of this fn — hand the DTO
+    // to the `_preloaded` variant (as the authenticated download path does)
+    // instead of letting `get_file_optimized` re-run the same metadata query.
+    let file_size = file_dto.size;
+    match retrieval
+        .get_file_optimized_preloaded(file_id, file_dto, false, true)
+        .await
+    {
         Ok((_, content)) => match content {
             OptimizedFileContent::Bytes { data, .. } => Response::builder()
                 .status(StatusCode::OK)
@@ -510,7 +517,7 @@ async fn serve_share_file(
                 .status(StatusCode::OK)
                 .header(header::CONTENT_TYPE, &*mime)
                 .header(header::CONTENT_DISPOSITION, &disposition)
-                .header(header::CONTENT_LENGTH, file_dto.size)
+                .header(header::CONTENT_LENGTH, file_size)
                 .header(header::ACCEPT_RANGES, "bytes")
                 .header(header::ETAG, &etag)
                 .header(

--- a/src/interfaces/api/handlers/webdav_handler.rs
+++ b/src/interfaces/api/handlers/webdav_handler.rs
@@ -259,6 +259,13 @@ struct DriveScope {
     db_path: String,
 }
 
+/// Borrow-only `s.strip_prefix(&format!("{prefix}/"))` — the prefix tests
+/// below run on EVERY native WebDAV verb, so they must not allocate a
+/// throwaway `{prefix}/` String per request.
+fn strip_prefix_slash<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    s.strip_prefix(prefix)?.strip_prefix('/')
+}
+
 async fn resolve_webdav_scope(
     state: &Arc<AppState>,
     user_id: Uuid,
@@ -292,8 +299,7 @@ async fn resolve_webdav_scope(
     if normalized == listing_marker {
         return Ok(WebdavTarget::ListDrives);
     }
-    let with_slash = format!("{}/", listing_marker);
-    if let Some(after_prefix) = normalized.strip_prefix(&with_slash) {
+    if let Some(after_prefix) = strip_prefix_slash(normalized, listing_marker) {
         if after_prefix.is_empty() {
             return Ok(WebdavTarget::ListDrives);
         }
@@ -316,7 +322,7 @@ async fn resolve_webdav_scope(
     let root_name = default.root_folder_name.as_str();
     let db_path = if normalized.is_empty() {
         root_name.to_string()
-    } else if normalized == root_name || normalized.starts_with(&format!("{}/", root_name)) {
+    } else if normalized == root_name || strip_prefix_slash(normalized, root_name).is_some() {
         // Pre-refactor bookmark already carried the drive-root prefix.
         normalized.to_string()
     } else {

--- a/src/interfaces/middleware/admin.rs
+++ b/src/interfaces/middleware/admin.rs
@@ -8,6 +8,7 @@
 //! for audit / ownership purposes.
 
 use axum::http::{HeaderMap, StatusCode, header};
+use smol_str::SmolStr;
 use uuid::Uuid;
 
 use crate::application::ports::auth_ports::TokenServicePort;
@@ -26,7 +27,7 @@ use crate::interfaces::middleware::user::{LiveRole, resolve_live_role};
 pub async fn require_admin(
     state: &AppState,
     headers: &HeaderMap,
-) -> Result<(Uuid, String), AppError> {
+) -> Result<(Uuid, SmolStr), AppError> {
     let auth = state
         .auth_service
         .as_ref()
@@ -85,7 +86,7 @@ pub async fn require_admin(
 pub async fn require_authenticated(
     state: &AppState,
     headers: &HeaderMap,
-) -> Result<(Uuid, String), AppError> {
+) -> Result<(Uuid, SmolStr), AppError> {
     let auth = state
         .auth_service
         .as_ref()

--- a/src/interfaces/middleware/auth.rs
+++ b/src/interfaces/middleware/auth.rs
@@ -204,10 +204,14 @@ pub async fn auth_middleware(
                                 LiveRole::Active(role) => role,
                                 LiveRole::Revoked => return Err(AuthError::AccountInactive),
                             };
+                            // `username`/`email` are `Arc<str>` refcount
+                            // bumps out of the cached claims; `role` is an
+                            // inline SmolStr — the whole build is 1 alloc
+                            // (the `Arc::new`) instead of 4.
                             let current_user = Arc::new(CurrentUser {
                                 id: user_id,
-                                username: claims.username.clone(),
-                                email: claims.email.clone(),
+                                username: Arc::clone(&claims.username),
+                                email: Arc::clone(&claims.email),
                                 role,
                             });
                             request.extensions_mut().insert(current_user);
@@ -319,8 +323,8 @@ pub async fn auth_middleware(
                             LiveRole::Active(role) => {
                                 let current_user = Arc::new(CurrentUser {
                                     id: user_id,
-                                    username: claims.username.clone(),
-                                    email: claims.email.clone(),
+                                    username: Arc::clone(&claims.username),
+                                    email: Arc::clone(&claims.email),
                                     role,
                                 });
                                 request.extensions_mut().insert(current_user);

--- a/src/interfaces/middleware/trace_span.rs
+++ b/src/interfaces/middleware/trace_span.rs
@@ -69,8 +69,11 @@ pub struct UuidRequestId;
 
 impl MakeRequestId for UuidRequestId {
     fn make_request_id<B>(&mut self, _request: &axum::http::Request<B>) -> Option<RequestId> {
-        let id = Uuid::now_v7().to_string();
-        axum::http::HeaderValue::from_str(&id)
+        // Stack-encode the UUID: `to_string()` allocated an intermediate
+        // String per request just for HeaderValue to copy it again.
+        let mut buf = [0u8; uuid::fmt::Hyphenated::LENGTH];
+        let id = Uuid::now_v7();
+        axum::http::HeaderValue::from_str(id.hyphenated().encode_lower(&mut buf))
             .ok()
             .map(RequestId::new)
     }

--- a/src/interfaces/middleware/user.rs
+++ b/src/interfaces/middleware/user.rs
@@ -27,6 +27,7 @@ use axum::extract::{Request, State};
 use axum::http::StatusCode;
 use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
+use smol_str::SmolStr;
 use std::sync::Arc;
 use uuid::Uuid;
 
@@ -109,8 +110,9 @@ pub async fn require_admin_user(
 pub enum LiveRole {
     /// The account exists and is active. Carries the caller's *current*
     /// role string (`"admin"` / `"user"`), which is authoritative and
-    /// supersedes the — possibly stale — JWT `role` claim.
-    Active(String),
+    /// supersedes the — possibly stale — JWT `role` claim. `SmolStr` so the
+    /// per-request render of the (≤23-byte) role never heap-allocates.
+    Active(SmolStr),
     /// The account is deactivated or deleted: the request must be rejected
     /// even though its token is still cryptographically valid.
     Revoked,
@@ -152,7 +154,7 @@ fn decide_live_role(
     claim_role: &str,
 ) -> LiveRole {
     match flags {
-        Ok(flags) if flags.active => LiveRole::Active(flags.role.to_string()),
+        Ok(flags) if flags.active => LiveRole::Active(SmolStr::new_static(flags.role.as_str())),
         Ok(_) => {
             audit_token_revoked(user_id, "deactivated");
             LiveRole::Revoked
@@ -170,7 +172,7 @@ fn decide_live_role(
                 error = %e,
                 "live-user re-check failed transiently; allowing request on the JWT claim role (fail-open)"
             );
-            LiveRole::Active(claim_role.to_string())
+            LiveRole::Active(SmolStr::new(claim_role))
         }
     }
 }
@@ -257,14 +259,14 @@ mod tests {
         let live = decide_live_role(Ok(flags(UserRole::Admin, true)), Uuid::nil(), "user");
         // The live record wins over the (stale) claim — a freshly promoted
         // user is admin even though their token still says "user".
-        assert_eq!(live, LiveRole::Active("admin".to_string()));
+        assert_eq!(live, LiveRole::Active(SmolStr::new_static("admin")));
     }
 
     #[test]
     fn active_user_yields_current_user_role() {
         // A demoted admin: token claim still "admin", live record "user".
         let live = decide_live_role(Ok(flags(UserRole::User, true)), Uuid::nil(), "admin");
-        assert_eq!(live, LiveRole::Active("user".to_string()));
+        assert_eq!(live, LiveRole::Active(SmolStr::new_static("user")));
     }
 
     #[test]
@@ -285,6 +287,6 @@ mod tests {
         // A DB blip must not lock everyone out: allow on the claim role.
         let err = DomainError::new(ErrorKind::InternalError, "User", "connection reset");
         let live = decide_live_role(Err(err), Uuid::nil(), "admin");
-        assert_eq!(live, LiveRole::Active("admin".to_string()));
+        assert_eq!(live, LiveRole::Active(SmolStr::new_static("admin")));
     }
 }

--- a/src/interfaces/nextcloud/avatar_handler.rs
+++ b/src/interfaces/nextcloud/avatar_handler.rs
@@ -1,12 +1,31 @@
 use axum::{
     extract::{Path, State},
-    http::{StatusCode, header},
+    http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use base64::Engine;
+use bytes::Bytes;
 use std::sync::Arc;
 
 use crate::common::di::AppState;
+
+/// Transcoded-avatar memo: `blake3(stored data URI)` → PNG bytes.
+///
+/// The WebP→PNG transcode below is a full image decode + PNG encode (tens
+/// of ms of CPU) that used to run on EVERY avatar request once the
+/// client's 1 h cache lapsed — per client, per surface. Avatars are tiny
+/// and rarely change; 32 entries bounds the memo to a few MB.
+static AVATAR_PNG_CACHE: std::sync::OnceLock<moka::sync::Cache<[u8; 32], Bytes>> =
+    std::sync::OnceLock::new();
+
+fn avatar_png_cache() -> &'static moka::sync::Cache<[u8; 32], Bytes> {
+    AVATAR_PNG_CACHE.get_or_init(|| {
+        moka::sync::Cache::builder()
+            .max_capacity(32)
+            .time_to_live(std::time::Duration::from_secs(24 * 3600))
+            .build()
+    })
+}
 
 /// Re-encode WebP image bytes as PNG. Returns `None` on decode/encode
 /// failure (treated upstream as "fall through to SVG" — a bad stored
@@ -77,10 +96,11 @@ fn parse_data_uri(uri: &str) -> Option<(String, Vec<u8>)> {
 pub async fn handle_dav_avatar(
     state: State<Arc<AppState>>,
     Path((username, size_with_ext)): Path<(String, String)>,
+    headers: HeaderMap,
 ) -> Response {
     let size_str = size_with_ext.strip_suffix(".png").unwrap_or(&size_with_ext);
     let size: u32 = size_str.parse().unwrap_or(64);
-    handle_avatar(state, Path((username, size))).await
+    handle_avatar(state, Path((username, size)), headers).await
 }
 
 /// GET /index.php/avatar/{user}/{size}
@@ -98,6 +118,7 @@ pub async fn handle_dav_avatar(
 pub async fn handle_avatar(
     State(state): State<Arc<AppState>>,
     Path((username, size)): Path<(String, u32)>,
+    headers: HeaderMap,
 ) -> Response {
     let size = size.clamp(16, 1024);
 
@@ -113,39 +134,66 @@ pub async fn handle_avatar(
             .get_user_by_username(&username)
             .await
         && let Some(image_uri) = user.image.as_deref()
-        && let Some((mime, bytes)) = parse_data_uri(image_uri)
     {
-        // WebP is OxiCloud's storage format of choice (smaller files,
-        // better quality at a given size) but NextCloud clients have
-        // patchy WebP support — older Qt-based desktop builds, some
-        // mobile image stacks. Transcode to PNG before serving on the
-        // NC surface so every client renders it. PNG is bigger on the
-        // wire but small enough at avatar dimensions that the
-        // tradeoff is worth it. Decode failure falls through to SVG.
-        let (final_mime, final_bytes): (&str, Vec<u8>) = if mime == "image/webp" {
-            match webp_to_png(&bytes) {
-                Some(png) => ("image/png", png),
-                None => return svg_initials_response(&username, size),
-            }
-        } else {
-            // Whatever MIME we stored (`image/png`, `image/jpeg`,
-            // `image/gif`) is universally supported by NC clients.
-            // The `mime` String is moved out via `.as_str()` here, so
-            // bind it locally to keep the borrow alive for the response.
-            (mime_as_static_str(&mime), bytes)
-        };
-        return (
-            StatusCode::OK,
-            [
-                (header::CONTENT_TYPE, final_mime),
+        // Content-derived ETag over the STORED value — computable before
+        // any base64 decode or image work. NC desktop/mobile revalidate
+        // avatars every cache lapse (1 h) per surface; this endpoint used
+        // to re-decode (and for WebP re-transcode to PNG — a full image
+        // decode + encode) and re-ship the body every time (ROUND10).
+        let content_hash: [u8; 32] = blake3::hash(image_uri.as_bytes()).into();
+        let etag = format!(
+            "\"av-{}\"",
+            crate::common::fmt::hex_lower(&content_hash[..12])
+        );
+        if let Some(inm) = headers.get(header::IF_NONE_MATCH)
+            && let Ok(client_etag) = inm.to_str()
+            && (client_etag == etag || client_etag == "*")
+        {
+            return Response::builder()
+                .status(StatusCode::NOT_MODIFIED)
+                .header(header::CACHE_CONTROL, "public, max-age=3600")
+                .header(header::ETAG, etag)
+                .body(axum::body::Body::empty())
+                .unwrap();
+        }
+
+        if let Some((mime, bytes)) = parse_data_uri(image_uri) {
+            // WebP is OxiCloud's storage format of choice (smaller files,
+            // better quality at a given size) but NextCloud clients have
+            // patchy WebP support — older Qt-based desktop builds, some
+            // mobile image stacks. Transcode to PNG before serving on the
+            // NC surface so every client renders it. The transcode result
+            // is memoised by content hash — decode+encode ran per request
+            // before. Decode failure falls through to SVG.
+            let (final_mime, final_bytes): (&str, Bytes) = if mime == "image/webp" {
+                if let Some(png) = avatar_png_cache().get(&content_hash) {
+                    ("image/png", png)
+                } else {
+                    match webp_to_png(&bytes) {
+                        Some(png) => {
+                            let png = Bytes::from(png);
+                            avatar_png_cache().insert(content_hash, png.clone());
+                            ("image/png", png)
+                        }
+                        None => return svg_initials_response(&username, size),
+                    }
+                }
+            } else {
+                // Whatever MIME we stored (`image/png`, `image/jpeg`,
+                // `image/gif`) is universally supported by NC clients.
+                (mime_as_static_str(&mime), Bytes::from(bytes))
+            };
+            return Response::builder()
+                .status(StatusCode::OK)
+                .header(header::CONTENT_TYPE, final_mime)
                 // Shorter cache than the SVG fallback because users can
                 // re-upload their picture at any time — the URL is the
                 // same so a long immutable cache would pin the old one.
-                (header::CACHE_CONTROL, "public, max-age=3600"),
-            ],
-            final_bytes,
-        )
-            .into_response();
+                .header(header::CACHE_CONTROL, "public, max-age=3600")
+                .header(header::ETAG, etag)
+                .body(axum::body::Body::from(final_bytes))
+                .unwrap();
+        }
     }
 
     svg_initials_response(&username, size)

--- a/src/interfaces/nextcloud/login_v2_handler.rs
+++ b/src/interfaces/nextcloud/login_v2_handler.rs
@@ -339,9 +339,9 @@ pub async fn handle_oidc_login_completion(
 
     let current_user = CurrentUser {
         id: user_id,
-        username: username.to_string(),
-        email: user_dto.email.clone(),
-        role: user_dto.role.clone(),
+        username: std::sync::Arc::from(username),
+        email: std::sync::Arc::from(user_dto.email.as_str()),
+        role: smol_str::SmolStr::new(&user_dto.role),
     };
 
     let drives = match state
@@ -438,7 +438,7 @@ async fn complete_flow(
 
     let login_name = match drive_id {
         Some(uuid) => format!("{}~{}", user.username, uuid),
-        None => user.username.clone(),
+        None => user.username.to_string(),
     };
 
     let base_url = state.core.config.base_url();
@@ -550,9 +550,9 @@ pub async fn handle_drive_pick(
     };
     let user = CurrentUser {
         id: user_id,
-        username,
-        email: user_dto.email.clone(),
-        role: user_dto.role.clone(),
+        username: std::sync::Arc::from(username.as_str()),
+        email: std::sync::Arc::from(user_dto.email.as_str()),
+        role: smol_str::SmolStr::new(&user_dto.role),
     };
 
     let _folder = match state

--- a/src/interfaces/nextcloud/ocs_handler.rs
+++ b/src/interfaces/nextcloud/ocs_handler.rs
@@ -109,11 +109,11 @@ pub async fn handle_user_info(
     // than the raw UUID the wire form carries.
     let id = session.raw_username.clone();
     let displayname = if session.is_home() {
-        session.user.username.clone()
+        session.user.username.to_string()
     } else {
         match session.chroot.as_ref() {
             Some(chroot) => format!("{}@{}", session.user.username, chroot.name),
-            None => session.user.username.clone(),
+            None => session.user.username.to_string(),
         }
     };
 
@@ -356,7 +356,7 @@ pub async fn handle_sharees_search(
         .into_iter()
         .filter_map(|u| {
             let handle = u.username.clone()?;
-            if handle == user.username {
+            if handle.as_str() == &*user.username {
                 return None;
             }
             Some(json!({

--- a/src/interfaces/nextcloud/preview_handler.rs
+++ b/src/interfaces/nextcloud/preview_handler.rs
@@ -5,7 +5,7 @@
 use axum::{
     body::Body,
     extract::{Query, State},
-    http::{StatusCode, header},
+    http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use serde::Deserialize;
@@ -39,6 +39,7 @@ pub async fn handle_preview(
     State(state): State<Arc<AppState>>,
     user: AuthUser,
     Query(params): Query<PreviewParams>,
+    headers: HeaderMap,
 ) -> impl IntoResponse {
     // Parse the Nextcloud file ID — the NC app may append an instance suffix
     // (e.g. "00000326ocnca"), so strip non-digit characters first.
@@ -135,6 +136,27 @@ pub async fn handle_preview(
         }
     };
 
+    // Conditional revalidation — the ETag is derived from (object id, size)
+    // only, so it is computable right here, BEFORE the blob-hash query and
+    // the thumbnail cache/disk read. NC clients revalidate gallery previews
+    // constantly; the REST thumbnail endpoint has honoured `If-None-Match`
+    // since PHOTOS-ETAG — this endpoint set an immutable ETag but never
+    // compared it, so every revalidation re-ran the whole pipeline and
+    // re-shipped the body (ROUND10). Authz already passed above; a 304
+    // must never skip the Read check.
+    let etag = format!("\"thumb-{}-{:?}\"", object_id, thumb_size);
+    if let Some(inm) = headers.get(header::IF_NONE_MATCH)
+        && let Ok(client_etag) = inm.to_str()
+        && (client_etag == etag || client_etag == "*")
+    {
+        return Response::builder()
+            .status(StatusCode::NOT_MODIFIED)
+            .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
+            .header(header::ETAG, etag)
+            .body(Body::empty())
+            .unwrap();
+    }
+
     // Check if file is an image
     if !state
         .core
@@ -175,7 +197,6 @@ pub async fn handle_preview(
         )
         .await
     {
-        let etag = format!("\"thumb-{}-{:?}\"", object_id, thumb_size);
         return Response::builder()
             .status(StatusCode::OK)
             .header(header::CONTENT_TYPE, "image/jpeg")
@@ -201,17 +222,14 @@ pub async fn handle_preview(
         )
         .await
     {
-        Ok(data) => {
-            let etag = format!("\"thumb-{}-{:?}\"", object_id, thumb_size);
-            Response::builder()
-                .status(StatusCode::OK)
-                .header(header::CONTENT_TYPE, "image/jpeg")
-                .header(header::CONTENT_LENGTH, data.len())
-                .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
-                .header(header::ETAG, etag)
-                .body(Body::from(data))
-                .unwrap()
-        }
+        Ok(data) => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "image/jpeg")
+            .header(header::CONTENT_LENGTH, data.len())
+            .header(header::CACHE_CONTROL, "public, max-age=31536000, immutable")
+            .header(header::ETAG, etag)
+            .body(Body::from(data))
+            .unwrap(),
         Err(err) => {
             tracing::error!("Thumbnail generation failed for {}: {}", object_id, err);
             Response::builder()

--- a/src/interfaces/nextcloud/trashbin_handler.rs
+++ b/src/interfaces/nextcloud/trashbin_handler.rs
@@ -16,7 +16,7 @@ use crate::common::di::AppState;
 use crate::interfaces::errors::AppError;
 use crate::interfaces::nextcloud::webdav_handler::{
     batch_resolve_ids, extract_nc_subpath_from_dest, format_oc_id, nc_id_of, nc_to_internal_path,
-    write_text_element,
+    write_date_element, write_etag_element, write_text_element,
 };
 
 const HEADER_DAV: HeaderName = HeaderName::from_static("dav");
@@ -445,11 +445,12 @@ fn write_trash_item_response<W: std::io::Write>(
     // d:displayname
     write_text_element(xml, "d:displayname", &item.name)?;
 
-    // d:getlastmodified
-    write_text_element(xml, "d:getlastmodified", &item.trashed_at.to_rfc2822())?;
+    // d:getlastmodified — stack-rendered (common::fmt), chrono fallback for
+    // out-of-range timestamps; byte-identical to the old `to_rfc2822()`.
+    write_date_element(xml, "d:getlastmodified", item.trashed_at.timestamp(), true)?;
 
-    // d:getetag
-    write_text_element(xml, "d:getetag", &format!("\"{}\"", item.original_id))?;
+    // d:getetag — exact-size quoted alloc instead of the format! interpreter.
+    write_etag_element(xml, "d:getetag", &item.original_id)?;
 
     // d:resourcetype
     if item.item_type == "folder" {
@@ -478,7 +479,8 @@ fn write_trash_item_response<W: std::io::Write>(
     // oc:fileid and oc:id — resolved up front in a batch query.
     let file_id = nc_id_of(id_map, &item.original_id);
     if let Some(id) = file_id {
-        write_text_element(xml, "oc:fileid", &id.to_string())?;
+        let mut ibuf = [0u8; 21];
+        write_text_element(xml, "oc:fileid", crate::common::fmt::i64_str(&mut ibuf, id))?;
         let oc_id = format_oc_id(id, file_id_svc);
         write_text_element(xml, "oc:id", &oc_id)?;
     }
@@ -491,11 +493,14 @@ fn write_trash_item_response<W: std::io::Write>(
     write_text_element(xml, "nc:trashbin-original-location", original_location)?;
 
     // nc:trashbin-deletion-time
-    write_text_element(
-        xml,
-        "nc:trashbin-deletion-time",
-        &item.trashed_at.timestamp().to_string(),
-    )?;
+    {
+        let mut ibuf = [0u8; 21];
+        write_text_element(
+            xml,
+            "nc:trashbin-deletion-time",
+            crate::common::fmt::i64_str(&mut ibuf, item.trashed_at.timestamp()),
+        )?;
+    }
 
     // oc:permissions — empty in trash
     write_text_element(xml, "oc:permissions", "")?;

--- a/src/interfaces/nextcloud/uploads_handler.rs
+++ b/src/interfaces/nextcloud/uploads_handler.rs
@@ -325,15 +325,16 @@ async fn handle_put_chunk(
         .map_err(|e| AppError::bad_request(format!("Invalid chunk path: {}", e)))?;
 
     let max_chunk = state.core.config.storage.chunk_max_bytes;
-    // A re-PUT of an existing chunk (client retry) makes the running
-    // session counter stale — drop it so the next gate rebuilds from disk.
-    let overwrite = tokio::fs::metadata(&chunk_path).await.is_ok();
     // No client-side integrity contract on the NC chunked surface — the
     // NC desktop client validates the assembled-file ETag against the
     // server-side `oc:checksums` after MOVE. So we skip per-chunk
     // hashing here (peak heap stays at ~one HTTP frame).
+    //
+    // Retry detection (a re-PUT makes the running session counter stale)
+    // rides on the open itself now — `created_fresh` from the `create_new`
+    // probe replaces the extra per-chunk `stat` this path used to issue.
     let streamed = stream_body_to_path(req.into_body(), &chunk_path, max_chunk, None).await?;
-    if overwrite {
+    if !streamed.created_fresh {
         nc.chunked_uploads
             .forget_session_bytes(&user.username, upload_id);
     } else {

--- a/src/interfaces/nextcloud/webdav_handler.rs
+++ b/src/interfaces/nextcloud/webdav_handler.rs
@@ -1510,16 +1510,24 @@ fn build_nc_streaming_propfind(
         // ── <d:multistatus> + the folder's own entry ─────────────────
         // Collection hrefs MUST end in `/` (RFC 4918 §5.2 + strict
         // NC-client enforcement — see `nc_collection_href`).
-        let folder_favs = if let Some(fav) = fav_svc {
-            fav.batch_check_favorites(user_id, &[(folder.id.as_str(), "folder")])
-                .await
-                .unwrap_or_default()
-        } else {
-            HashSet::new()
-        };
-        let (_, folder_id_map) =
-            batch_resolve_ids(file_id_svc, &[], &[folder.id.as_str()]).await;
-        let folder_dead = folder_dead_props(&state.webdav_dead_props, &folder).await;
+        // Same three independent reads as the per-page child triple below,
+        // and on the critical path of EVERY folder PROPFIND's first byte —
+        // overlapped with `join!` (ROUND10; the header trio was left serial
+        // when ROUND9 converted the page loops).
+        let folder_id_arr = [folder.id.as_str()];
+        let (folder_favs, (_, folder_id_map), folder_dead) = tokio::join!(
+            async {
+                if let Some(fav) = fav_svc {
+                    fav.batch_check_favorites(user_id, &[(folder.id.as_str(), "folder")])
+                        .await
+                        .unwrap_or_default()
+                } else {
+                    HashSet::new()
+                }
+            },
+            batch_resolve_ids(file_id_svc, &[], &folder_id_arr),
+            folder_dead_props(&state.webdav_dead_props, &folder),
+        );
 
         let mut buf = Vec::with_capacity(4096);
         {
@@ -1756,7 +1764,8 @@ pub fn write_folder_response<W: std::io::Write>(
 
     // Nextcloud/ownCloud properties
     if let Some(id) = file_id {
-        write_text_element(xml, "oc:fileid", &id.to_string())?;
+        let mut buf = [0u8; 21];
+        write_text_element(xml, "oc:fileid", crate::common::fmt::i64_str(&mut buf, id))?;
     }
     if let Some(oid) = oc_id {
         write_text_element(xml, "oc:id", oid)?;
@@ -1770,9 +1779,18 @@ pub fn write_folder_response<W: std::io::Write>(
     // surface's `write_folder_standard_props` (see
     // `AppState::resolve_webdav_quota`).
     if let Some((used, available)) = quota {
-        write_text_element(xml, "d:quota-used-bytes", &used.to_string())?;
+        let mut buf = [0u8; 21];
+        write_text_element(
+            xml,
+            "d:quota-used-bytes",
+            crate::common::fmt::i64_str(&mut buf, used),
+        )?;
         if let Some(avail) = available {
-            write_text_element(xml, "d:quota-available-bytes", &avail.to_string())?;
+            write_text_element(
+                xml,
+                "d:quota-available-bytes",
+                crate::common::fmt::i64_str(&mut buf, avail),
+            )?;
         }
     }
     write_text_element(xml, "oc:owner-id", owner)?;
@@ -1858,7 +1876,8 @@ pub fn write_file_response<W: std::io::Write>(
 
     // Nextcloud/ownCloud properties
     if let Some(id) = file_id {
-        write_text_element(xml, "oc:fileid", &id.to_string())?;
+        let mut buf = [0u8; 21];
+        write_text_element(xml, "oc:fileid", crate::common::fmt::i64_str(&mut buf, id))?;
     }
     if let Some(oid) = oc_id {
         write_text_element(xml, "oc:id", oid)?;
@@ -1900,8 +1919,19 @@ pub fn write_file_response<W: std::io::Write>(
 
     write_text_element(xml, "nc:is-encrypted", "0")?;
     write_text_element(xml, "nc:mount-type", "")?;
-    write_text_element(xml, "nc:creation_time", &file.created_at.to_string())?;
-    write_text_element(xml, "nc:upload_time", &file.modified_at.to_string())?;
+    {
+        let mut buf = [0u8; 20];
+        write_text_element(
+            xml,
+            "nc:creation_time",
+            crate::common::fmt::u64_str(&mut buf, file.created_at),
+        )?;
+        write_text_element(
+            xml,
+            "nc:upload_time",
+            crate::common::fmt::u64_str(&mut buf, file.modified_at),
+        )?;
+    }
 
     xml.write_event(Event::End(BytesEnd::new("d:prop")))
         .xml_err()?;
@@ -1921,7 +1951,7 @@ pub fn write_file_response<W: std::io::Write>(
 /// (`common::fmt`) — the old per-row `to_rfc2822()` / `to_rfc3339()`
 /// ran chrono's format interpreter and allocated a String each.
 /// Out-of-range timestamps keep the chrono path, byte-identical.
-fn write_date_element<W: std::io::Write>(
+pub fn write_date_element<W: std::io::Write>(
     xml: &mut Writer<W>,
     tag: &str,
     secs: i64,
@@ -1946,7 +1976,7 @@ fn write_date_element<W: std::io::Write>(
 
 /// `d:getetag` with the HTTP quoting — one exactly-sized allocation
 /// instead of `format!`'s grow-from-empty.
-fn write_etag_element<W: std::io::Write>(
+pub fn write_etag_element<W: std::io::Write>(
     xml: &mut Writer<W>,
     tag: &str,
     etag: &str,

--- a/src/interfaces/upload_ingest.rs
+++ b/src/interfaces/upload_ingest.rs
@@ -291,6 +291,10 @@ pub fn stream_from_files(
 pub struct StreamedToPath {
     /// Total bytes written.
     pub bytes_written: u64,
+    /// `true` when the destination did not exist before this call — the
+    /// open itself detects it (`create_new` + AlreadyExists fallback), so
+    /// retry-detection callers don't need a separate `stat` per chunk.
+    pub created_fresh: bool,
     /// Lowercase hex digest, populated only when `checksum_alg=Some(_)`
     /// was passed. The algorithm is identified by [`StreamedToPath::alg`].
     pub checksum_hex: Option<String>,
@@ -329,9 +333,32 @@ pub async fn stream_body_to_path(
     // per frame (benches/UPLOAD-SPOOL.md). Same capacity as the dedup
     // handler's spool loop. On the error paths below the partial file is
     // removed, so silently dropping unflushed buffer contents is fine.
-    let file = tokio::fs::File::create(path)
+    //
+    // `create_new` first: the common fresh-chunk case stays one open AND
+    // doubles as the retry probe (AlreadyExists → truncate-open), so callers
+    // that need overwrite detection no longer pay a separate stat per chunk.
+    let (file, created_fresh) = match tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
         .await
-        .map_err(|e| AppError::internal_error(format!("Failed to open chunk file: {e}")))?;
+    {
+        Ok(f) => (f, true),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            let f = tokio::fs::OpenOptions::new()
+                .write(true)
+                .truncate(true)
+                .open(path)
+                .await
+                .map_err(|e| AppError::internal_error(format!("Failed to open chunk file: {e}")))?;
+            (f, false)
+        }
+        Err(e) => {
+            return Err(AppError::internal_error(format!(
+                "Failed to open chunk file: {e}"
+            )));
+        }
+    };
     let mut file = tokio::io::BufWriter::with_capacity(512 * 1024, file);
 
     let mut total_bytes: usize = 0;
@@ -377,6 +404,7 @@ pub async fn stream_body_to_path(
 
     Ok(StreamedToPath {
         bytes_written: total_bytes as u64,
+        created_fresh,
         checksum_hex: hasher.map(IncrementalHasher::finalize_hex),
         alg: checksum_alg,
     })


### PR DESCRIPTION
Benchmark-gated (benches/ROUND10.md; every change carries a BEFORE/AFTER
harness with equivalence/safety gates — two designs were rejected or
rewritten by their own benches before adoption):

- Auth hot path: TokenClaims/CurrentUser display fields to Arc<str>, role
  to inline SmolStr end-to-end (Bearer, cookie, Basic-auth cache) — 4→1
  allocs per authenticated request, 3→0 per warm DAV request; JWT
  Encoding/Decoding/Validation built once.
- Cold shared-album herd: leader-inline parent batching in PgAclEngine
  (+ cascade try_get_with single-flight) — 100→2 parent queries per
  100-thumb cold herd, herd wall 1.9x, sequential + warm paths unchanged,
  all ROUND8/9 safety gates plus new herd-equivalence gates.
- Query-shape pack: share download double-fetch 2→1 (2.18x), contact-group
  COUNT(*) 14.9x, save_faces UNNEST 3.9x, playlist reorder UNNEST 63.7x
  (now atomic), search files∥folders join! 1.45x, move drive-lookup join!
  2.14x, trash partial (drive_id, trashed_at) indexes, CalDAV event-gate
  narrow read, favorites/recents binary-decode port, dead count_files
  removed.
- NC surface: preview + avatar honour If-None-Match (e2e: 5 KB and 197 KB
  → 0 bytes per revalidation), avatar WebP→PNG transcode memoised,
  PROPFIND/trashbin integer+date emits on stack formatters, folder-header
  enrichment join!, chunk-PUT retry stat folded into create_new open.
- common::fmt integer rendering rewritten on the std 2-digit LUT after the
  round's own bench caught the div-loop losing to to_string (16.1 ns vs
  22.5; speeds every prior-round call site).
- Micro-pack: WebDAV scope probe borrow-only, ShareService base_url
  snapshot, cookie_secure OnceLock, Arc'd AES-GCM cipher, stack request-id,
  tantivy analyzer clone dropped.
- SPA: search stale-guard + AbortController (10→1 completed round-trips,
  stale-clobber gone), getFolder in-flight dedup, gridColumns matchMedia
  hoist (10k→0 style reads).

Backend: cargo fmt + clippy -D warnings clean, 524 tests green.
Frontend: npm run check clean, 301 vitest green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018DdM7V7M3QPW7HEHg3gLov