### PR TITLE
Round 11: StoragePath, classifier fusion, memoized statics, query shapes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4178,6 +4178,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "unicode-normalization",
  "urlencoding",
@@ -5809,6 +5810,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6375,6 +6382,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,6 @@ tower-http = { version = "0.6.11", features = ["fs", "compression-gzip", "compre
 flate2 = "1.1.9"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-# Round-11: moves log formatting+write off the async workers. `lossy(false)`
-# so audit lines are never dropped (emitters block only when the 128k-line
-# channel is full — backpressure, not loss). See benches/ROUND11.md.
-tracing-appender = "0.2"
 chrono = { version = "0.4.45", features = ["serde"] }
 # RFC 5545 iCalendar parser + emitter.
 #
@@ -146,6 +142,10 @@ bench = []
 
 [dev-dependencies]
 criterion = "0.5"
+# Round-11 L1 harness only (bench_log_writer): the non-blocking writer was
+# REJECTED for production — slower than sync on fast sinks and can lose
+# buffered tail lines at shutdown on slow ones (benches/ROUND11.md).
+tracing-appender = "0.2"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(integration_tests)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ tower-http = { version = "0.6.11", features = ["fs", "compression-gzip", "compre
 flate2 = "1.1.9"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+# Round-11: moves log formatting+write off the async workers. `lossy(false)`
+# so audit lines are never dropped (emitters block only when the 128k-line
+# channel is full — backpressure, not loss). See benches/ROUND11.md.
+tracing-appender = "0.2"
 chrono = { version = "0.4.45", features = ["serde"] }
 # RFC 5545 iCalendar parser + emitter.
 #
@@ -348,6 +352,34 @@ required-features = ["bench"]
 [[example]]
 name = "bench_micro_allocs"
 path = "examples/bench_micro_allocs.rs"
+required-features = ["bench"]
+
+# Round-11 battery ────────────────────────────────────────────────────────────
+
+# Round-11 CPU/alloc micro-pack — download DTO hand-off, Last-Modified stack
+# render, status.php/openapi.json memoization, upload-session PROPFIND emit,
+# rate-limiter single-op, CSRF/ETag/recent-id micro-allocs, 4xx body, vCard
+# emit, search page move, cosine norms, encrypted write in-place, StoragePath
+# joined-only materialization. No Postgres.
+[[example]]
+name = "bench_round11_micro"
+path = "examples/bench_round11_micro.rs"
+required-features = ["bench"]
+
+# Round-11 query-shape pack — deferred-upload 3→1 CTE, Calendar/AddressBook/
+# Playlist direct-grant cache, expand_user join!, geo min-cast, recluster
+# UNNEST batch (needs the dev Postgres up).
+[[example]]
+name = "bench_round11_queries"
+path = "examples/bench_round11_queries.rs"
+required-features = ["bench"]
+
+# Round-11 log-writer benchmark — sync stdout fmt layer vs tracing-appender
+# non_blocking(lossy=false) under 4-worker emit contention, fast + slow
+# writer profiles. Run once per arm via BENCH_LOG_ARM. No Postgres.
+[[example]]
+name = "bench_log_writer"
+path = "examples/bench_log_writer.rs"
 required-features = ["bench"]
 
 # Round-10 battery ────────────────────────────────────────────────────────────

--- a/benches/ROUND11.md
+++ b/benches/ROUND11.md
@@ -2,115 +2,268 @@
 
 Benchmark-gated, same rule as ROUND2-10: every change ships with a
 BEFORE/AFTER benchmark and an equivalence/safety gate; an AFTER that doesn't
-beat its BEFORE gets rolled back or redesigned. Three candidates went
-through exactly that loop this round (§Rejected): the moka `and_upsert_with`
-rate-limiter rewrite measured SLOWER than the two-op shape it was meant to
-replace and was redesigned as a lock-free `get`+`insert`; the GET/HEAD
-`Last-Modified` stack-render port measured neutral-to-worse (the chrono
-String is already the terminal allocation) and was dropped; the first
-search-page `drain(range)` model lost to `to_vec` on wall and was reshaped
-as `into_iter().skip().take()`.
+beat its BEFORE gets rolled back or redesigned. Four candidates went through
+exactly that loop this round (§Rejected below): the moka `and_upsert_with`
+rate-limiter rewrite, the GET/HEAD `Last-Modified` stack-render port, the
+`min(uuid)` geo-cluster cast (PostgreSQL has no such aggregate — the gate
+caught it before it could ship broken), and the `tracing-appender`
+non-blocking log writer (slower than sync on fast sinks, tail-loss risk on
+slow ones).
 
 Measured on 4 cores / 15 GiB, local PostgreSQL 16 (fsync off), release
 profile; frontend on Node 22 / vitest 4 (jsdom). Reproduce any row with the
-command in its section.
+command in its section (`benches/ROUND11.md` §Environment).
 
 ## Summary
 
-(numbers filled from the final runs below)
-
 | # | change | key metric | before → after |
 |--:|---|---|---|
-| 1 | REST download: dead `FileDto` clone → capture mime/size + move | allocs per download | 7 → 0 (dead clone removed) |
-| 2 | `StoragePath` → single canonical joined `String` (segments derived lazily; entity `path_string` duplicate field removed) | allocs / wall per 500-row page | TBD |
-| 3 | Display classifier fusion (`classify_display`, stack-lowered ext shared by the three trees) | ns / allocs per listing row | TBD |
-| 4 | `/status.php` → `OnceLock<Bytes>` | ns / allocs per poll | TBD |
-| 5 | `/openapi.json` → `OnceLock<Bytes>` (was: rebuild 171 KiB spec per request) | ns per request | TBD |
-| 6 | NC upload-session PROPFIND: `write!` + capacity + stack dates | ns / allocs per 256-chunk PROPFIND | TBD |
-| 7 | CSRF header token borrow compare | ns / allocs per state-changing request | TBD |
-| 8 | Thumbnail/preview ETag: `as_str` push (Debug-identical bytes) | ns per thumbnail request | TBD |
-| 9 | Recent-handler id: stack `encode_lower` | ns / allocs per call | TBD |
-| 10 | 4xx body: borrowed serialize + `ErrorKind::as_str` + `not_found` clone kill | ns / allocs per 404 | TBD |
-| 11 | vCard emit: `write!` (+ borrowed address fields) | ns / allocs per vCard | TBD |
-| 12 | Search page: `into_iter().skip().take()` move | allocs per 50-item page | TBD |
-| 13 | Content-hit verify: parse-once pairs | ns per 100-hit page | TBD |
-| 14 | Group last-user check: HashSet probe | ns per 500×500 check | TBD |
-| 15 | Retry op-label: lazy closure | ns / allocs per blob op | TBD |
-| 16 | `encrypt_bytes`: in-place detached (write side now mirrors the in-place read) | ns / allocs per 256 KiB chunk | TBD |
-| 17 | Encrypted `collect_stream`: chunk-sized reserve | allocs per 1 MiB read | TBD |
-| 18 | Recluster cosine: precomputed norms (bit-identical) | ns per 200-face pass | TBD |
-| 19 | `CalendarEventDto`: `into_parts` move (11 KiB `ical_data` copy gone) | ns / allocs per event | TBD |
-| 20 | RateLimiter: lock-free `get` + `insert` | ns / allocs per limited request | TBD |
-| Q1 | Deferred upload registration: 3 round-trips → 1 CTE insert | ms per uploaded file | TBD |
-| Q2 | Calendar/AddressBook/Playlist authz `direct_grant_cache` | ms per DAV check | TBD |
-| Q3 | `expand_user`: `tokio::join!` the 2 independent queries | ms per cold expansion | TBD |
-| Q4 | Geo clusters: `min(file_id)::text` (cast per cluster, not per row) | ms per viewport | TBD |
-| Q5 | Recluster persistence: per-face UPDATEs → one UNNEST batch | ms per 200-face apply | TBD |
-| L1 | Log writer: `tracing-appender` non_blocking (lossy=false) | p99 emit µs under contention | TBD |
-| S1 | SPA `ResourceList.selectedEntries`: O(N)×2 per toggle → O(k·log k), hosts consume the snippet param | comparisons per toggle | 2N → k |
-| S2 | SPA Recent: star reads `favoriteIds` prop, mapper no longer set-dependent | rows re-mapped per star click | N → 0 |
-| S3 | SPA admin `timeAgo`: cached `Intl.DateTimeFormat` | constructions per 1000 formats | ≤1 (was 1000) |
+| 1 | REST download: dead `FileDto` clone → capture mime/size + move | ns / allocs per download | 295.3 → 20.7 ns · 7 → 0 allocs |
+| 2 | `StoragePath` → single canonical joined `String`; `File`/`Folder` drop the duplicate `path_string` field | 500-row page (depth 4) | 121.0 → 80.3 µs (**1.51x**) · 4 000 → 1 000 allocs |
+| 3 | Display classifier fusion (`classify_display`, one stack-lowered ext for the three trees) | 13-row mixed corpus | 4 390 → 2 074 ns (**2.12x**) · 21 → 0 allocs |
+| 4 | `/status.php` → `OnceLock<Bytes>` | per NC client poll | 836 → 28.8 ns (**29x**) · 14 → 0 allocs |
+| 5 | `/openapi.json` → `OnceLock<Bytes>` (was rebuilding the 171 KiB spec per request) | per request | 2.77 ms → 18.5 ns · 12 474 → 0 allocs |
+| 6 | NC upload-session PROPFIND: `write!` + pre-sized body + stack dates | 256-chunk session | 203.7 → 75.4 µs (**2.70x**) · 2 582 → 772 allocs |
+| 7 | CSRF token: borrow-only compare (+ borrowed cookie extraction) | per state-changing request | 55.2 → 2.2 ns · 1 → 0 allocs |
+| 8 | Thumbnail/preview ETag via `as_str` (Debug-identical bytes — cached client ETags stay valid) | per thumbnail request | 150.5 → 87.7 ns · 3 → 2 allocs |
+| 9 | Recent-handler id: stack `encode_lower` | per record/remove | 52.2 → 10.7 ns · 1 → 0 allocs |
+| 10 | 4xx body: borrowed `ErrorResponse` + `ErrorKind::as_str` + `not_found`/`already_exists` clone kill | per 404 | 426 → 367 ns · 11 → 8 allocs |
+| 11 | vCard emit: `write!` + borrowed address fields | per contact create/update | 804 → 386 ns (**2.08x**) · 21 → 5 allocs |
+| 12 | Search page: `into_iter().skip().take()` move (both branches) | 50-item page | 108.3 → 89.4 µs · −301 allocs |
+| 13 | Content-hit verify: parse each UUID once | 100-hit page | 7.90 → 5.20 µs (**1.52x**) |
+| 14 | Group last-user check: HashSet probe | 500×500 check | 105.3 → 17.1 µs (**6.1x**) |
+| 15 | Retry op-label: lazy closure (success path never formats) | per blob op | 71.8 → 0.7 ns · 2 → 0 allocs |
+| 16 | `encrypt_bytes`: in-place detached, single buffer (write now mirrors the in-place read) | 256 KiB chunk | 231.1 → 208.1 µs (**1.11x**) · 2 → 1 allocs |
+| 17 | Encrypted `collect_stream`: chunk-sized reserve | 1 MiB blob, 4 KiB frames | 60.4 → 53.2 µs · 9 → 1 allocs |
+| 18 | Recluster cosine: norms precomputed once (bit-identical gate over all pairs) | 200 faces × 512-dim pass | 7.70 → 7.17 ms (**1.07x**) |
+| 19 | `CalendarEventDto`: `into_parts` move (the ~11 KiB `ical_data` memcpy gone) | per CalDAV event row | 497 → 283 ns (**1.76x**) · 14 → 8 allocs |
+| 20 | RateLimiter: lock-free `get` (borrows the key) + `insert` | per limited request | allocs 8.0 → 6.0 · wall neutral (1 657 vs 1 695 ns, within run variance) |
+| Q1 | Deferred upload registration: 3 round-trips → 1 CTE insert (the `persist_file` template) | per uploaded file (incl. cleanup DELETE) | 1.83 → 1.32 ms · gates: identical path/drive, missing-parent → not-found |
+| Q2 | Calendar/AddressBook/Playlist authz `direct_grant_cache` (single-flight, invalidated on `set_role`/`clear_role`) | per DAV check | 0.197 ms → 0.2 µs on hit (**~1000x**) · revocation-flip gate OK |
+| Q3 | `expand_user`: `tokio::join!` the `is_external` read + groups CTE | per cold expansion | 0.426 → 0.204 ms (**2.1x**) |
+| Q5 | Recluster persistence: per-face UPDATE loop → one UNNEST batch | 200-face apply (incl. reset) | 80.0 → 8.7 ms (**9.2x**) · final column state identical |
+| S1 | SPA `ResourceList.selectedEntries`: O(N)×2 per toggle → id-index O(k·log k); hosts consume the snippet param | comparisons per 51-toggle gesture (N=2 000) | 204 000 → <2 602 · identical output/order gated |
+| S2 | SPA Recent: star reads the new `favoriteIds` prop — mapper no longer depends on the set | rows re-mapped per star click (N=400) | 400 → 0 · identical star states gated |
+| S3 | SPA admin `timeAgo` >30d: cached `Intl.DateTimeFormat` | constructions per 1 000 formats | ≤1 · output equals `toLocaleDateString()` |
 
-Also shipped without a dedicated row: `already_exists` clone kill (same
-shape as `not_found`), CardDAV `getlastmodified` stack render (per-contact
-REPORT path, ROUND10-§13 helper + fallback), NC capabilities poll logs
-demoted to `debug` (INFO forced a locked-stdout write per client poll),
-trash `to_dto` `into_parts` move + interned display fields (trash listing
-+ path-resolver rows now share the ROUND9 interning).
+Also shipped without a dedicated row: CardDAV `getlastmodified` per-contact
+stack render (ROUND10-§13 helper + chrono fallback), NC capabilities poll
+logs demoted to `debug` (each poll forced a formatted line + locked stdout
+write), trash `to_dto` `into_parts` move + fused/interned display fields
+(trash listing and path-resolver rows now share the ROUND9 interning),
+`TrashedItemDto` name/path moves.
+
+Cross-round regression guards re-run after the StoragePath / classifier
+rework — both gates PASS byte-identical, and the shipped code now beats the
+numbers those rounds recorded:
+
+- `bench_row_path` (round 4): file row 705 → 280 ns/row (2.52x), allocs
+  15.75 → 6.00; folder row 684 → 365 ns (1.87x), 14.08 → 5.24.
+- `bench_dto_map` (round 3): File→FileDto 839 → 606 ns/row, 10.09 → 3.08
+  allocs; Folder→FolderDto 314 → 161 ns, 11.80 → 1.00 allocs.
+
+## [1] REST download dead clone → move
+
+```
+cargo run --release --features bench --example bench_round11_micro   # §1
+```
+
+`download_file_impl` cloned the whole `FileDto` (7 owned Strings) into
+`get_file_optimized_preloaded` on every authenticated download, purely to
+read `mime_type`/`size` afterwards — the share path already captured+moved
+(ROUND10 §3 fixed its double-*fetch*, not this clone). Now: one `Arc<str>`
+bump + a `u64` copy, then move. 295.3 → 20.7 ns, 7 → 0 allocs per download.
+
+## [2] StoragePath joined-only representation
+
+```
+cargo run --release --features bench --example bench_round11_micro   # §20
+cargo run --release --features bench --example bench_row_path        # cross-round gate
+```
+
+`StoragePath` stored `segments: Vec<String>` — one heap String per path
+component built on EVERY hydrated row — while the DTO path only ever
+consumed the joined form, and the entities carried a second `path_string`
+duplicate. The value object now stores the canonical joined `String` alone
+(`"/"` or `/seg(/seg)*`); `file_name`/`parent`/`segments()`/`Display`
+derive on demand; `File`/`Folder` lost the duplicate field (`path_string()`
+borrows). `.segments()` had zero external callers — verified before the
+rework. Equivalence gates: identical `path_string`, `file_name`, `parent`,
+`Display` across the corpus, plus the round-4 harness's byte-identical
+gate. 500-row page: 121.0 → 80.3 µs, 4 000 → 1 000 allocs; per-row RAM
+drops by the Vec + per-segment String headers + the duplicate path.
+
+## [3] Display classifier fusion
+
+```
+cargo run --release --features bench --example bench_round11_micro   # §21
+```
+
+Every listed file ran the full MIME classification three times
+(`icon_class_for`, `icon_special_class_for`, `category_for`), each
+heap-allocating its own `to_ascii_lowercase()` on the extension-fallback
+path. The three decision trees are byte-for-byte preserved (they diverge
+deliberately, so no merged tree); `classify_display` lowers the extension
+once into a 16-byte stack buffer shared by all three. Extensions longer
+than any table entry short-circuit to the same `_`-arm defaults (gated).
+Call sites: `FileDto::from`, folder/favorites/recent handlers, trash
+listing (×2), path-resolver — the last two also gained the ROUND9
+interning they had missed (`Arc::from` per row → refcount bump).
+13-row corpus: 4 390 → 2 074 ns, 21 → 0 allocs.
+
+## [4][5] Memoized process-invariant bodies
+
+```
+cargo run --release --features bench --example bench_round11_micro   # §3, §18
+```
+
+`/status.php` rebuilt its `json!` tree per NC client poll (836 ns / 14
+allocs → 28.8 ns / 0). `/openapi.json` was the extreme case: utoipa
+reconstructed and re-serialized the whole 171 KiB spec on every request —
+2.77 ms / 12 474 allocs → 18.5 ns / 0 via the same `OnceLock<Bytes>`
+pattern as ROUND9's capabilities memoization. Byte-identical gates on both.
+
+## [6] NC upload-session PROPFIND emit
+
+The last hand-built XML handler: `String::new()` + `push_str(&format!(…))`
+per element per chunk + chrono `to_rfc2822()` per chunk. Now pre-sized +
+`write!` + `common::fmt::rfc2822_utc` (chrono fallback out-of-range).
+Byte-identical gates at 16 and 256 chunks (escape distributes over
+concatenation; RFC 2822 output has no XML-special chars). 16 chunks:
+13.2 → 5.2 µs; 256 chunks: 203.7 → 75.4 µs, 2 582 → 772 allocs.
+
+## [Q1] Deferred upload registration 3 → 1
+
+```
+cargo run --release --features bench --example bench_round11_queries # §1
+```
+
+The write-behind REST upload path ran parent-drive SELECT → INSERT →
+parent-path SELECT, the first and third re-reading the identical
+`storage.folders` row. Ported to the `WITH parent AS (…) INSERT … SELECT
+… RETURNING (SELECT path FROM parent)` template `persist_file` has used
+since ROUND2 — 0 rows ⇒ the same `not_found("Folder")` the old first query
+produced (gated, anti-enum shape preserved). Root uploads (no parent)
+keep their previous two-step shape.
+
+## [Q2] direct_grant_cache
+
+Calendar/AddressBook/Playlist were the only `check()` arms with no result
+cache — every CalDAV/CardDAV/music request re-ran the `role_grants` point
+query, and DAV clients poll continuously. Added
+`direct_grant_cache: Cache<(Subject, Resource, Permission), bool>`
+(30 s TTL / 100k, `try_get_with` single-flight — the ROUND8/10 pattern),
+flushed on `set_role`/`clear_role` for those resource types; group/expiry
+churn self-heals within the TTL exactly like `cascade_grant_cache`.
+Gates: identical verdict; a revocation + flush flips the next check.
+0.197 ms → 0.2 µs on hit.
+
+## [Q3] expand_user join!
+
+The `is_external` point read and the recursive groups CTE are independent;
+serial await paid two round-trips end-to-end on every cold expansion
+(per user per 30 s TTL window). `tokio::join!`: 0.426 → 0.204 ms.
+
+## [Q5] Recluster UNNEST batch
+
+`POST /api/people/recluster` issued one `UPDATE faces.faces SET person_id`
+per face sequentially (both the unassign-small-clusters and assign loops).
+Assignments now accumulate and apply as a single
+`UPDATE … FROM unnest($1::uuid[], $2::uuid[])` (the ROUND10 `save_faces`
+pattern) — 200-face library: 80.0 → 8.7 ms, final column state identical.
+Pairs with §18's norm precomputation on the CPU side (7.70 → 7.17 ms for
+the O(N²) pass, bit-identical similarity gated over every pair).
+
+## [S1][S2][S3] SPA pack (vitest gates)
+
+```
+cd frontend && npx vitest run src/lib/components/round11.bench.test.ts
+```
+
+- **`ResourceList.selectedEntries`** (the ROUND10 flagged item): the
+  component re-filtered the ENTIRE items array per selection change, and
+  favorites/recent ignored the snippet param and recomputed their own
+  `entries.filter(…)` shadow — two full O(N) scans per toggle, O(N²)-ish
+  across a shift-range. Now an id→index Map (rebuilt only when `items`
+  changes) projects the selection in O(k·log k) preserving item order;
+  hosts consume the snippet param and their dead `selectedIds` mirror is
+  gone (the component's prune effect already self-heals on reload).
+  51-toggle gesture on 2 000 items: 204 000 → <2 602 comparisons.
+- **Recent favorite star**: the entry mapper read `favoriteIds.has(id)`,
+  subscribing the whole O(N) map to the SvelteSet — one star click rebuilt
+  all N entries and re-rendered every visible row. `ResourceList` gained a
+  `favoriteIds` prop read directly by the star widget; the mapper is
+  set-independent. Star click: N → 0 rows re-mapped, star states gated
+  identical.
+- **admin `timeAgo`**: the >30-day fallback called `toLocaleDateString()`
+  (a fresh `Intl.DateTimeFormat` per call); now the app-wide cached
+  formatter — output equality gated, ≤1 construction per 1 000 formats.
 
 ## Rejected / reworked this round (the discipline working)
 
-- **RateLimiter `entry().and_upsert_with`**: 1 846.5 → 1 862.1 ns and
-  8.0 → 9.1 allocs/op — moka's compute-entry machinery costs more than the
-  two-op shape it replaced. Redesigned as lock-free `get` (borrows the
-  key, no alloc) + `insert`; identical counter sequence gated.
+- **`min(fm.file_id)::text` geo-cluster cast (Q4)**: PostgreSQL has **no
+  `min(uuid)` aggregate** — the "cast once per cluster" rewrite fails to
+  parse (`42883`). The gate caught it before it could ship broken; the
+  per-row-cast original stays (22.6 ms per 5k-row viewport, admin-shaped
+  traffic), and a custom `CREATE AGGREGATE` was judged schema surface this
+  query doesn't justify. The bench section now reproduces the rejection.
+- **RateLimiter `entry().and_upsert_with`**: 1 657 → 2 365 ns and
+  8.0 → 9.1 allocs — moka's compute-entry machinery costs more than the
+  two ops it replaced. Redesigned as lock-free `get` (borrows the key, no
+  alloc) + `insert`: 6.0 allocs, wall within variance; identical counter
+  sequence gated. Adopted in that form.
 - **GET/HEAD `Last-Modified` stack-render port**: chrono's `to_rfc2822()`
-  String IS the terminal allocation the header needs (44.3 ns incl. the
-  alloc vs 46.5 ns for stack render + the same alloc). Only body-emit
-  sites (where `write!` lands in an existing buffer) benefit — those were
-  ported (§6, CardDAV); the header sites were left on chrono.
-- **Search page `drain(range).collect()`**: −300 allocs but slower on
-  wall than `to_vec` in the first model (tail memmove). Reshaped as
-  `into_iter().skip().take().collect()` — moves the page, drops the rest,
-  no tail shift.
+  String IS the terminal allocation the header needs (38.7 ns incl. alloc
+  vs 47.0 ns stack render + the same alloc). Only body-emit sites (where
+  `write!` lands in an existing buffer, 31.8 ns / 0 allocs) benefit —
+  those were ported (§6 + CardDAV); header sites stay on chrono.
+- **`tracing-appender` non-blocking log writer (L1)**: on a fast sink
+  (stdout→/dev/null — the containerized default) sync sustains 1.41M ev/s
+  vs 0.99M non-blocking, with a better tail (p999 76 vs 151 µs, max 0.8
+  vs 8.3 ms — the channel hop costs more than the write). Non-blocking
+  only wins on a slow sink (20 µs/line: 6.4x wall, p50 22 → 1.9 µs), but
+  there the drain gate FAILED — buffered tail lines can be lost at
+  shutdown, unacceptable for the audit channel. Not adopted;
+  `tracing-appender` stays as a dev-dependency for the reproducible
+  harness (`bench_log_writer`, 4 arms via `BENCH_LOG_ARM`/`_WRITER`).
+- **First search-page model (`drain(range)`)**: −300 allocs but slower on
+  wall (tail memmove). Reshaped as `into_iter().skip().take().collect()`
+  — moves the page, drops the rest, wins both axes (§12 row in Summary).
 
 ## Deferred / flagged (not shipped this round)
 
-- **NC preview 304 still runs `get_file`** (`preview_handler.rs`): the
-  object-id → file fetch on the revalidation path is only needed for
-  existence semantics (a deleted file must 404, not 304). Dropping it is
-  a behavior decision — same class as the standing CalDAV
-  authz-before-fetch reorder — flagged for maintainer sign-off.
+- **NC preview 304 still runs `get_file`**: dropping the fetch on the
+  revalidation path changes existence semantics (deleted file → 304
+  instead of 404) — needs maintainer sign-off, same class as the standing
+  CalDAV authz-before-fetch reorder (ROUND9/10 flag).
 - **`CachedBlobBackend`'s `Mutex<LruCache>` index** serializes every
-  cached read; a moka byte-weigher migration (the file-content-cache
-  pattern) is the natural fix but touches eviction-unlink semantics —
-  deserves its own round with a concurrency bench.
+  cached read on remote+cache deployments; the moka byte-weigher
+  migration (file-content-cache pattern) deserves its own round with a
+  concurrency bench and eviction-unlink care.
 - **Capture-metadata extraction reads each media file 2-3×**
-  (`media_metadata_service.rs`: kamadak full read + nom-exif path re-read
-  + track fallback re-read). Feeding nom-exif from the in-memory buffer
-  needs its `MediaSource` API verified on the pinned version.
+  (`media_metadata_service`: kamadak full read + nom-exif path re-read +
+  track fallback). Feeding nom-exif from the in-memory buffer needs its
+  `MediaSource` API verified on the pinned version.
 - **`CachedBlobBackend::local_blob_path` sync `stat`** (ROUND10 flag
-  stands): needs an async port variant.
+  stands — needs an async port variant).
 - **Azure SDK 0.21 stack** drags duplicate dependency trees (h2 0.3+0.4,
-  two hashbrown generations, base64 0.13) into the binary; an SDK bump is
-  a dedicated migration, not a perf tweak.
+  three hashbrown generations, base64 0.13, getrandom 0.1) into every
+  build — an SDK bump is a dedicated migration.
 - **`AudioMetadataRepository::list_by_{artist,album,genre}`** are dead
-  code (never called) with seq-scan `ILIKE` shapes — flag for deletion
-  rather than indexing.
+  code with seq-scan `ILIKE` shapes — flag for deletion, not indexing.
 - **`CachedBlobBackend::put_blob` cache population** silently fails for
-  S3/Azure whole-file puts (the inner backend deletes the source before
-  the cache copy runs) — correctness note for maintainers, not perf.
-- **CalDAV authz-before-fetch reorder** — ROUND9/10 flag stands.
+  S3/Azure whole-file puts (inner backend deletes the source before the
+  cache copy) — correctness note for maintainers.
+- **Grouped file/grid views unvirtualized** (ROUND10 flag stands).
 
 ## Environment / methodology
 
 - `cargo run --release --features bench --example bench_round11_micro`
-  (pure CPU, counting allocator, BEFORE replicas vs shipped code).
+  — 21 sections, counting allocator, BEFORE replicas vs shipped shapes,
+  equivalence gates inline (`BENCH_ITERS`, default 100k).
 - `cargo run --release --features bench --example bench_round11_queries`
-  (Postgres; seeds + sweeps its own fixtures).
+  — needs Postgres; seeds and sweeps its own fixtures (`BENCH_PASSES`).
 - `BENCH_LOG_ARM=sync|nonblocking [BENCH_LOG_WRITER=slow] cargo run
   --release --features bench --example bench_log_writer >/dev/null`.
 - `cd frontend && npx vitest run src/lib/components/round11.bench.test.ts`.
-- Regression guards from earlier rounds re-run after the StoragePath /
-  classifier changes: `bench_row_path` (round-4 gates) and `bench_dto_map`
-  (round-3 gates).
+- Cross-round guards: `bench_row_path`, `bench_dto_map`.

--- a/benches/ROUND11.md
+++ b/benches/ROUND11.md
@@ -1,0 +1,116 @@
+# Round 11 — StoragePath re-representation, classifier fusion, memoized static bodies, query-shape pack, SPA fine-grained stars
+
+Benchmark-gated, same rule as ROUND2-10: every change ships with a
+BEFORE/AFTER benchmark and an equivalence/safety gate; an AFTER that doesn't
+beat its BEFORE gets rolled back or redesigned. Three candidates went
+through exactly that loop this round (§Rejected): the moka `and_upsert_with`
+rate-limiter rewrite measured SLOWER than the two-op shape it was meant to
+replace and was redesigned as a lock-free `get`+`insert`; the GET/HEAD
+`Last-Modified` stack-render port measured neutral-to-worse (the chrono
+String is already the terminal allocation) and was dropped; the first
+search-page `drain(range)` model lost to `to_vec` on wall and was reshaped
+as `into_iter().skip().take()`.
+
+Measured on 4 cores / 15 GiB, local PostgreSQL 16 (fsync off), release
+profile; frontend on Node 22 / vitest 4 (jsdom). Reproduce any row with the
+command in its section.
+
+## Summary
+
+(numbers filled from the final runs below)
+
+| # | change | key metric | before → after |
+|--:|---|---|---|
+| 1 | REST download: dead `FileDto` clone → capture mime/size + move | allocs per download | 7 → 0 (dead clone removed) |
+| 2 | `StoragePath` → single canonical joined `String` (segments derived lazily; entity `path_string` duplicate field removed) | allocs / wall per 500-row page | TBD |
+| 3 | Display classifier fusion (`classify_display`, stack-lowered ext shared by the three trees) | ns / allocs per listing row | TBD |
+| 4 | `/status.php` → `OnceLock<Bytes>` | ns / allocs per poll | TBD |
+| 5 | `/openapi.json` → `OnceLock<Bytes>` (was: rebuild 171 KiB spec per request) | ns per request | TBD |
+| 6 | NC upload-session PROPFIND: `write!` + capacity + stack dates | ns / allocs per 256-chunk PROPFIND | TBD |
+| 7 | CSRF header token borrow compare | ns / allocs per state-changing request | TBD |
+| 8 | Thumbnail/preview ETag: `as_str` push (Debug-identical bytes) | ns per thumbnail request | TBD |
+| 9 | Recent-handler id: stack `encode_lower` | ns / allocs per call | TBD |
+| 10 | 4xx body: borrowed serialize + `ErrorKind::as_str` + `not_found` clone kill | ns / allocs per 404 | TBD |
+| 11 | vCard emit: `write!` (+ borrowed address fields) | ns / allocs per vCard | TBD |
+| 12 | Search page: `into_iter().skip().take()` move | allocs per 50-item page | TBD |
+| 13 | Content-hit verify: parse-once pairs | ns per 100-hit page | TBD |
+| 14 | Group last-user check: HashSet probe | ns per 500×500 check | TBD |
+| 15 | Retry op-label: lazy closure | ns / allocs per blob op | TBD |
+| 16 | `encrypt_bytes`: in-place detached (write side now mirrors the in-place read) | ns / allocs per 256 KiB chunk | TBD |
+| 17 | Encrypted `collect_stream`: chunk-sized reserve | allocs per 1 MiB read | TBD |
+| 18 | Recluster cosine: precomputed norms (bit-identical) | ns per 200-face pass | TBD |
+| 19 | `CalendarEventDto`: `into_parts` move (11 KiB `ical_data` copy gone) | ns / allocs per event | TBD |
+| 20 | RateLimiter: lock-free `get` + `insert` | ns / allocs per limited request | TBD |
+| Q1 | Deferred upload registration: 3 round-trips → 1 CTE insert | ms per uploaded file | TBD |
+| Q2 | Calendar/AddressBook/Playlist authz `direct_grant_cache` | ms per DAV check | TBD |
+| Q3 | `expand_user`: `tokio::join!` the 2 independent queries | ms per cold expansion | TBD |
+| Q4 | Geo clusters: `min(file_id)::text` (cast per cluster, not per row) | ms per viewport | TBD |
+| Q5 | Recluster persistence: per-face UPDATEs → one UNNEST batch | ms per 200-face apply | TBD |
+| L1 | Log writer: `tracing-appender` non_blocking (lossy=false) | p99 emit µs under contention | TBD |
+| S1 | SPA `ResourceList.selectedEntries`: O(N)×2 per toggle → O(k·log k), hosts consume the snippet param | comparisons per toggle | 2N → k |
+| S2 | SPA Recent: star reads `favoriteIds` prop, mapper no longer set-dependent | rows re-mapped per star click | N → 0 |
+| S3 | SPA admin `timeAgo`: cached `Intl.DateTimeFormat` | constructions per 1000 formats | ≤1 (was 1000) |
+
+Also shipped without a dedicated row: `already_exists` clone kill (same
+shape as `not_found`), CardDAV `getlastmodified` stack render (per-contact
+REPORT path, ROUND10-§13 helper + fallback), NC capabilities poll logs
+demoted to `debug` (INFO forced a locked-stdout write per client poll),
+trash `to_dto` `into_parts` move + interned display fields (trash listing
++ path-resolver rows now share the ROUND9 interning).
+
+## Rejected / reworked this round (the discipline working)
+
+- **RateLimiter `entry().and_upsert_with`**: 1 846.5 → 1 862.1 ns and
+  8.0 → 9.1 allocs/op — moka's compute-entry machinery costs more than the
+  two-op shape it replaced. Redesigned as lock-free `get` (borrows the
+  key, no alloc) + `insert`; identical counter sequence gated.
+- **GET/HEAD `Last-Modified` stack-render port**: chrono's `to_rfc2822()`
+  String IS the terminal allocation the header needs (44.3 ns incl. the
+  alloc vs 46.5 ns for stack render + the same alloc). Only body-emit
+  sites (where `write!` lands in an existing buffer) benefit — those were
+  ported (§6, CardDAV); the header sites were left on chrono.
+- **Search page `drain(range).collect()`**: −300 allocs but slower on
+  wall than `to_vec` in the first model (tail memmove). Reshaped as
+  `into_iter().skip().take().collect()` — moves the page, drops the rest,
+  no tail shift.
+
+## Deferred / flagged (not shipped this round)
+
+- **NC preview 304 still runs `get_file`** (`preview_handler.rs`): the
+  object-id → file fetch on the revalidation path is only needed for
+  existence semantics (a deleted file must 404, not 304). Dropping it is
+  a behavior decision — same class as the standing CalDAV
+  authz-before-fetch reorder — flagged for maintainer sign-off.
+- **`CachedBlobBackend`'s `Mutex<LruCache>` index** serializes every
+  cached read; a moka byte-weigher migration (the file-content-cache
+  pattern) is the natural fix but touches eviction-unlink semantics —
+  deserves its own round with a concurrency bench.
+- **Capture-metadata extraction reads each media file 2-3×**
+  (`media_metadata_service.rs`: kamadak full read + nom-exif path re-read
+  + track fallback re-read). Feeding nom-exif from the in-memory buffer
+  needs its `MediaSource` API verified on the pinned version.
+- **`CachedBlobBackend::local_blob_path` sync `stat`** (ROUND10 flag
+  stands): needs an async port variant.
+- **Azure SDK 0.21 stack** drags duplicate dependency trees (h2 0.3+0.4,
+  two hashbrown generations, base64 0.13) into the binary; an SDK bump is
+  a dedicated migration, not a perf tweak.
+- **`AudioMetadataRepository::list_by_{artist,album,genre}`** are dead
+  code (never called) with seq-scan `ILIKE` shapes — flag for deletion
+  rather than indexing.
+- **`CachedBlobBackend::put_blob` cache population** silently fails for
+  S3/Azure whole-file puts (the inner backend deletes the source before
+  the cache copy runs) — correctness note for maintainers, not perf.
+- **CalDAV authz-before-fetch reorder** — ROUND9/10 flag stands.
+
+## Environment / methodology
+
+- `cargo run --release --features bench --example bench_round11_micro`
+  (pure CPU, counting allocator, BEFORE replicas vs shipped code).
+- `cargo run --release --features bench --example bench_round11_queries`
+  (Postgres; seeds + sweeps its own fixtures).
+- `BENCH_LOG_ARM=sync|nonblocking [BENCH_LOG_WRITER=slow] cargo run
+  --release --features bench --example bench_log_writer >/dev/null`.
+- `cd frontend && npx vitest run src/lib/components/round11.bench.test.ts`.
+- Regression guards from earlier rounds re-run after the StoragePath /
+  classifier changes: `bench_row_path` (round-4 gates) and `bench_dto_map`
+  (round-3 gates).

--- a/examples/bench_dto_map.rs
+++ b/examples/bench_dto_map.rs
@@ -139,7 +139,7 @@ mod before {
         FileDto {
             id: parts.id,
             name: parts.name,
-            path: parts.path_string,
+            path: parts.storage_path.into_joined(),
             size: parts.size,
             mime_type,
             folder_id: parts.folder_id,

--- a/examples/bench_log_writer.rs
+++ b/examples/bench_log_writer.rs
@@ -1,0 +1,157 @@
+//! Round-11 log-writer benchmark — synchronous fmt layer (stdout under a
+//! global lock, on the async workers) vs `tracing_appender::non_blocking`
+//! with `lossy(false)` (audit lines must never drop; the emitting thread
+//! blocks only if the 128k-line channel fills).
+//!
+//! Two writer profiles:
+//!   - fast: stdout redirected to /dev/null (best case for the sync arm)
+//!   - slow: a writer that burns ~20 µs per line under the same lock,
+//!     modelling a laggy pipe / journald / TTY consumer
+//!
+//! The global subscriber can only be installed once per process, so the
+//! arm is chosen via env and the harness runs the binary once per arm:
+//!
+//!   BENCH_LOG_ARM=sync        cargo run --release --features bench --example bench_log_writer >/dev/null
+//!   BENCH_LOG_ARM=nonblocking cargo run --release --features bench --example bench_log_writer >/dev/null
+//!   BENCH_LOG_WRITER=slow BENCH_LOG_ARM=...   (slow-writer profile)
+//!
+//! Measurements print to stderr. Emits 4 workers × 25k events; reports
+//! total wall, per-event p50/p99/p999 emit latency, and (for the
+//! non-blocking arm) confirms zero dropped lines via a line count gate
+//! (lossy(false) + guard flush).
+
+use std::io::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+static LINES: AtomicU64 = AtomicU64::new(0);
+
+/// Counts lines then forwards to stdout (which the run command redirects
+/// to /dev/null). The `slow` profile burns ~20 µs per write while holding
+/// the caller's lock, modelling a slow consumer.
+struct CountingWriter {
+    slow: bool,
+}
+
+impl Write for CountingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        LINES.fetch_add(1, Ordering::Relaxed);
+        if self.slow {
+            let t = Instant::now();
+            while t.elapsed().as_micros() < 20 {
+                std::hint::spin_loop();
+            }
+        }
+        std::io::stdout().write_all(buf)?;
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        std::io::stdout().flush()
+    }
+}
+
+#[derive(Clone)]
+struct MakeCounting {
+    slow: bool,
+}
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for MakeCounting {
+    type Writer = CountingWriter;
+    fn make_writer(&'a self) -> Self::Writer {
+        CountingWriter { slow: self.slow }
+    }
+}
+
+fn main() {
+    let arm = std::env::var("BENCH_LOG_ARM").unwrap_or_else(|_| "sync".into());
+    let slow = std::env::var("BENCH_LOG_WRITER").as_deref() == Ok("slow");
+    let workers = 4usize;
+    let per_worker = 25_000u64;
+
+    // Same filter shape as main.rs.
+    let filter = tracing_subscriber::EnvFilter::new("info,http=warn,http::web=error");
+
+    // Keep the non-blocking guard alive for the whole run.
+    let _guard: Option<tracing_appender::non_blocking::WorkerGuard> = match arm.as_str() {
+        "nonblocking" => {
+            let (nb, guard) = tracing_appender::non_blocking::NonBlockingBuilder::default()
+                .lossy(false)
+                .finish(CountingWriter { slow });
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(tracing_subscriber::fmt::layer().with_writer(nb))
+                .init();
+            Some(guard)
+        }
+        _ => {
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(tracing_subscriber::fmt::layer().with_writer(MakeCounting { slow }))
+                .init();
+            None
+        }
+    };
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(workers)
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let (wall, mut lat_us): (f64, Vec<f64>) = rt.block_on(async {
+        let t0 = Instant::now();
+        let mut handles = Vec::new();
+        for w in 0..workers {
+            handles.push(tokio::spawn(async move {
+                let mut lats = Vec::with_capacity(per_worker as usize);
+                for i in 0..per_worker {
+                    let t = Instant::now();
+                    tracing::info!(worker = w, seq = i, "bench log line with a few fields");
+                    lats.push(t.elapsed().as_secs_f64() * 1e6);
+                    if i % 512 == 0 {
+                        tokio::task::yield_now().await;
+                    }
+                }
+                lats
+            }));
+        }
+        let mut all = Vec::new();
+        for h in handles {
+            all.extend(h.await.unwrap());
+        }
+        (t0.elapsed().as_secs_f64(), all)
+    });
+
+    // Flush (drop guard for non-blocking) before counting lines.
+    drop(_guard);
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    lat_us.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let pct = |p: f64| lat_us[((lat_us.len() as f64 * p) as usize).min(lat_us.len() - 1)];
+    let total = workers as u64 * per_worker;
+    let emitted = LINES.load(Ordering::Relaxed);
+
+    eprintln!(
+        "arm={arm} writer={} events={total} wall={:.3}s  ({:.0} ev/s)",
+        if slow {
+            "slow(20µs)"
+        } else {
+            "fast(/dev/null)"
+        },
+        wall,
+        total as f64 / wall
+    );
+    eprintln!(
+        "  emit latency µs: p50={:.1} p99={:.1} p999={:.1} max={:.1}",
+        pct(0.50),
+        pct(0.99),
+        pct(0.999),
+        lat_us[lat_us.len() - 1]
+    );
+    eprintln!(
+        "  gate[no lines dropped]: {}",
+        if emitted >= total { "OK" } else { "FAILED" }
+    );
+}

--- a/examples/bench_round11_micro.rs
+++ b/examples/bench_round11_micro.rs
@@ -8,14 +8,17 @@
 //! Sections (all pure CPU, no Postgres):
 //!    1. REST download `FileDto` dead clone vs mime/size capture + move
 //!    2. Single-resource GET/HEAD `Last-Modified`: chrono `to_rfc2822()`
-//!       vs `common::fmt::rfc2822_utc` stack render (gate: byte-identical)
+//!       vs `common::fmt::rfc2822_utc` stack render (gate: byte-identical).
+//!       VERDICT: header port REJECTED — the chrono String is already the
+//!       terminal allocation; only body-emit sites benefit.
 //!    3. `/status.php` poll: rebuild `json!` + serialize vs `OnceLock<Bytes>`
 //!       (gate: byte-identical)
 //!    4. NC chunk-upload session PROPFIND: `push_str(&format!)` + chrono
 //!       per chunk vs `with_capacity` + `write!` + stack dates
 //!       (gate: byte-identical XML)
-//!    5. RateLimiter: 2 key allocs + entry+insert vs 1 alloc + single
-//!       `and_upsert_with` (gate: identical allow/deny + counts)
+//!    5. RateLimiter: 2 key allocs + entry+insert vs (a) `and_upsert_with`
+//!       [REJECTED: slower + more allocs] vs (b) lock-free get + insert
+//!       [ADOPTED] (gate: identical counter sequences)
 //!    6. CSRF header token: `to_string` vs borrow compare (gate: same bool)
 //!    7. Thumbnail ETag: `{:?}` Debug enums vs `as_str` + push (gate: bytes)
 //!    8. Recent-handler id: `Uuid::to_string` vs stack `encode_lower`

--- a/examples/bench_round11_micro.rs
+++ b/examples/bench_round11_micro.rs
@@ -1,0 +1,1614 @@
+//! Round-11 CPU/alloc micro-pack — BEFORE replicas vs AFTER shapes.
+//!
+//! Same discipline as ROUND2-10: every section measures a byte-faithful
+//! replica of the shipped code (BEFORE) against the candidate shape
+//! (AFTER), with an equivalence gate. An AFTER that doesn't win gets
+//! rolled back instead of adopted.
+//!
+//! Sections (all pure CPU, no Postgres):
+//!    1. REST download `FileDto` dead clone vs mime/size capture + move
+//!    2. Single-resource GET/HEAD `Last-Modified`: chrono `to_rfc2822()`
+//!       vs `common::fmt::rfc2822_utc` stack render (gate: byte-identical)
+//!    3. `/status.php` poll: rebuild `json!` + serialize vs `OnceLock<Bytes>`
+//!       (gate: byte-identical)
+//!    4. NC chunk-upload session PROPFIND: `push_str(&format!)` + chrono
+//!       per chunk vs `with_capacity` + `write!` + stack dates
+//!       (gate: byte-identical XML)
+//!    5. RateLimiter: 2 key allocs + entry+insert vs 1 alloc + single
+//!       `and_upsert_with` (gate: identical allow/deny + counts)
+//!    6. CSRF header token: `to_string` vs borrow compare (gate: same bool)
+//!    7. Thumbnail ETag: `{:?}` Debug enums vs `as_str` + push (gate: bytes)
+//!    8. Recent-handler id: `Uuid::to_string` vs stack `encode_lower`
+//!       (gate: identical str)
+//!    9. 4xx error body: status+message clones + `kind.to_string()` vs
+//!       borrowed single-alloc serialize (gate: byte-identical JSON)
+//!   10. vCard emit: `push_str(&format!)` vs `write!` (gate: bytes)
+//!   11. Search page slice: `.to_vec()` clone vs `drain` move (gate: equal)
+//!   12. Content-hit verify: double `Uuid::parse_str` vs parse-once pairs
+//!       (gate: same verified set)
+//!   13. Group last-user check: O(N·M) slice contains vs HashSet
+//!       (gate: same bool)
+//!   14. Retry op label: eager `format!` vs lazy closure (success path)
+//!   15. `encrypt_bytes`: ciphertext alloc + copy vs in-place detached
+//!       (gate: byte-identical output for a fixed nonce + round-trip)
+//!   16. Encrypted `collect_stream`: `Vec::new()` growth vs pre-sized
+//!       (gate: same bytes)
+//!   17. Face clustering `cosine`: per-pair norm recompute vs precomputed
+//!       sqrt norms (gate: bitwise-identical similarity + same unions)
+//!   18. `/openapi.json`: rebuild + serialize vs `OnceLock<Bytes>`
+//!       (gate: byte-identical)
+//!   19. `CalendarEventDto::from`: getter clones (incl. the ~11 KB
+//!       `ical_data`) vs `into_parts` move (gate: identical DTO fields)
+//!   20. `StoragePath` row materialization: eager `Vec<String>` segments +
+//!       duplicated `path_string` vs single canonical joined `String`
+//!       (gate: identical path/file_name/parent/Display)
+//!
+//! Run: cargo run --release --features bench --example bench_round11_micro
+//! Tunables (env): BENCH_ITERS (100000)
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::env;
+use std::fmt::Write as _;
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+// ─── Counting allocator ─────────────────────────────────────────────────────
+
+static ALLOC_CALLS: AtomicU64 = AtomicU64::new(0);
+
+struct CountingAlloc;
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc_zeroed(layout) }
+    }
+}
+
+#[global_allocator]
+static GLOBAL: CountingAlloc = CountingAlloc;
+
+fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
+    env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn measure<R>(label: &str, iters: u64, mut f: impl FnMut() -> R) -> (f64, f64) {
+    for _ in 0..1000 {
+        black_box(f());
+    }
+    let a0 = ALLOC_CALLS.load(Ordering::Relaxed);
+    let t0 = Instant::now();
+    for _ in 0..iters {
+        black_box(f());
+    }
+    let wall = t0.elapsed().as_secs_f64();
+    let allocs = (ALLOC_CALLS.load(Ordering::Relaxed) - a0) as f64 / iters as f64;
+    let ns = wall * 1e9 / iters as f64;
+    println!("    {label:<52} {ns:>10.1} ns/op   {allocs:>8.3} allocs/op");
+    (ns, allocs)
+}
+
+fn gate(name: &str, ok: bool) {
+    if ok {
+        println!("    gate[{name}]: OK");
+    } else {
+        println!("    gate[{name}]: FAILED — DO NOT SHIP THIS SECTION");
+    }
+}
+
+// ─── §1 download FileDto dead clone ─────────────────────────────────────────
+
+/// Field-faithful replica of `FileDto` (`application/dtos/file_dto.rs`).
+#[derive(Clone)]
+#[allow(dead_code)]
+struct FileDtoRep {
+    id: String,
+    name: String,
+    path: String,
+    size: u64,
+    mime_type: Arc<str>,
+    folder_id: Option<String>,
+    created_at: u64,
+    modified_at: u64,
+    icon_class: Arc<str>,
+    icon_special_class: Arc<str>,
+    category: Arc<str>,
+    size_formatted: String,
+    sort_date: Option<u64>,
+    content_hash: String,
+    etag: String,
+    created_by: Option<uuid::Uuid>,
+    updated_by: Option<uuid::Uuid>,
+}
+
+fn sample_file_dto() -> FileDtoRep {
+    FileDtoRep {
+        id: "0198c9a0-1111-7abc-9def-0123456789ab".into(),
+        name: "IMG_20260716_193245.jpg".into(),
+        path: "/Photos/2026/07/IMG_20260716_193245.jpg".into(),
+        size: 4_183_212,
+        mime_type: Arc::from("image/jpeg"),
+        folder_id: Some("0198c9a0-2222-7abc-9def-0123456789ab".into()),
+        created_at: 1_784_500_000,
+        modified_at: 1_784_500_020,
+        icon_class: Arc::from("fas fa-file-image"),
+        icon_special_class: Arc::from("image-icon"),
+        category: Arc::from("Image"),
+        size_formatted: "3.99 MB".into(),
+        sort_date: None,
+        content_hash: "b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3".into(),
+        etag: "\"b3b3b3b3-1784500020\"".into(),
+        created_by: None,
+        updated_by: None,
+    }
+}
+
+/// The downstream service consumes the DTO (as `get_file_optimized_preloaded`
+/// does) and returns it (discarded by the handler as `_file`).
+#[inline(never)]
+fn service_consume(dto: FileDtoRep) -> (FileDtoRep, u64) {
+    let s = dto.size;
+    (dto, s)
+}
+
+fn section_1(iters: u64) {
+    println!("  §1 REST download FileDto hand-off (per download)");
+    let dto = sample_file_dto();
+
+    // The handler owns `file_dto` (fetched per request) in both shapes; the
+    // arms isolate ONLY the hand-off into `get_file_optimized_preloaded`.
+    // BEFORE: `file_dto.clone()` in, then read mime/size from the retained
+    // copy. AFTER: capture mime (Arc bump) + size, MOVE the DTO in.
+    measure("BEFORE dead clone into service", iters, || {
+        let (ret, _s) = service_consume(dto.clone());
+        drop(ret);
+        (dto.mime_type.clone(), dto.size)
+    });
+    measure("AFTER  capture mime/size + move", iters, || {
+        // Model the move without giving up the corpus DTO: production moves
+        // the request-owned value; the captures are the only per-call work.
+        let mime = dto.mime_type.clone();
+        let size = dto.size;
+        black_box((&dto, mime, size)).1
+    });
+}
+
+// ─── §2 Last-Modified header value ──────────────────────────────────────────
+
+fn section_2(iters: u64) {
+    println!("  §2 GET/HEAD Last-Modified render (per response)");
+    let ts: i64 = 1_784_500_020;
+
+    let before = chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0)
+        .unwrap_or_else(chrono::Utc::now)
+        .to_rfc2822();
+    let mut buf = [0u8; 31];
+    let after = oxicloud::common::fmt::rfc2822_utc(&mut buf, ts)
+        .map(str::to_owned)
+        .unwrap_or_default();
+    gate("rfc2822 bytes identical", before == after);
+
+    measure("BEFORE chrono to_rfc2822", iters, || {
+        chrono::DateTime::<chrono::Utc>::from_timestamp(black_box(ts), 0)
+            .unwrap_or_else(chrono::Utc::now)
+            .to_rfc2822()
+    });
+    measure("AFTER  fmt::rfc2822_utc + header alloc", iters, || {
+        let mut b = [0u8; 31];
+        oxicloud::common::fmt::rfc2822_utc(&mut b, black_box(ts))
+            .map(str::to_owned)
+            .unwrap_or_default()
+    });
+    measure("AFTER  fmt::rfc2822_utc stack only", iters, || {
+        let mut b = [0u8; 31];
+        oxicloud::common::fmt::rfc2822_utc(&mut b, black_box(ts)).map(|s| s.len())
+    });
+}
+
+// ─── §3 /status.php ─────────────────────────────────────────────────────────
+
+fn build_status_json(major: u32, minor: u32, patch: u32, version_string: &str) -> Vec<u8> {
+    let v = serde_json::json!({
+        "installed": true,
+        "maintenance": false,
+        "needsDbUpgrade": false,
+        "version": format!("{}.{}.{}.1", major, minor, patch),
+        "versionstring": version_string,
+        "productname": "OxiCloud",
+        "edition": ""
+    });
+    serde_json::to_vec(&v).expect("status json")
+}
+
+fn section_3(iters: u64) {
+    println!("  §3 /status.php poll (per request)");
+    let (maj, min, pat) = (31u32, 0u32, 0u32);
+    let vs = "31.0.0";
+
+    static CACHED: std::sync::OnceLock<bytes::Bytes> = std::sync::OnceLock::new();
+    let cached = CACHED.get_or_init(|| bytes::Bytes::from(build_status_json(maj, min, pat, vs)));
+    gate(
+        "status body identical",
+        cached.as_ref() == build_status_json(maj, min, pat, vs).as_slice(),
+    );
+
+    measure("BEFORE rebuild json! + serialize", iters, || {
+        build_status_json(black_box(maj), min, pat, black_box(vs))
+    });
+    measure("AFTER  OnceLock<Bytes> refcount bump", iters, || {
+        CACHED.get().unwrap().clone()
+    });
+}
+
+// ─── §4 NC chunk-upload session PROPFIND ────────────────────────────────────
+
+/// Replica of `uploads_handler::xml_escape` semantics (escape into owned
+/// String only when needed).
+fn xml_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '&' => out.push_str("&amp;"),
+            '<' => out.push_str("&lt;"),
+            '>' => out.push_str("&gt;"),
+            '"' => out.push_str("&quot;"),
+            '\'' => out.push_str("&apos;"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+struct ChunkRep {
+    name: String,
+    size: u64,
+    mtime: u64,
+}
+
+fn chunk_listing(n: usize) -> (String, u64, Vec<ChunkRep>) {
+    let chunks = (0..n)
+        .map(|i| ChunkRep {
+            name: format!("{:05}", i + 1),
+            size: 10 * 1024 * 1024,
+            mtime: 1_784_500_000 + i as u64,
+        })
+        .collect();
+    ("admin".to_string(), 1_784_500_000, chunks)
+}
+
+fn propfind_before(raw_username: &str, upload_id: &str, mtime: u64, chunks: &[ChunkRep]) -> String {
+    let session_href = format!("/remote.php/dav/uploads/{}/{}/", raw_username, upload_id);
+    let session_last_modified = chrono::DateTime::<chrono::Utc>::from_timestamp(mtime as i64, 0)
+        .unwrap_or_else(chrono::Utc::now)
+        .to_rfc2822();
+
+    let mut body = String::new();
+    body.push_str(r#"<?xml version="1.0" encoding="utf-8"?>"#);
+    body.push_str(r#"<d:multistatus xmlns:d="DAV:">"#);
+    body.push_str("<d:response>");
+    body.push_str(&format!("<d:href>{}</d:href>", xml_escape(&session_href)));
+    body.push_str("<d:propstat><d:prop>");
+    body.push_str("<d:resourcetype><d:collection/></d:resourcetype>");
+    body.push_str(&format!(
+        "<d:getlastmodified>{}</d:getlastmodified>",
+        xml_escape(&session_last_modified)
+    ));
+    body.push_str("</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>");
+    body.push_str("</d:response>");
+
+    for chunk in chunks {
+        let chunk_href = format!(
+            "/remote.php/dav/uploads/{}/{}/{}",
+            raw_username, upload_id, chunk.name
+        );
+        let chunk_modified = chrono::DateTime::<chrono::Utc>::from_timestamp(chunk.mtime as i64, 0)
+            .unwrap_or_else(chrono::Utc::now)
+            .to_rfc2822();
+
+        body.push_str("<d:response>");
+        body.push_str(&format!("<d:href>{}</d:href>", xml_escape(&chunk_href)));
+        body.push_str("<d:propstat><d:prop>");
+        body.push_str("<d:resourcetype/>");
+        body.push_str(&format!(
+            "<d:getcontentlength>{}</d:getcontentlength>",
+            chunk.size
+        ));
+        body.push_str(&format!(
+            "<d:getlastmodified>{}</d:getlastmodified>",
+            xml_escape(&chunk_modified)
+        ));
+        body.push_str("</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>");
+        body.push_str("</d:response>");
+    }
+
+    body.push_str("</d:multistatus>");
+    body
+}
+
+/// Emit a `<d:getlastmodified>` element with the stack renderer, falling
+/// back to chrono outside the 4-digit-year range (same fallback shape as
+/// `nextcloud/webdav_handler.rs`). RFC 2822 output contains no
+/// XML-special characters, so the escape pass is skipped by construction.
+fn write_lastmodified(body: &mut String, secs: i64) {
+    let mut b = [0u8; 31];
+    match oxicloud::common::fmt::rfc2822_utc(&mut b, secs) {
+        Some(s) => {
+            let _ = write!(body, "<d:getlastmodified>{}</d:getlastmodified>", s);
+        }
+        None => {
+            let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0)
+                .unwrap_or_else(chrono::Utc::now)
+                .to_rfc2822();
+            let _ = write!(
+                body,
+                "<d:getlastmodified>{}</d:getlastmodified>",
+                xml_escape(&dt)
+            );
+        }
+    }
+}
+
+fn propfind_after(raw_username: &str, upload_id: &str, mtime: u64, chunks: &[ChunkRep]) -> String {
+    let mut body = String::with_capacity(256 + chunks.len() * 256);
+    body.push_str(r#"<?xml version="1.0" encoding="utf-8"?>"#);
+    body.push_str(r#"<d:multistatus xmlns:d="DAV:">"#);
+    body.push_str("<d:response>");
+    let _ = write!(
+        body,
+        "<d:href>/remote.php/dav/uploads/{}/{}/</d:href>",
+        xml_escape(raw_username),
+        xml_escape(upload_id)
+    );
+    body.push_str("<d:propstat><d:prop>");
+    body.push_str("<d:resourcetype><d:collection/></d:resourcetype>");
+    write_lastmodified(&mut body, mtime as i64);
+    body.push_str("</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>");
+    body.push_str("</d:response>");
+
+    for chunk in chunks {
+        body.push_str("<d:response>");
+        let _ = write!(
+            body,
+            "<d:href>/remote.php/dav/uploads/{}/{}/{}</d:href>",
+            xml_escape(raw_username),
+            xml_escape(upload_id),
+            xml_escape(&chunk.name)
+        );
+        body.push_str("<d:propstat><d:prop>");
+        body.push_str("<d:resourcetype/>");
+        let _ = write!(
+            body,
+            "<d:getcontentlength>{}</d:getcontentlength>",
+            chunk.size
+        );
+        write_lastmodified(&mut body, chunk.mtime as i64);
+        body.push_str("</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>");
+        body.push_str("</d:response>");
+    }
+
+    body.push_str("</d:multistatus>");
+    body
+}
+
+fn section_4(iters: u64) {
+    println!("  §4 NC upload-session PROPFIND body (per PROPFIND)");
+    for n in [16usize, 256] {
+        let (user, mtime, chunks) = chunk_listing(n);
+        let b = propfind_before(&user, "web-file-upload-abc123", mtime, &chunks);
+        let a = propfind_after(&user, "web-file-upload-abc123", mtime, &chunks);
+        gate(&format!("xml identical ({n} chunks)"), a == b);
+        let it = (iters / n as u64).max(50);
+        measure(&format!("BEFORE push_str(&format!) {n} chunks"), it, || {
+            propfind_before(&user, "web-file-upload-abc123", mtime, black_box(&chunks))
+        });
+        measure(
+            &format!("AFTER  write! + capacity   {n} chunks"),
+            it,
+            || propfind_after(&user, "web-file-upload-abc123", mtime, black_box(&chunks)),
+        );
+    }
+}
+
+// ─── §5 RateLimiter ─────────────────────────────────────────────────────────
+
+fn section_5(iters: u64) {
+    println!("  §5 RateLimiter check_and_increment (per limited request)");
+    let cache_b: moka::sync::Cache<String, u32> = moka::sync::Cache::builder()
+        .time_to_live(std::time::Duration::from_secs(60))
+        .max_capacity(10_000)
+        .build();
+    let cache_a: moka::sync::Cache<String, u32> = moka::sync::Cache::builder()
+        .time_to_live(std::time::Duration::from_secs(60))
+        .max_capacity(10_000)
+        .build();
+    let ip = "203.0.113.42";
+
+    // Equivalence gate: identical counter sequences over a fresh key.
+    let seq_b: Vec<u32> = (0..5)
+        .map(|_| {
+            let c = cache_b
+                .entry(ip.to_string())
+                .or_insert_with(|| 0)
+                .into_value()
+                + 1;
+            cache_b.insert(ip.to_string(), c);
+            c
+        })
+        .collect();
+    let seq_a: Vec<u32> = (0..5)
+        .map(|_| {
+            cache_a
+                .entry(ip.to_string())
+                .and_upsert_with(|e| e.map(|v| v.into_value() + 1).unwrap_or(1))
+                .into_value()
+        })
+        .collect();
+    gate("counter sequence identical", seq_a == seq_b);
+    cache_a.invalidate(ip);
+    cache_b.invalidate(ip);
+
+    // Gate for the get+insert variant: identical counter sequence.
+    let cache_c: moka::sync::Cache<String, u32> = moka::sync::Cache::builder()
+        .time_to_live(std::time::Duration::from_secs(60))
+        .max_capacity(10_000)
+        .build();
+    let seq_c: Vec<u32> = (0..5)
+        .map(|_| {
+            let count = cache_c.get(ip).unwrap_or(0) + 1;
+            cache_c.insert(ip.to_string(), count);
+            count
+        })
+        .collect();
+    gate("get+insert sequence identical", seq_c == seq_b);
+    cache_c.invalidate(ip);
+
+    measure("BEFORE 2 allocs + entry+insert", iters, || {
+        let key = ip.to_string();
+        let count = cache_b.entry(key).or_insert_with(|| 0).into_value() + 1;
+        cache_b.insert(ip.to_string(), count);
+        count
+    });
+    measure("AFTER-1 and_upsert_with", iters, || {
+        cache_a
+            .entry(ip.to_string())
+            .and_upsert_with(|e| e.map(|v| v.into_value() + 1).unwrap_or(1))
+            .into_value()
+    });
+    measure("AFTER-2 lock-free get + insert", iters, || {
+        let count = cache_c.get(black_box(ip)).unwrap_or(0) + 1;
+        cache_c.insert(ip.to_string(), count);
+        count
+    });
+}
+
+// ─── §6 CSRF header token ───────────────────────────────────────────────────
+
+fn section_6(iters: u64) {
+    println!("  §6 CSRF token compare (per state-changing cookie request)");
+    let cookie_token = Some("9f8e7d6c5b4a39281706f5e4d3c2b1a0".to_string());
+    let header_val = "9f8e7d6c5b4a39281706f5e4d3c2b1a0";
+
+    let before = {
+        let header_token = Some(header_val).map(|s| s.to_string());
+        matches!((cookie_token.as_ref(), header_token.as_ref()),
+            (Some(c), Some(h)) if !c.is_empty() && c == h)
+    };
+    let after = {
+        let header_token: Option<&str> = Some(header_val);
+        matches!((cookie_token.as_ref(), header_token),
+            (Some(c), Some(h)) if !c.is_empty() && c == h)
+    };
+    gate("csrf verdict identical", before == after);
+
+    measure("BEFORE header to_string + compare", iters, || {
+        let header_token = Some(black_box(header_val)).map(|s| s.to_string());
+        matches!((cookie_token.as_ref(), header_token.as_ref()),
+            (Some(c), Some(h)) if !c.is_empty() && c == h)
+    });
+    measure("AFTER  borrow compare", iters, || {
+        let header_token: Option<&str> = Some(black_box(header_val));
+        matches!((cookie_token.as_ref(), header_token),
+            (Some(c), Some(h)) if !c.is_empty() && c == h)
+    });
+}
+
+// ─── §7 Thumbnail ETag ──────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+enum SizeRep {
+    Icon,
+    Preview,
+    Large,
+}
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+enum FormatRep {
+    Webp,
+    Jpeg,
+}
+impl SizeRep {
+    fn as_str(self) -> &'static str {
+        match self {
+            SizeRep::Icon => "Icon",
+            SizeRep::Preview => "Preview",
+            SizeRep::Large => "Large",
+        }
+    }
+}
+impl FormatRep {
+    fn as_str(self) -> &'static str {
+        match self {
+            FormatRep::Webp => "Webp",
+            FormatRep::Jpeg => "Jpeg",
+        }
+    }
+}
+
+fn section_7(iters: u64) {
+    println!("  §7 thumbnail ETag build (per thumbnail request)");
+    let id = "0198c9a0-1111-7abc-9def-0123456789ab";
+    let (sz, fm) = (SizeRep::Preview, FormatRep::Webp);
+
+    let before = format!("\"thumb-{}-{:?}-{:?}\"", id, sz, fm);
+    let after = {
+        let mut s = String::with_capacity(9 + id.len() + sz.as_str().len() + fm.as_str().len());
+        s.push_str("\"thumb-");
+        s.push_str(id);
+        s.push('-');
+        s.push_str(sz.as_str());
+        s.push('-');
+        s.push_str(fm.as_str());
+        s.push('"');
+        s
+    };
+    gate("etag bytes identical", before == after);
+
+    measure("BEFORE format! with {:?} enums", iters, || {
+        format!("\"thumb-{}-{:?}-{:?}\"", black_box(id), sz, fm)
+    });
+    measure("AFTER  as_str + sized push", iters, || {
+        let id = black_box(id);
+        let mut s = String::with_capacity(9 + id.len() + sz.as_str().len() + fm.as_str().len());
+        s.push_str("\"thumb-");
+        s.push_str(id);
+        s.push('-');
+        s.push_str(sz.as_str());
+        s.push('-');
+        s.push_str(fm.as_str());
+        s.push('"');
+        s
+    });
+}
+
+// ─── §8 recent-handler id round-trip ────────────────────────────────────────
+
+fn section_8(iters: u64) {
+    println!("  §8 recent-handler item_id hand-off (per record/remove)");
+    let id = uuid::Uuid::parse_str("0198c9a0-1111-7abc-9def-0123456789ab").unwrap();
+
+    let before = id.to_string();
+    let mut buf = [0u8; 36];
+    let after: &str = id.as_hyphenated().encode_lower(&mut buf);
+    gate("id str identical", before == after);
+
+    measure("BEFORE Uuid::to_string per call", iters, || {
+        let s = black_box(id).to_string();
+        s.len()
+    });
+    measure("AFTER  stack encode_lower", iters, || {
+        let mut b = [0u8; 36];
+        let s: &str = black_box(id).as_hyphenated().encode_lower(&mut b);
+        s.len()
+    });
+}
+
+// ─── §9 4xx error body ──────────────────────────────────────────────────────
+
+#[derive(serde::Serialize)]
+struct ErrorResponseOwned {
+    status: String,
+    error: String,
+    message: String,
+    error_type: String,
+}
+
+#[derive(serde::Serialize)]
+struct ErrorResponseBorrowed<'a> {
+    status: &'a str,
+    error: &'a str,
+    message: &'a str,
+    error_type: &'static str,
+}
+
+fn section_9(iters: u64) {
+    println!("  §9 4xx error response build (per 404/401/403)");
+    // Model: DomainError::not_found("File", id) → AppError → into_response.
+    let entity = "File";
+    let id = "0198c9a0-1111-7abc-9def-0123456789ab";
+    let status = axum::http::StatusCode::NOT_FOUND;
+
+    let before_bytes = {
+        // not_found: id.clone() + eager format!
+        let idc = id.to_string();
+        let _entity_id = Some(idc.clone());
+        let message = format!("{} not found: {}", entity, idc);
+        // From<DomainError>: kind.to_string()
+        let error_type = "Not Found".to_string();
+        // into_response: status.to_string() + message.clone()
+        let body = ErrorResponseOwned {
+            status: status.to_string(),
+            error: message.clone(),
+            message,
+            error_type,
+        };
+        serde_json::to_vec(&body).unwrap()
+    };
+    let after_bytes = {
+        let idc = id.to_string();
+        let message = format!("{} not found: {}", entity, idc);
+        let _entity_id = Some(idc);
+        let status_s = status.to_string();
+        let body = ErrorResponseBorrowed {
+            status: &status_s,
+            error: &message,
+            message: &message,
+            error_type: "Not Found",
+        };
+        serde_json::to_vec(&body).unwrap()
+    };
+    gate("error JSON identical", before_bytes == after_bytes);
+
+    measure("BEFORE clones + owned serialize", iters, || {
+        let idc = black_box(id).to_string();
+        let _entity_id = Some(idc.clone());
+        let message = format!("{} not found: {}", black_box(entity), idc);
+        let error_type = "Not Found".to_string();
+        let body = ErrorResponseOwned {
+            status: status.to_string(),
+            error: message.clone(),
+            message,
+            error_type,
+        };
+        serde_json::to_vec(&body).unwrap()
+    });
+    measure("AFTER  move + borrowed serialize", iters, || {
+        let idc = black_box(id).to_string();
+        let message = format!("{} not found: {}", black_box(entity), idc);
+        let _entity_id = Some(idc);
+        let status_s = status.to_string();
+        let body = ErrorResponseBorrowed {
+            status: &status_s,
+            error: &message,
+            message: &message,
+            error_type: "Not Found",
+        };
+        serde_json::to_vec(&body).unwrap()
+    });
+}
+
+// ─── §10 vCard emit ─────────────────────────────────────────────────────────
+
+struct ContactRep {
+    full_name: String,
+    first: String,
+    last: String,
+    email_home: String,
+    email_work: String,
+    phone: String,
+    org: String,
+    title: String,
+    uid: String,
+}
+
+fn sample_contact() -> ContactRep {
+    ContactRep {
+        full_name: "Ada Lovelace".into(),
+        first: "Ada".into(),
+        last: "Lovelace".into(),
+        email_home: "ada@example.org".into(),
+        email_work: "ada@analytical.engines".into(),
+        phone: "+44 20 7946 0958".into(),
+        org: "Analytical Engines Ltd".into(),
+        title: "Chief Mathematician".into(),
+        uid: "0198c9a0-3333-7abc-9def-0123456789ab".into(),
+    }
+}
+
+fn vcard_before(c: &ContactRep) -> String {
+    let mut vcard = String::from("BEGIN:VCARD\r\nVERSION:3.0\r\n");
+    vcard.push_str(&format!("FN:{}\r\n", c.full_name));
+    vcard.push_str(&format!("N:{};{};;;\r\n", c.last, c.first));
+    vcard.push_str(&format!("EMAIL;TYPE=HOME:{}\r\n", c.email_home));
+    vcard.push_str(&format!("EMAIL;TYPE=WORK:{}\r\n", c.email_work));
+    vcard.push_str(&format!("TEL;TYPE=CELL:{}\r\n", c.phone));
+    vcard.push_str(&format!("ORG:{}\r\n", c.org));
+    vcard.push_str(&format!("TITLE:{}\r\n", c.title));
+    vcard.push_str(&format!("UID:{}\r\n", c.uid));
+    vcard.push_str("END:VCARD\r\n");
+    vcard
+}
+
+fn vcard_after(c: &ContactRep) -> String {
+    let mut vcard = String::from("BEGIN:VCARD\r\nVERSION:3.0\r\n");
+    let _ = write!(vcard, "FN:{}\r\n", c.full_name);
+    let _ = write!(vcard, "N:{};{};;;\r\n", c.last, c.first);
+    let _ = write!(vcard, "EMAIL;TYPE=HOME:{}\r\n", c.email_home);
+    let _ = write!(vcard, "EMAIL;TYPE=WORK:{}\r\n", c.email_work);
+    let _ = write!(vcard, "TEL;TYPE=CELL:{}\r\n", c.phone);
+    let _ = write!(vcard, "ORG:{}\r\n", c.org);
+    let _ = write!(vcard, "TITLE:{}\r\n", c.title);
+    let _ = write!(vcard, "UID:{}\r\n", c.uid);
+    vcard.push_str("END:VCARD\r\n");
+    vcard
+}
+
+fn section_10(iters: u64) {
+    println!("  §10 vCard emit (per contact create/update)");
+    let c = sample_contact();
+    gate("vcard bytes identical", vcard_before(&c) == vcard_after(&c));
+    measure("BEFORE push_str(&format!) per line", iters, || {
+        vcard_before(black_box(&c))
+    });
+    measure("AFTER  write! per line", iters, || {
+        vcard_after(black_box(&c))
+    });
+}
+
+// ─── §11 search page slice ──────────────────────────────────────────────────
+
+#[derive(Clone, PartialEq, Debug)]
+#[allow(dead_code)]
+struct SearchHitRep {
+    id: String,
+    name: String,
+    path: String,
+    etag: String,
+    content_hash: String,
+    size_formatted: String,
+    size: u64,
+}
+
+fn search_corpus(n: usize) -> Vec<SearchHitRep> {
+    (0..n)
+        .map(|i| SearchHitRep {
+            id: format!("0198c9a0-1111-7abc-9def-{:012}", i),
+            name: format!("Informe anual {i}.pdf"),
+            path: format!("/Documentos/2026/Informe anual {i}.pdf"),
+            etag: format!("\"e{i}-1784500020\""),
+            content_hash: "b3".repeat(32),
+            size_formatted: "1.24 MB".into(),
+            size: 1_300_000 + i as u64,
+        })
+        .collect()
+}
+
+fn section_11(iters: u64) {
+    println!("  §11 search page extraction (per uncached query, 50-item page)");
+    let full = search_corpus(400);
+    let (start, end) = (100usize, 150usize);
+
+    let before_page = full[start..end].to_vec();
+    let after_page: Vec<SearchHitRep> = {
+        let own = full.clone();
+        own.into_iter().skip(start).take(end - start).collect()
+    };
+    gate("page contents identical", before_page == after_page);
+
+    // Both arms pay the identical own-clone (the service owns the enriched
+    // vec in production); the delta is page extraction: deep-clone the
+    // slice + drop the whole vec, vs consume the vec moving the page out.
+    let it = (iters / 50).max(100);
+    measure("BEFORE slice.to_vec() (clones page)", it, || {
+        let own = full.clone();
+        let page = own[start..end].to_vec();
+        (own.len(), page)
+    });
+    measure("AFTER  into_iter skip/take (moves)", it, || {
+        let own = full.clone();
+        let n = own.len();
+        let page: Vec<SearchHitRep> = own.into_iter().skip(start).take(end - start).collect();
+        (n, page)
+    });
+}
+
+// ─── §12 content-hit double parse ───────────────────────────────────────────
+
+fn section_12(iters: u64) {
+    println!("  §12 content-hit verify loop (per content search, 100 hits)");
+    let hits: Vec<String> = (0..100)
+        .map(|i| format!("0198c9a0-1111-7abc-9def-{:012}", i))
+        .collect();
+    let allowed: std::collections::HashSet<uuid::Uuid> = hits
+        .iter()
+        .step_by(2)
+        .map(|s| uuid::Uuid::parse_str(s).unwrap())
+        .collect();
+
+    let before: Vec<&String> = {
+        let mut ids = Vec::with_capacity(hits.len());
+        for h in &hits {
+            if let Ok(u) = uuid::Uuid::parse_str(h) {
+                ids.push(u);
+            }
+        }
+        hits.iter()
+            .filter(|h| {
+                uuid::Uuid::parse_str(h)
+                    .map(|u| allowed.contains(&u))
+                    .unwrap_or(false)
+            })
+            .collect()
+    };
+    let after: Vec<&String> = {
+        let pairs: Vec<(&String, uuid::Uuid)> = hits
+            .iter()
+            .filter_map(|h| uuid::Uuid::parse_str(h).ok().map(|u| (h, u)))
+            .collect();
+        pairs
+            .iter()
+            .filter(|(_, u)| allowed.contains(u))
+            .map(|(h, _)| *h)
+            .collect()
+    };
+    gate("verified set identical", before == after);
+
+    let it = (iters / 100).max(100);
+    measure("BEFORE parse twice per hit", it, || {
+        let mut ids = Vec::with_capacity(hits.len());
+        for h in &hits {
+            if let Ok(u) = uuid::Uuid::parse_str(h) {
+                ids.push(u);
+            }
+        }
+        black_box(&ids);
+        let v: Vec<&String> = hits
+            .iter()
+            .filter(|h| {
+                uuid::Uuid::parse_str(h)
+                    .map(|u| allowed.contains(&u))
+                    .unwrap_or(false)
+            })
+            .collect();
+        v.len()
+    });
+    measure("AFTER  parse once, carry pairs", it, || {
+        let pairs: Vec<(&String, uuid::Uuid)> = hits
+            .iter()
+            .filter_map(|h| uuid::Uuid::parse_str(h).ok().map(|u| (h, u)))
+            .collect();
+        let ids: Vec<uuid::Uuid> = pairs.iter().map(|(_, u)| *u).collect();
+        black_box(&ids);
+        let v: Vec<&String> = pairs
+            .iter()
+            .filter(|(_, u)| allowed.contains(u))
+            .map(|(h, _)| *h)
+            .collect();
+        v.len()
+    });
+}
+
+// ─── §13 group last-user containment ────────────────────────────────────────
+
+fn section_13(iters: u64) {
+    println!("  §13 group last-user check (per group edit, 500×500)");
+    let before_users: Vec<uuid::Uuid> = (0..500).map(|_| uuid::Uuid::new_v4()).collect();
+    let mut child_users = before_users.clone();
+    child_users.rotate_left(250);
+
+    let b = before_users.iter().all(|u| child_users.contains(u));
+    let set: std::collections::HashSet<&uuid::Uuid> = child_users.iter().collect();
+    let a = before_users.iter().all(|u| set.contains(u));
+    gate("verdict identical", a == b);
+
+    let it = (iters / 500).max(50);
+    measure("BEFORE O(N·M) slice contains", it, || {
+        before_users
+            .iter()
+            .all(|u| black_box(&child_users).contains(u))
+    });
+    measure("AFTER  HashSet build + probe", it, || {
+        let s: std::collections::HashSet<&uuid::Uuid> = black_box(&child_users).iter().collect();
+        before_users.iter().all(|u| s.contains(u))
+    });
+}
+
+// ─── §14 retry label ────────────────────────────────────────────────────────
+
+fn retry_sync_before(name: &str, f: impl Fn() -> u64) -> u64 {
+    // success path: label was allocated by the caller, never read
+    black_box(name);
+    f()
+}
+fn retry_sync_after(_name: impl Fn() -> String, f: impl Fn() -> u64) -> u64 {
+    f()
+}
+
+fn section_14(iters: u64) {
+    println!("  §14 retry op-label (per blob op, success path)");
+    let hash = "b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3b3";
+    measure("BEFORE eager format! label", iters, || {
+        retry_sync_before(&format!("get_blob_stream({})", black_box(hash)), || 7)
+    });
+    measure("AFTER  lazy closure label", iters, || {
+        retry_sync_after(|| format!("get_blob_stream({})", black_box(hash)), || 7)
+    });
+}
+
+// ─── §15/16 encrypted backend ───────────────────────────────────────────────
+
+fn section_15_16(iters: u64) {
+    use aes_gcm::aead::{Aead, AeadInPlace, KeyInit};
+    use aes_gcm::{Aes256Gcm, Nonce};
+
+    println!("  §15 encrypt_bytes (per encrypted chunk write, 256 KiB)");
+    const NONCE_SIZE: usize = 12;
+    let key = [7u8; 32];
+    let cipher = Aes256Gcm::new_from_slice(&key).unwrap();
+    let data = vec![0xA5u8; 256 * 1024];
+    let nonce_fixed = [9u8; 12];
+    let nonce = Nonce::from_slice(&nonce_fixed);
+
+    // BEFORE: cipher.encrypt allocates ciphertext; copied again after nonce.
+    let before_out = {
+        let ciphertext = cipher.encrypt(nonce, data.as_slice()).unwrap();
+        let mut encrypted = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
+        encrypted.extend_from_slice(&nonce_fixed);
+        encrypted.extend_from_slice(&ciphertext);
+        encrypted
+    };
+    // AFTER: single buffer, in-place detached encrypt, append tag.
+    let after_out = {
+        let mut out = Vec::with_capacity(NONCE_SIZE + data.len() + 16);
+        out.extend_from_slice(&nonce_fixed);
+        out.extend_from_slice(&data);
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut out[NONCE_SIZE..])
+            .unwrap();
+        out.extend_from_slice(&tag);
+        out
+    };
+    gate(
+        "ciphertext identical (fixed nonce)",
+        before_out == after_out,
+    );
+    // Round-trip through the decrypt shape used in production.
+    let rt = {
+        let mut enc = after_out.clone();
+        let ct = enc.split_off(NONCE_SIZE);
+        let n = Nonce::from_slice(&enc);
+        let mut ct = ct;
+        cipher.decrypt_in_place(n, b"", &mut ct).unwrap();
+        ct
+    };
+    gate("decrypt round-trip", rt == data);
+
+    let it = (iters / 100).max(200);
+    measure("BEFORE encrypt + second copy", it, || {
+        let ciphertext = cipher.encrypt(nonce, black_box(data.as_slice())).unwrap();
+        let mut encrypted = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
+        encrypted.extend_from_slice(&nonce_fixed);
+        encrypted.extend_from_slice(&ciphertext);
+        encrypted
+    });
+    measure("AFTER  in-place detached", it, || {
+        let data = black_box(data.as_slice());
+        let mut out = Vec::with_capacity(NONCE_SIZE + data.len() + 16);
+        out.extend_from_slice(&nonce_fixed);
+        out.extend_from_slice(data);
+        let tag = cipher
+            .encrypt_in_place_detached(nonce, b"", &mut out[NONCE_SIZE..])
+            .unwrap();
+        out.extend_from_slice(&tag);
+        out
+    });
+
+    println!("  §16 collect_stream buffer growth (1 MiB blob, 4 KiB frames)");
+    let frames: Vec<Vec<u8>> = (0..256).map(|i| vec![i as u8; 4096]).collect();
+    let expect: Vec<u8> = frames.iter().flatten().copied().collect();
+
+    let before_buf = {
+        let mut buf = Vec::new();
+        for f in &frames {
+            buf.extend_from_slice(f);
+        }
+        buf
+    };
+    let after_buf = {
+        let mut buf: Vec<u8> = Vec::new();
+        for f in &frames {
+            if buf.capacity() == 0 {
+                buf.reserve(1024 * 1024 + 28);
+            }
+            buf.extend_from_slice(f);
+        }
+        buf
+    };
+    gate(
+        "collected bytes identical",
+        before_buf == expect && after_buf == expect,
+    );
+
+    let it = (iters / 100).max(200);
+    measure("BEFORE Vec::new() growth", it, || {
+        let mut buf = Vec::new();
+        for f in black_box(&frames) {
+            buf.extend_from_slice(f);
+        }
+        buf
+    });
+    measure("AFTER  reserve on first frame", it, || {
+        let mut buf: Vec<u8> = Vec::new();
+        for f in black_box(&frames) {
+            if buf.capacity() == 0 {
+                buf.reserve(1024 * 1024 + 28);
+            }
+            buf.extend_from_slice(f);
+        }
+        buf
+    });
+}
+
+// ─── §17 cosine norms ───────────────────────────────────────────────────────
+
+fn cosine_before(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let (mut dot, mut na, mut nb) = (0.0f32, 0.0f32, 0.0f32);
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+/// AFTER: norms precomputed once per face (same accumulation order), the
+/// pair loop keeps only the dot product. The final expression keeps the
+/// exact `dot / (sqrt(na) * sqrt(nb))` arithmetic, so results are
+/// bit-identical to the BEFORE.
+fn norm_sq(v: &[f32]) -> f32 {
+    let mut n = 0.0f32;
+    for &x in v {
+        n += x * x;
+    }
+    n
+}
+fn cosine_after(a: &[f32], b: &[f32], na: f32, nb: f32) -> f32 {
+    if a.len() != b.len() || a.is_empty() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    for (&x, &y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+fn section_17(iters: u64) {
+    println!("  §17 recluster cosine pass (200 faces × 512-dim)");
+    let n = 200usize;
+    let mut state = 0x12345678u64;
+    let mut next = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        (state % 2000) as f32 / 1000.0 - 1.0
+    };
+    let faces: Vec<Vec<f32>> = (0..n).map(|_| (0..512).map(|_| next()).collect()).collect();
+
+    // Gate: bit-identical similarity over every pair.
+    let norms: Vec<f32> = faces.iter().map(|f| norm_sq(f)).collect();
+    let mut identical = true;
+    for i in 0..n {
+        for j in (i + 1)..n {
+            let b = cosine_before(&faces[i], &faces[j]);
+            let a = cosine_after(&faces[i], &faces[j], norms[i], norms[j]);
+            if a.to_bits() != b.to_bits() {
+                identical = false;
+            }
+        }
+    }
+    gate("similarity bit-identical (all pairs)", identical);
+
+    let it = (iters / 20_000).max(3);
+    measure("BEFORE per-pair norms", it, || {
+        let mut acc = 0.0f32;
+        for i in 0..n {
+            for j in (i + 1)..n {
+                acc += cosine_before(black_box(&faces[i]), &faces[j]);
+            }
+        }
+        acc
+    });
+    measure("AFTER  precomputed norms", it, || {
+        let norms: Vec<f32> = faces.iter().map(|f| norm_sq(f)).collect();
+        let mut acc = 0.0f32;
+        for i in 0..n {
+            for j in (i + 1)..n {
+                acc += cosine_after(black_box(&faces[i]), &faces[j], norms[i], norms[j]);
+            }
+        }
+        acc
+    });
+}
+
+// ─── §18 /openapi.json ──────────────────────────────────────────────────────
+
+fn section_18(iters: u64) {
+    println!("  §18 /openapi.json (per request)");
+    use utoipa::OpenApi as _;
+    let built = oxicloud::interfaces::api::ApiDoc::openapi();
+    let baseline = serde_json::to_vec(&built).unwrap();
+
+    static SPEC: std::sync::OnceLock<bytes::Bytes> = std::sync::OnceLock::new();
+    let cached = SPEC.get_or_init(|| {
+        bytes::Bytes::from(
+            serde_json::to_vec(&oxicloud::interfaces::api::ApiDoc::openapi()).unwrap(),
+        )
+    });
+    gate(
+        "spec bytes identical",
+        cached.as_ref() == baseline.as_slice(),
+    );
+    println!("    (spec size: {} KiB)", baseline.len() / 1024);
+
+    let it = (iters / 2000).max(20);
+    measure("BEFORE rebuild ApiDoc + serialize", it, || {
+        serde_json::to_vec(&oxicloud::interfaces::api::ApiDoc::openapi())
+            .unwrap()
+            .len()
+    });
+    measure("AFTER  OnceLock<Bytes> bump", iters, || {
+        SPEC.get().unwrap().clone().len()
+    });
+}
+
+// ─── §19 CalendarEventDto move ──────────────────────────────────────────────
+
+#[allow(dead_code)]
+struct EventRep {
+    id: uuid::Uuid,
+    calendar_id: uuid::Uuid,
+    summary: String,
+    description: Option<String>,
+    location: Option<String>,
+    start: i64,
+    end: i64,
+    all_day: bool,
+    rrule: Option<String>,
+    ical_uid: String,
+    ical_data: String,
+}
+
+#[allow(dead_code)]
+struct EventDtoRep {
+    id: String,
+    calendar_id: String,
+    summary: String,
+    description: Option<String>,
+    location: Option<String>,
+    start: i64,
+    end: i64,
+    all_day: bool,
+    rrule: Option<String>,
+    ical_uid: String,
+    ical_data: String,
+}
+
+fn sample_event(ical_kb: usize) -> EventRep {
+    EventRep {
+        id: uuid::Uuid::new_v4(),
+        calendar_id: uuid::Uuid::new_v4(),
+        summary: "Reunión trimestral de resultados".into(),
+        description: Some("Orden del día: revisión de métricas, hoja de ruta.".into()),
+        location: Some("Sala Turing, 3ª planta".into()),
+        start: 1_784_500_000,
+        end: 1_784_503_600,
+        all_day: false,
+        rrule: Some("FREQ=MONTHLY;BYDAY=1MO".into()),
+        ical_uid: "evt-0198c9a0@oxicloud".into(),
+        ical_data: format!(
+            "BEGIN:VEVENT\r\nUID:evt@x\r\nSUMMARY:Reunión\r\n{}END:VEVENT\r\n",
+            "ATTENDEE;CN=Persona;PARTSTAT=ACCEPTED:mailto:p@example.org\r\n".repeat(ical_kb * 16)
+        ),
+    }
+}
+
+fn dto_before(e: &EventRep) -> EventDtoRep {
+    EventDtoRep {
+        id: e.id.to_string(),
+        calendar_id: e.calendar_id.to_string(),
+        summary: e.summary.as_str().to_string(),
+        description: e.description.as_deref().map(|s| s.to_string()),
+        location: e.location.as_deref().map(|s| s.to_string()),
+        start: e.start,
+        end: e.end,
+        all_day: e.all_day,
+        rrule: e.rrule.as_deref().map(|s| s.to_string()),
+        ical_uid: e.ical_uid.as_str().to_string(),
+        ical_data: e.ical_data.as_str().to_string(),
+    }
+}
+
+fn dto_after(e: EventRep) -> EventDtoRep {
+    EventDtoRep {
+        id: e.id.to_string(),
+        calendar_id: e.calendar_id.to_string(),
+        summary: e.summary,
+        description: e.description,
+        location: e.location,
+        start: e.start,
+        end: e.end,
+        all_day: e.all_day,
+        rrule: e.rrule,
+        ical_uid: e.ical_uid,
+        ical_data: e.ical_data,
+    }
+}
+
+fn section_19(iters: u64) {
+    println!("  §19 CalendarEventDto::from (per event, 11 KiB ical_data)");
+    let ev = sample_event(11);
+    let b = dto_before(&ev);
+    let a = dto_after(sample_event_clone(&ev));
+    gate(
+        "dto fields identical",
+        b.summary == a.summary && b.ical_data == a.ical_data && b.id == a.id,
+    );
+
+    let it = (iters / 20).max(500);
+    measure("BEFORE getter clones (11 KiB copy)", it, || {
+        // model: adapter owns the entity (fetched row), converts, drops it
+        let owned = sample_event_clone(&ev);
+        let dto = dto_before(&owned);
+        drop(owned);
+        dto.ical_data.len()
+    });
+    measure("AFTER  into_parts move", it, || {
+        let owned = sample_event_clone(&ev);
+        let dto = dto_after(owned);
+        dto.ical_data.len()
+    });
+}
+
+fn sample_event_clone(e: &EventRep) -> EventRep {
+    EventRep {
+        id: e.id,
+        calendar_id: e.calendar_id,
+        summary: e.summary.clone(),
+        description: e.description.clone(),
+        location: e.location.clone(),
+        start: e.start,
+        end: e.end,
+        all_day: e.all_day,
+        rrule: e.rrule.clone(),
+        ical_uid: e.ical_uid.clone(),
+        ical_data: e.ical_data.clone(),
+    }
+}
+
+// ─── §20 StoragePath row materialization ────────────────────────────────────
+
+/// BEFORE replica: `StoragePath { segments: Vec<String> }` +
+/// `from_folder_and_name` building joined AND per-segment Strings, with the
+/// entity retaining BOTH `storage_path` and `path_string` (the current
+/// shipped shape).
+mod sp_before {
+    pub struct StoragePathRep {
+        pub segments: Vec<String>,
+    }
+    fn is_safe(s: &str) -> bool {
+        !s.is_empty() && s != "." && s != ".." && !s.contains('/')
+    }
+    pub fn from_folder_and_name(
+        folder_path: Option<&str>,
+        file_name: &str,
+    ) -> (StoragePathRep, String) {
+        let fp = folder_path.unwrap_or("");
+        let mut joined = String::with_capacity(fp.len() + file_name.len() + 2);
+        let mut segments: Vec<String> =
+            Vec::with_capacity(fp.bytes().filter(|&b| b == b'/').count() + 2);
+        for seg in fp
+            .split('/')
+            .chain(file_name.split('/'))
+            .filter(|s| is_safe(s))
+        {
+            joined.push('/');
+            joined.push_str(seg);
+            segments.push(seg.to_string());
+        }
+        if segments.is_empty() {
+            joined.push('/');
+        }
+        (StoragePathRep { segments }, joined)
+    }
+    pub struct EntityRep {
+        pub storage_path: StoragePathRep,
+        pub path_string: String,
+        #[allow(dead_code)]
+        pub name: String,
+    }
+    impl EntityRep {
+        pub fn file_name(&self) -> Option<String> {
+            self.storage_path.segments.last().cloned()
+        }
+        pub fn display(&self) -> String {
+            if self.storage_path.segments.is_empty() {
+                return "/".to_string();
+            }
+            let mut s = String::new();
+            for seg in &self.storage_path.segments {
+                s.push('/');
+                s.push_str(seg);
+            }
+            s
+        }
+    }
+}
+
+/// AFTER shape: canonical joined `String` only; segments derived on demand.
+mod sp_after {
+    pub struct StoragePathRep {
+        joined: String,
+    }
+    fn is_safe(s: &str) -> bool {
+        !s.is_empty() && s != "." && s != ".." && !s.contains('/')
+    }
+    impl StoragePathRep {
+        pub fn from_folder_and_name(folder_path: Option<&str>, file_name: &str) -> Self {
+            let fp = folder_path.unwrap_or("");
+            let mut joined = String::with_capacity(fp.len() + file_name.len() + 2);
+            for seg in fp
+                .split('/')
+                .chain(file_name.split('/'))
+                .filter(|s| is_safe(s))
+            {
+                joined.push('/');
+                joined.push_str(seg);
+            }
+            if joined.is_empty() {
+                joined.push('/');
+            }
+            Self { joined }
+        }
+        pub fn as_joined(&self) -> &str {
+            &self.joined
+        }
+        pub fn into_joined(self) -> String {
+            self.joined
+        }
+        pub fn file_name(&self) -> Option<String> {
+            if self.joined == "/" {
+                None
+            } else {
+                self.joined.rsplit('/').next().map(str::to_string)
+            }
+        }
+    }
+    pub struct EntityRep {
+        pub storage_path: StoragePathRep,
+        #[allow(dead_code)]
+        pub name: String,
+    }
+    impl EntityRep {
+        pub fn file_name(&self) -> Option<String> {
+            self.storage_path.file_name()
+        }
+        pub fn display(&self) -> String {
+            self.storage_path.as_joined().to_string()
+        }
+    }
+}
+
+fn section_20(iters: u64) {
+    println!("  §20 row → entity path materialization (500-row page, depth 4)");
+    let rows: Vec<(String, String)> = (0..500)
+        .map(|i| {
+            (
+                format!("/Fotos/2026/Julio/Viaje a la sierra {}", i % 7),
+                format!("IMG_2026{:04}.jpg", i),
+            )
+        })
+        .collect();
+
+    // Equivalence gates across representations.
+    let mut ok_path = true;
+    let mut ok_name = true;
+    let mut ok_disp = true;
+    for (fp, name) in &rows {
+        let (bsp, bjoined) = sp_before::from_folder_and_name(Some(fp), name);
+        let be = sp_before::EntityRep {
+            storage_path: bsp,
+            path_string: bjoined,
+            name: name.clone(),
+        };
+        let asp = sp_after::StoragePathRep::from_folder_and_name(Some(fp), name);
+        let ae = sp_after::EntityRep {
+            storage_path: asp,
+            name: name.clone(),
+        };
+        ok_path &= be.path_string == ae.storage_path.as_joined();
+        ok_name &= be.file_name() == ae.file_name();
+        ok_disp &= be.display() == ae.display();
+    }
+    gate("path_string identical", ok_path);
+    gate("file_name identical", ok_name);
+    gate("display identical", ok_disp);
+
+    let it = (iters / 500).max(100);
+    measure("BEFORE joined + Vec<String> + dup", it, || {
+        let mut total = 0usize;
+        for (fp, name) in black_box(&rows) {
+            let (sp, joined) = sp_before::from_folder_and_name(Some(fp), name);
+            let e = sp_before::EntityRep {
+                storage_path: sp,
+                path_string: joined,
+                name: name.clone(),
+            };
+            // DTO consumes the joined string (moved), segments dropped.
+            let dto_path = e.path_string;
+            total += dto_path.len();
+        }
+        total
+    });
+    measure("AFTER  single canonical String", it, || {
+        let mut total = 0usize;
+        for (fp, name) in black_box(&rows) {
+            let sp = sp_after::StoragePathRep::from_folder_and_name(Some(fp), name);
+            let e = sp_after::EntityRep {
+                storage_path: sp,
+                name: name.clone(),
+            };
+            let dto_path = e.storage_path.into_joined();
+            total += dto_path.len();
+        }
+        total
+    });
+}
+
+// ─── §21 display classifier fusion ──────────────────────────────────────────
+
+fn section_21(iters: u64) {
+    use oxicloud::application::dtos::display_helpers::{
+        category_for, classify_display, icon_class_for, icon_special_class_for,
+    };
+    println!("  §21 display triple-classify (per listing row)");
+
+    // Corpus spanning: specific MIME, prefix MIME, octet-stream + ext
+    // fallback (lower/UPPER), no-ext, >16-byte ext, non-ASCII ext, dotfile.
+    let corpus: &[(&str, &str)] = &[
+        ("IMG_2026.JPG", "image/jpeg"),
+        ("informe.pdf", "application/pdf"),
+        ("main.rs", "application/octet-stream"),
+        ("ARCHIVO.TXT", ""),
+        ("setup.AppImage", "application/octet-stream"),
+        ("video.mkv", "video/x-matroska"),
+        ("script.PY", ""),
+        ("no_extension", "application/octet-stream"),
+        ("weird.extensionlongerthansixteen", ""),
+        ("acentuado.ñml", ""),
+        (".bashrc", "text/plain"),
+        ("data.json", "application/json"),
+        ("song.FLAC", "application/octet-stream"),
+    ];
+
+    // Gate 1: fused output identical to the three public classifiers.
+    let mut ok = true;
+    for (name, mime) in corpus {
+        let c = classify_display(name, mime);
+        ok &= c.icon_class == icon_class_for(name, mime)
+            && c.icon_special_class == icon_special_class_for(name, mime)
+            && c.category == category_for(name, mime);
+    }
+    gate("fused == three classifiers (corpus)", ok);
+    // Gate 2: the historical heap-lowered ext hits the same arms — for
+    // ≤16-byte exts the stack lowering equals `to_ascii_lowercase()`; a
+    // >16-byte ext must land on the same defaults the old `_` arms gave.
+    let long = classify_display("weird.extensionlongerthansixteen", "");
+    gate(
+        "long-ext defaults match old `_` arms",
+        long.icon_class == "fas fa-file"
+            && long.icon_special_class.is_empty()
+            && long.category == "Document",
+    );
+
+    // BEFORE replica: per-classifier ext_of + heap to_ascii_lowercase (the
+    // shipped trees are shared, so the delta measured is exactly the
+    // plumbing the fusion removed).
+    fn ext_of(name: &str) -> Option<&str> {
+        let name = name.rsplit('/').next().unwrap_or(name);
+        let after_dot = name.rsplit('.').next()?;
+        if after_dot.len() == name.len() || after_dot.is_empty() {
+            return None;
+        }
+        Some(after_dot)
+    }
+
+    let it = (iters / 10).max(1000);
+    measure("BEFORE 3× classify (heap ext on fallback)", it, || {
+        let mut acc = 0usize;
+        for (name, mime) in corpus {
+            // The pre-fusion code heap-lowercased the ext INSIDE each
+            // classifier, but only on rows that fell through to the
+            // extension fallback (generic/empty MIME) — replicate exactly
+            // that alloc profile next to the shared decision trees.
+            let falls_back = mime.is_empty() || *mime == "application/octet-stream";
+            if falls_back {
+                let _l = ext_of(name).map(|e| e.to_ascii_lowercase());
+            }
+            let a = icon_class_for(name, mime);
+            if falls_back {
+                let _l = ext_of(name).map(|e| e.to_ascii_lowercase());
+            }
+            let b = icon_special_class_for(name, mime);
+            if falls_back {
+                let _l = ext_of(name).map(|e| e.to_ascii_lowercase());
+            }
+            let c = category_for(name, mime);
+            acc += a.len() + b.len() + c.len();
+        }
+        acc
+    });
+    measure("AFTER  fused classify_display", it, || {
+        let mut acc = 0usize;
+        for (name, mime) in corpus {
+            let c = classify_display(name, mime);
+            acc += c.icon_class.len() + c.icon_special_class.len() + c.category.len();
+        }
+        acc
+    });
+}
+
+// ─── main ───────────────────────────────────────────────────────────────────
+
+fn main() {
+    let iters: u64 = env_or("BENCH_ITERS", 100_000);
+    println!("bench_round11_micro — iters={iters}\n");
+
+    section_1(iters);
+    section_2(iters);
+    section_3(iters);
+    section_4(iters);
+    section_5(iters);
+    section_6(iters);
+    section_7(iters);
+    section_8(iters);
+    section_9(iters);
+    section_10(iters);
+    section_11(iters);
+    section_12(iters);
+    section_13(iters);
+    section_14(iters);
+    section_15_16(iters);
+    section_17(iters);
+    section_18(iters);
+    section_19(iters);
+    section_20(iters);
+    section_21(iters);
+
+    println!("\ndone");
+}

--- a/examples/bench_round11_queries.rs
+++ b/examples/bench_round11_queries.rs
@@ -312,7 +312,13 @@ async fn direct_grant_query(pool: &PgPool, subject: Uuid, cal: Uuid) -> bool {
     )
     .bind(vec!["user"])
     .bind(vec![subject])
-    .bind(vec!["reader", "contributor", "manager", "owner"])
+    .bind(vec![
+        "owner",
+        "editor",
+        "contributor",
+        "commenter",
+        "viewer",
+    ])
     .bind("calendar")
     .bind(cal)
     .fetch_optional(pool)
@@ -546,11 +552,15 @@ async fn section_geo(pool: &PgPool, s: &Seed, passes: usize) {
     }
     tx.commit().await.expect("commit geo seed");
 
-    let mut b = geo_query(pool, s.owner, "min(fm.file_id::text)").await;
-    let mut a = geo_query(pool, s.owner, "min(fm.file_id)::text").await;
-    b.sort_by(|x, y| x.3.cmp(&y.3));
-    a.sort_by(|x, y| x.3.cmp(&y.3));
-    gate("cluster rows identical", a == b);
+    // REJECTED BY GATE: PostgreSQL has no `min(uuid)` aggregate — the
+    // planned `min(fm.file_id)::text` (cast per cluster) fails to parse, so
+    // the per-row-cast original stays. Verify the rejection reproducibly
+    // and record the BEFORE for the doc.
+    let min_uuid_err = sqlx::query("SELECT min(fm.file_id)::text FROM storage.file_metadata fm")
+        .fetch_optional(pool)
+        .await
+        .is_err();
+    gate("min(uuid) unsupported → AFTER rejected", min_uuid_err);
 
     let (ms_b, _) = timed(passes.min(60), || async {
         geo_query(pool, s.owner, "min(fm.file_id::text)")
@@ -558,14 +568,7 @@ async fn section_geo(pool: &PgPool, s: &Seed, passes: usize) {
             .len()
     })
     .await;
-    let (ms_a, _) = timed(passes.min(60), || async {
-        geo_query(pool, s.owner, "min(fm.file_id)::text")
-            .await
-            .len()
-    })
-    .await;
-    println!("    BEFORE min(file_id::text)  p50 {ms_b:.3} ms");
-    println!("    AFTER  min(file_id)::text  p50 {ms_a:.3} ms");
+    println!("    BEFORE min(file_id::text)  p50 {ms_b:.3} ms   (AFTER rejected — see gate)");
 
     let _ = sqlx::query("DELETE FROM storage.files WHERE drive_id = $1 AND name LIKE 'geo-%'")
         .bind(s.drive)

--- a/examples/bench_round11_queries.rs
+++ b/examples/bench_round11_queries.rs
@@ -1,0 +1,727 @@
+//! Round-11 query-shape pack — BEFORE query shapes vs AFTER (needs Postgres).
+//!
+//! Sections:
+//!   1. Deferred upload registration (the default REST upload path):
+//!      3 round-trips (parent drive SELECT → INSERT → parent path SELECT,
+//!      the middle two re-reading the SAME folders row) vs the single
+//!      `WITH parent AS (…) INSERT … RETURNING` template `persist_file`
+//!      already uses. Gate: identical returned (path, drive) + identical
+//!      not-found semantics for a missing parent.
+//!   2. Calendar/AddressBook/Playlist authz: the only `check()` arms with
+//!      no result cache — `role_grants` point query per check vs a moka
+//!      `direct_grant_cache` hit. Gate: same verdict + revocation flip
+//!      after invalidate.
+//!   3. `expand_user` cache miss: `is_external` + recursive groups CTE
+//!      awaited serially vs `tokio::join!`. Gate: same result set.
+//!   4. Places geo clusters: `min(fm.file_id::text)` (casts every row)
+//!      vs `min(fm.file_id)::text` (one cast per cluster). Gate:
+//!      identical cluster rows (uuid byte order == canonical text order).
+//!   5. Recluster persistence: F sequential `assign_person` UPDATEs vs
+//!      one `UPDATE … FROM unnest($1,$2)` batch. Gate: identical final
+//!      `person_id` column state.
+//!
+//! Run (needs Postgres; reads DATABASE_URL from .env):
+//!   cargo run --release --features bench --example bench_round11_queries
+//! Tunables (env): BENCH_PASSES (200)
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use sqlx::{PgPool, Row, postgres::PgPoolOptions};
+use uuid::Uuid;
+
+fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
+    std::env::var(key)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn p50(mut v: Vec<f64>) -> f64 {
+    v.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    v[v.len() / 2]
+}
+
+async fn timed<F, Fut, R>(passes: usize, mut f: F) -> (f64, R)
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = R>,
+{
+    let mut last = f().await;
+    let mut samples = Vec::with_capacity(passes);
+    for _ in 0..passes {
+        let t = Instant::now();
+        last = f().await;
+        samples.push(t.elapsed().as_secs_f64() * 1e3);
+    }
+    (p50(samples), last)
+}
+
+fn gate(name: &str, ok: bool) {
+    if ok {
+        println!("    gate[{name}]: OK");
+    } else {
+        println!("    gate[{name}]: FAILED — DO NOT SHIP THIS SECTION");
+    }
+}
+
+struct Seed {
+    owner: Uuid,
+    drive: Uuid,
+    root: Uuid,
+}
+
+async fn seed_base(pool: &PgPool, tag: &str) -> Seed {
+    // Idempotent sweep of leftovers from an aborted earlier run.
+    let _ = sqlx::query(
+        "DELETE FROM storage.files WHERE drive_id IN
+             (SELECT id FROM storage.drives WHERE default_for_user IN
+                 (SELECT id FROM auth.users WHERE username = $1))",
+    )
+    .bind(format!("bench_r11_{tag}"))
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM storage.folders WHERE lpath = $1::ltree")
+        .bind(format!("br11{tag}"))
+        .execute(pool)
+        .await;
+    let _ = sqlx::query(
+        "DELETE FROM storage.drives WHERE default_for_user IN
+             (SELECT id FROM auth.users WHERE username = $1)",
+    )
+    .bind(format!("bench_r11_{tag}"))
+    .execute(pool)
+    .await;
+    let _ = sqlx::query("DELETE FROM auth.users WHERE username = $1")
+        .bind(format!("bench_r11_{tag}"))
+        .execute(pool)
+        .await;
+
+    let mut tx = pool.begin().await.expect("begin seed tx");
+    let owner: Uuid = sqlx::query_scalar(
+        "INSERT INTO auth.users (username, email, role)
+         VALUES ($1, $2, 'user') RETURNING id",
+    )
+    .bind(format!("bench_r11_{tag}"))
+    .bind(format!("bench_r11_{tag}@bench.invalid"))
+    .fetch_one(&mut *tx)
+    .await
+    .expect("seed owner");
+    let drive: Uuid = sqlx::query_scalar(
+        "INSERT INTO storage.drives (kind, default_for_user, policies)
+         VALUES ('personal', $1, '{\"include_in_photo_index\": true}'::jsonb) RETURNING id",
+    )
+    .bind(owner)
+    .fetch_one(&mut *tx)
+    .await
+    .expect("seed drive");
+    let root: Uuid = sqlx::query_scalar(
+        "INSERT INTO storage.folders (name, path, lpath, drive_id)
+         VALUES ('Personal', '/Personal', $2::ltree, $1) RETURNING id",
+    )
+    .bind(drive)
+    .bind(format!("br11{tag}"))
+    .fetch_one(&mut *tx)
+    .await
+    .expect("seed root");
+    sqlx::query("UPDATE storage.drives SET root_folder_id = $1 WHERE id = $2")
+        .bind(root)
+        .bind(drive)
+        .execute(&mut *tx)
+        .await
+        .expect("stamp root");
+    sqlx::query(
+        "INSERT INTO storage.role_grants
+             (subject_type, subject_id, resource_type, resource_id, role, granted_by)
+         VALUES ('user', $1, 'drive', $2, 'owner'::storage.grant_role, $1)",
+    )
+    .bind(owner)
+    .bind(drive)
+    .execute(&mut *tx)
+    .await
+    .expect("seed owner grant");
+    tx.commit().await.expect("commit seed tx");
+    Seed { owner, drive, root }
+}
+
+async fn cleanup_base(pool: &PgPool, s: &Seed) {
+    let _ = sqlx::query("DELETE FROM storage.role_grants WHERE subject_id = $1 OR granted_by = $1")
+        .bind(s.owner)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.files WHERE drive_id = $1")
+        .bind(s.drive)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("UPDATE storage.drives SET root_folder_id = NULL WHERE id = $1")
+        .bind(s.drive)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.folders WHERE id = $1")
+        .bind(s.root)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.drives WHERE id = $1")
+        .bind(s.drive)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM auth.users WHERE id = $1")
+        .bind(s.owner)
+        .execute(pool)
+        .await;
+}
+
+// ─── §1 deferred upload registration ────────────────────────────────────────
+
+const PLACEHOLDER: &str = "0000000000000000000000000000000000000000000000000000000000000000";
+
+async fn deferred_before(
+    pool: &PgPool,
+    name: &str,
+    folder_id: Uuid,
+    caller: Uuid,
+) -> (String, String, Uuid) {
+    // Q1: resolve_parent_drive
+    let drive_id: Uuid =
+        sqlx::query_scalar("SELECT drive_id FROM storage.folders WHERE id = $1::uuid")
+            .bind(folder_id.to_string())
+            .fetch_optional(pool)
+            .await
+            .expect("q1")
+            .expect("parent exists");
+    // Q2: INSERT
+    let row: (String, i64, i64) = sqlx::query_as(
+        r#"
+        INSERT INTO storage.files
+            (name, folder_id, drive_id, blob_hash, size,
+             mime_type, category_order, created_by, updated_by)
+        VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $8)
+        RETURNING id::text,
+                  EXTRACT(EPOCH FROM created_at)::bigint,
+                  EXTRACT(EPOCH FROM updated_at)::bigint
+        "#,
+    )
+    .bind(name)
+    .bind(folder_id.to_string())
+    .bind(drive_id)
+    .bind(PLACEHOLDER)
+    .bind(4096i64)
+    .bind("application/octet-stream")
+    .bind(9999i16)
+    .bind(caller)
+    .fetch_one(pool)
+    .await
+    .expect("q2");
+    // Q3: lookup_folder_path
+    let path: String = sqlx::query_scalar("SELECT path FROM storage.folders WHERE id = $1::uuid")
+        .bind(folder_id.to_string())
+        .fetch_optional(pool)
+        .await
+        .expect("q3")
+        .expect("parent exists");
+    (row.0, path, drive_id)
+}
+
+async fn deferred_after(
+    pool: &PgPool,
+    name: &str,
+    folder_id: Uuid,
+    caller: Uuid,
+) -> Option<(String, String, Uuid)> {
+    let row: Option<(String, String, Uuid, i64, i64)> = sqlx::query_as(
+        r#"
+        WITH parent AS (
+            SELECT id, drive_id, path FROM storage.folders WHERE id = $2::uuid
+        )
+        INSERT INTO storage.files
+            (name, folder_id, drive_id, blob_hash, size,
+             mime_type, category_order, created_by, updated_by)
+        SELECT $1, parent.id, parent.drive_id, $3, $4, $5, $6, $7, $7
+          FROM parent
+        RETURNING id::text,
+                  (SELECT path FROM parent),
+                  drive_id,
+                  EXTRACT(EPOCH FROM created_at)::bigint,
+                  EXTRACT(EPOCH FROM updated_at)::bigint
+        "#,
+    )
+    .bind(name)
+    .bind(folder_id.to_string())
+    .bind(PLACEHOLDER)
+    .bind(4096i64)
+    .bind("application/octet-stream")
+    .bind(9999i16)
+    .bind(caller)
+    .fetch_optional(pool)
+    .await
+    .expect("cte insert");
+    row.map(|(id, path, drive, _, _)| (id, path, drive))
+}
+
+async fn section_deferred(pool: &PgPool, s: &Seed, passes: usize) {
+    println!("  §1 deferred upload registration (per uploaded file)");
+
+    // Gates: identical (path, drive); missing parent → 0 rows (not-found).
+    let b = deferred_before(pool, "gate-b.bin", s.root, s.owner).await;
+    let a = deferred_after(pool, "gate-a.bin", s.root, s.owner)
+        .await
+        .expect("row");
+    gate("path+drive identical", b.1 == a.1 && b.2 == a.2);
+    let missing = deferred_after(pool, "gate-m.bin", Uuid::new_v4(), s.owner).await;
+    gate("missing parent → not-found", missing.is_none());
+    let _ = sqlx::query("DELETE FROM storage.files WHERE blob_hash = $1")
+        .bind(PLACEHOLDER)
+        .execute(pool)
+        .await;
+
+    let (ms_b, _) = timed(passes, || async {
+        let r = deferred_before(pool, "bench-b.bin", s.root, s.owner).await;
+        let _ = sqlx::query("DELETE FROM storage.files WHERE id = $1::uuid")
+            .bind(&r.0)
+            .execute(pool)
+            .await;
+        r.2
+    })
+    .await;
+    let (ms_a, _) = timed(passes, || async {
+        let r = deferred_after(pool, "bench-a.bin", s.root, s.owner)
+            .await
+            .unwrap();
+        let _ = sqlx::query("DELETE FROM storage.files WHERE id = $1::uuid")
+            .bind(&r.0)
+            .execute(pool)
+            .await;
+        r.2
+    })
+    .await;
+    // Both arms pay the same cleanup DELETE; the delta is the 3-vs-1 shape.
+    println!("    BEFORE 3 round-trips  p50 {ms_b:.3} ms   (incl. cleanup DELETE)");
+    println!("    AFTER  1 CTE insert   p50 {ms_a:.3} ms   (incl. cleanup DELETE)");
+}
+
+// ─── §2 calendar direct-grant cache ─────────────────────────────────────────
+
+async fn direct_grant_query(pool: &PgPool, subject: Uuid, cal: Uuid) -> bool {
+    sqlx::query_scalar::<_, i32>(
+        "SELECT 1 FROM storage.role_grants
+          WHERE subject_type = ANY($1) AND subject_id = ANY($2)
+            AND role = ANY($3::storage.grant_role[])
+            AND resource_type = $4 AND resource_id = $5
+            AND (expires_at IS NULL OR expires_at > NOW())
+          LIMIT 1",
+    )
+    .bind(vec!["user"])
+    .bind(vec![subject])
+    .bind(vec!["reader", "contributor", "manager", "owner"])
+    .bind("calendar")
+    .bind(cal)
+    .fetch_optional(pool)
+    .await
+    .expect("grant query")
+    .is_some()
+}
+
+async fn section_grant_cache(pool: &Arc<PgPool>, s: &Seed, passes: usize) {
+    println!("  §2 Calendar/AddressBook/Playlist authz check (per DAV request)");
+    let cal = Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO storage.role_grants
+             (subject_type, subject_id, resource_type, resource_id, role, granted_by)
+         VALUES ('user', $1, 'calendar', $2, 'owner'::storage.grant_role, $1)",
+    )
+    .bind(s.owner)
+    .bind(cal)
+    .execute(pool.as_ref())
+    .await
+    .expect("seed calendar grant");
+
+    let cache: moka::future::Cache<(Uuid, Uuid), bool> = moka::future::Cache::builder()
+        .max_capacity(100_000)
+        .time_to_live(std::time::Duration::from_secs(30))
+        .build();
+
+    // Gates: identical verdict; revocation + invalidate flips the verdict.
+    let v_query = direct_grant_query(pool, s.owner, cal).await;
+    let v_cached = {
+        let pool2 = pool.clone();
+        cache
+            .try_get_with((s.owner, cal), async move {
+                Ok::<bool, std::convert::Infallible>(direct_grant_query(&pool2, s.owner, cal).await)
+            })
+            .await
+            .unwrap()
+    };
+    gate("verdict identical", v_query == v_cached && v_query);
+    sqlx::query(
+        "DELETE FROM storage.role_grants WHERE resource_type = 'calendar' AND resource_id = $1",
+    )
+    .bind(cal)
+    .execute(pool.as_ref())
+    .await
+    .expect("revoke");
+    cache.invalidate_all();
+    let v_after_revoke = {
+        let pool2 = pool.clone();
+        cache
+            .try_get_with((s.owner, cal), async move {
+                Ok::<bool, std::convert::Infallible>(direct_grant_query(&pool2, s.owner, cal).await)
+            })
+            .await
+            .unwrap()
+    };
+    gate("revocation flips verdict", !v_after_revoke);
+    // Re-seed for the measurement.
+    sqlx::query(
+        "INSERT INTO storage.role_grants
+             (subject_type, subject_id, resource_type, resource_id, role, granted_by)
+         VALUES ('user', $1, 'calendar', $2, 'owner'::storage.grant_role, $1)",
+    )
+    .bind(s.owner)
+    .bind(cal)
+    .execute(pool.as_ref())
+    .await
+    .expect("re-seed");
+    cache.invalidate_all();
+
+    let (ms_b, _) = timed(passes, || async {
+        direct_grant_query(pool, s.owner, cal).await
+    })
+    .await;
+    let (ms_a, _) = timed(passes, || async {
+        let pool2 = pool.clone();
+        cache
+            .try_get_with((s.owner, cal), async move {
+                Ok::<bool, std::convert::Infallible>(direct_grant_query(&pool2, s.owner, cal).await)
+            })
+            .await
+            .unwrap()
+    })
+    .await;
+    println!("    BEFORE role_grants query per check  p50 {ms_b:.3} ms");
+    println!("    AFTER  moka hit                     p50 {ms_a:.4} ms");
+
+    sqlx::query(
+        "DELETE FROM storage.role_grants WHERE resource_type = 'calendar' AND resource_id = $1",
+    )
+    .bind(cal)
+    .execute(pool.as_ref())
+    .await
+    .expect("cleanup grant");
+}
+
+// ─── §3 expand_user serial vs join ──────────────────────────────────────────
+
+async fn q_is_external(pool: &PgPool, user: Uuid) -> bool {
+    sqlx::query_scalar::<_, bool>("SELECT is_external FROM auth.users WHERE id = $1")
+        .bind(user)
+        .fetch_optional(pool)
+        .await
+        .expect("is_external")
+        .unwrap_or(true)
+}
+
+async fn q_groups(pool: &PgPool, user: Uuid) -> Vec<Uuid> {
+    sqlx::query(
+        "WITH RECURSIVE user_groups AS (
+             SELECT group_id
+               FROM auth.subject_group_members
+              WHERE member_user_id = $1
+             UNION
+             SELECT m.group_id
+               FROM auth.subject_group_members m
+               JOIN user_groups ug ON m.member_group_id = ug.group_id
+         )
+         SELECT group_id FROM user_groups",
+    )
+    .bind(user)
+    .fetch_all(pool)
+    .await
+    .expect("groups CTE")
+    .iter()
+    .map(|r| r.get::<Uuid, _>("group_id"))
+    .collect()
+}
+
+async fn section_expand(pool: &PgPool, s: &Seed, passes: usize) {
+    println!("  §3 expand_user cold miss (per user per TTL window)");
+
+    let b = {
+        let e = q_is_external(pool, s.owner).await;
+        let g = q_groups(pool, s.owner).await;
+        (e, g)
+    };
+    let a = {
+        let (e, g) = tokio::join!(q_is_external(pool, s.owner), q_groups(pool, s.owner));
+        (e, g)
+    };
+    gate("expansion identical", b == a);
+
+    let (ms_b, _) = timed(passes, || async {
+        let e = q_is_external(pool, s.owner).await;
+        let g = q_groups(pool, s.owner).await;
+        (e, g.len())
+    })
+    .await;
+    let (ms_a, _) = timed(passes, || async {
+        let (e, g) = tokio::join!(q_is_external(pool, s.owner), q_groups(pool, s.owner));
+        (e, g.len())
+    })
+    .await;
+    println!("    BEFORE serial 2 queries  p50 {ms_b:.3} ms");
+    println!("    AFTER  tokio::join!      p50 {ms_a:.3} ms");
+}
+
+// ─── §4 geo clusters min cast ───────────────────────────────────────────────
+
+async fn geo_query(pool: &PgPool, caller: Uuid, min_expr: &str) -> Vec<(i64, f64, f64, String)> {
+    sqlx::query_as(&format!(
+        r#"
+        SELECT count(*)              AS n,
+               avg(fm.longitude)     AS clng,
+               avg(fm.latitude)      AS clat,
+               {min_expr}            AS sample_id
+          FROM storage.file_metadata fm
+          JOIN storage.files fi ON fi.id = fm.file_id
+         WHERE fi.drive_id IN (
+                 SELECT d.id
+                   FROM storage.drives d
+                   JOIN storage.role_grants g
+                     ON g.resource_type = 'drive'
+                    AND g.resource_id   = d.id
+                  WHERE (
+                          (g.subject_type = 'user'  AND g.subject_id = $1)
+                       OR (g.subject_type = 'group' AND g.subject_id IN
+                               (SELECT storage.caller_group_ids($1)))
+                        )
+                    AND (g.expires_at IS NULL OR g.expires_at > NOW())
+                    AND (d.policies->>'include_in_photo_index')::boolean = true
+               )
+           AND NOT fi.is_trashed
+           AND fm.latitude IS NOT NULL
+           AND fm.longitude IS NOT NULL
+           AND fm.longitude BETWEEN $2 AND $3
+           AND fm.latitude  BETWEEN $4 AND $5
+         GROUP BY round(fm.longitude / $6), round(fm.latitude / $6)
+        "#
+    ))
+    .bind(caller)
+    .bind(-10.0f64)
+    .bind(10.0f64)
+    .bind(35.0f64)
+    .bind(45.0f64)
+    .bind(0.5f64)
+    .fetch_all(pool)
+    .await
+    .expect("geo query")
+}
+
+async fn section_geo(pool: &PgPool, s: &Seed, passes: usize) {
+    println!("  §4 Places geo clusters (per map viewport, 5k geotagged rows)");
+    // Seed 5k geotagged photos across the viewport.
+    let mut tx = pool.begin().await.expect("begin geo seed");
+    for chunk in 0..10 {
+        let ids: Vec<Uuid> = sqlx::query_scalar(
+            "INSERT INTO storage.files
+                 (name, folder_id, drive_id, blob_hash, size, mime_type, category_order)
+             SELECT 'geo-' || $4 || '-' || g, $1, $2, $3, 1024, 'image/jpeg', 100
+               FROM generate_series(1, 500) g
+             RETURNING id",
+        )
+        .bind(s.root)
+        .bind(s.drive)
+        .bind(PLACEHOLDER)
+        .bind(chunk.to_string())
+        .fetch_all(&mut *tx)
+        .await
+        .expect("seed geo files");
+        sqlx::query(
+            "INSERT INTO storage.file_metadata (file_id, latitude, longitude)
+             SELECT u, 35.0 + (random() * 10.0), -10.0 + (random() * 20.0)
+               FROM unnest($1::uuid[]) u",
+        )
+        .bind(&ids)
+        .execute(&mut *tx)
+        .await
+        .expect("seed geo meta");
+    }
+    tx.commit().await.expect("commit geo seed");
+
+    let mut b = geo_query(pool, s.owner, "min(fm.file_id::text)").await;
+    let mut a = geo_query(pool, s.owner, "min(fm.file_id)::text").await;
+    b.sort_by(|x, y| x.3.cmp(&y.3));
+    a.sort_by(|x, y| x.3.cmp(&y.3));
+    gate("cluster rows identical", a == b);
+
+    let (ms_b, _) = timed(passes.min(60), || async {
+        geo_query(pool, s.owner, "min(fm.file_id::text)")
+            .await
+            .len()
+    })
+    .await;
+    let (ms_a, _) = timed(passes.min(60), || async {
+        geo_query(pool, s.owner, "min(fm.file_id)::text")
+            .await
+            .len()
+    })
+    .await;
+    println!("    BEFORE min(file_id::text)  p50 {ms_b:.3} ms");
+    println!("    AFTER  min(file_id)::text  p50 {ms_a:.3} ms");
+
+    let _ = sqlx::query("DELETE FROM storage.files WHERE drive_id = $1 AND name LIKE 'geo-%'")
+        .bind(s.drive)
+        .execute(pool)
+        .await;
+}
+
+// ─── §5 recluster assignment batch ──────────────────────────────────────────
+
+async fn section_recluster(pool: &PgPool, s: &Seed, passes: usize) {
+    println!("  §5 recluster face assignment (200-face library)");
+    // One photo + 200 faces.
+    let file: Uuid = sqlx::query_scalar(
+        "INSERT INTO storage.files
+             (name, folder_id, drive_id, blob_hash, size, mime_type, category_order)
+         VALUES ('faces.jpg', $1, $2, $3, 1024, 'image/jpeg', 100) RETURNING id",
+    )
+    .bind(s.root)
+    .bind(s.drive)
+    .bind(PLACEHOLDER)
+    .fetch_one(pool)
+    .await
+    .expect("seed face file");
+    let face_ids: Vec<Uuid> = sqlx::query_scalar(
+        "INSERT INTO faces.faces (file_id, user_id, bbox, det_score, embedding)
+         SELECT $1, $2, ARRAY[0.1,0.1,0.2,0.2]::real[], 0.99, '\\x00'::bytea
+           FROM generate_series(1, 200)
+         RETURNING id",
+    )
+    .bind(file)
+    .bind(s.owner)
+    .fetch_all(pool)
+    .await
+    .expect("seed faces");
+    let person: Uuid =
+        sqlx::query_scalar("INSERT INTO faces.persons (user_id) VALUES ($1) RETURNING id")
+            .bind(s.owner)
+            .fetch_one(pool)
+            .await
+            .expect("seed person");
+
+    let assignments: Vec<(Uuid, Option<Uuid>)> =
+        face_ids.iter().map(|f| (*f, Some(person))).collect();
+
+    async fn reset(pool: &PgPool, ids: &[Uuid]) {
+        sqlx::query("UPDATE faces.faces SET person_id = NULL WHERE id = ANY($1)")
+            .bind(ids)
+            .execute(pool)
+            .await
+            .expect("reset");
+    }
+    async fn state(pool: &PgPool, ids: &[Uuid]) -> Vec<(Uuid, Option<Uuid>)> {
+        let mut rows: Vec<(Uuid, Option<Uuid>)> =
+            sqlx::query_as("SELECT id, person_id FROM faces.faces WHERE id = ANY($1)")
+                .bind(ids)
+                .fetch_all(pool)
+                .await
+                .expect("state");
+        rows.sort();
+        rows
+    }
+
+    // BEFORE: one UPDATE per face.
+    reset(pool, &face_ids).await;
+    for (f, p) in &assignments {
+        sqlx::query("UPDATE faces.faces SET person_id = $2 WHERE id = $1")
+            .bind(f)
+            .bind(p)
+            .execute(pool)
+            .await
+            .expect("assign");
+    }
+    let st_b = state(pool, &face_ids).await;
+    // AFTER: one UNNEST batch.
+    reset(pool, &face_ids).await;
+    let (fs, ps): (Vec<Uuid>, Vec<Option<Uuid>>) = assignments.iter().cloned().unzip();
+    sqlx::query(
+        "UPDATE faces.faces f SET person_id = u.pid
+           FROM (SELECT unnest($1::uuid[]) AS fid, unnest($2::uuid[]) AS pid) u
+          WHERE f.id = u.fid",
+    )
+    .bind(&fs)
+    .bind(&ps)
+    .execute(pool)
+    .await
+    .expect("batch assign");
+    let st_a = state(pool, &face_ids).await;
+    gate("final person_id state identical", st_a == st_b);
+
+    let it = passes.min(30);
+    let (ms_b, _) = timed(it, || async {
+        reset(pool, &face_ids).await;
+        for (f, p) in &assignments {
+            sqlx::query("UPDATE faces.faces SET person_id = $2 WHERE id = $1")
+                .bind(f)
+                .bind(p)
+                .execute(pool)
+                .await
+                .expect("assign");
+        }
+        0u32
+    })
+    .await;
+    let (ms_a, _) = timed(it, || async {
+        reset(pool, &face_ids).await;
+        let (fs, ps): (Vec<Uuid>, Vec<Option<Uuid>>) = assignments.iter().cloned().unzip();
+        sqlx::query(
+            "UPDATE faces.faces f SET person_id = u.pid
+               FROM (SELECT unnest($1::uuid[]) AS fid, unnest($2::uuid[]) AS pid) u
+              WHERE f.id = u.fid",
+        )
+        .bind(&fs)
+        .bind(&ps)
+        .execute(pool)
+        .await
+        .expect("batch");
+        0u32
+    })
+    .await;
+    println!("    BEFORE 200 sequential UPDATEs  p50 {ms_b:.3} ms  (incl. reset)");
+    println!("    AFTER  1 UNNEST batch          p50 {ms_a:.3} ms  (incl. reset)");
+
+    let _ = sqlx::query("DELETE FROM faces.persons WHERE id = $1")
+        .bind(person)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM storage.files WHERE id = $1")
+        .bind(file)
+        .execute(pool)
+        .await;
+}
+
+// ─── main ───────────────────────────────────────────────────────────────────
+
+#[tokio::main]
+async fn main() {
+    let _ = dotenvy::dotenv();
+    let url = std::env::var("DATABASE_URL").expect("DATABASE_URL required (see .env)");
+    let passes: usize = env_or("BENCH_PASSES", 200);
+    println!("bench_round11_queries — passes={passes}\n");
+
+    let pool = Arc::new(
+        PgPoolOptions::new()
+            .max_connections(8)
+            .connect(&url)
+            .await
+            .expect("connect"),
+    );
+    let seed = seed_base(&pool, "q").await;
+
+    section_deferred(&pool, &seed, passes).await;
+    section_grant_cache(&pool, &seed, passes).await;
+    section_expand(&pool, &seed, passes).await;
+    section_geo(&pool, &seed, passes).await;
+    section_recluster(&pool, &seed, passes.min(30)).await;
+
+    cleanup_base(&pool, &seed).await;
+    println!("\ndone");
+}

--- a/examples/bench_row_path.rs
+++ b/examples/bench_row_path.rs
@@ -482,7 +482,7 @@ fn gate_file(name: &str, folder_path: Option<&str>) -> bool {
     );
     match (b, a) {
         (Ok(b), Ok(a)) => {
-            let seg_a: Vec<String> = a.storage_path().segments().to_vec();
+            let seg_a: Vec<String> = a.storage_path().segments().map(str::to_string).collect();
             if b.name != a.name()
                 || b.path_string != a.path_string()
                 || b.storage_path.segments != seg_a
@@ -539,7 +539,7 @@ fn gate_folder(name: &str, path: &str) -> bool {
     );
     match (b, a) {
         (Ok(b), Ok(a)) => {
-            let seg_a: Vec<String> = a.storage_path().segments().to_vec();
+            let seg_a: Vec<String> = a.storage_path().segments().map(str::to_string).collect();
             if b.name != a.name()
                 || b.path_string != a.path_string()
                 || b.storage_path.segments != seg_a

--- a/frontend/src/lib/components/ResourceList.svelte
+++ b/frontend/src/lib/components/ResourceList.svelte
@@ -119,6 +119,15 @@
 		onopen?: (entry: ResourceEntry) => void;
 		/** Per-entry favorite star toggle. */
 		onfavorite?: (entry: ResourceEntry) => void;
+		/**
+		 * Live favorite-id set for the star state. When provided, the star
+		 * reads membership here instead of `entry.isFavorite`, so a toggle
+		 * repaints one star instead of forcing the host to rebuild every
+		 * entry object (the Recent page paid a full O(N) re-map + re-render
+		 * per star click through its `favoriteIds.has()` inside the entry
+		 * mapper — see benches/ROUND11.md).
+		 */
+		favoriteIds?: ReadonlySet<string> | null;
 		/** Selection changed (set of selected entry ids). */
 		onselectionchange?: (ids: Set<string>) => void;
 		actions?: Snippet<[ResourceEntry]>;
@@ -156,6 +165,7 @@
 		onreload,
 		onopen,
 		onfavorite,
+		favoriteIds = null,
 		onselectionchange,
 		actions,
 		toolbar,
@@ -252,7 +262,22 @@
 			onselectionchange?.(selected);
 		}
 	}
-	const selectedEntries = $derived(items.filter((i) => selected.has(i.id)));
+	// Index rebuilt only when `items` changes; the projection below is then
+	// O(k · log k) in the selection size k instead of the old O(N) full-list
+	// `items.filter(...)` re-scan on every toggle (O(N²)-ish across a
+	// shift-range gesture once the batch toolbar was mounted). Item order is
+	// preserved via the index sort so the toolbar sees the same array the
+	// filter produced.
+	const itemIndexById = $derived(new Map(items.map((i, idx) => [i.id, idx])));
+	const selectedEntries = $derived.by(() => {
+		const picked: { idx: number; item: ResourceEntry }[] = [];
+		for (const id of selected) {
+			const idx = itemIndexById.get(id);
+			if (idx !== undefined) picked.push({ idx, item: items[idx] });
+		}
+		picked.sort((a, b) => a.idx - b.idx);
+		return picked.map((p) => p.item);
+	});
 
 	// Drop selection ids that are no longer present after a reload.
 	$effect(() => {
@@ -380,18 +405,19 @@
 			</span>
 		</div>
 		{#if onfavorite}
+			{@const starred = favoriteIds ? favoriteIds.has(entry.id) : !!entry.isFavorite}
 			<button
 				class="rl-star"
-				class:rl-star--on={entry.isFavorite}
+				class:rl-star--on={starred}
 				data-testid={`resource-list-favorite-${entry.id}-btn`}
-				title={entry.isFavorite
+				title={starred
 					? t('files.unfavorite', 'Remove favorite')
 					: t('files.favorite', 'Add favorite')}
-				aria-pressed={!!entry.isFavorite}
+				aria-pressed={starred}
 				onclick={(e) => {
 					e.stopPropagation();
 					onfavorite(entry);
-				}}><Icon name={entry.isFavorite ? 'star' : 'star-outline'} /></button
+				}}><Icon name={starred ? 'star' : 'star-outline'} /></button
 			>
 		{/if}
 		{#if actions}

--- a/frontend/src/lib/components/round11.bench.test.ts
+++ b/frontend/src/lib/components/round11.bench.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Benchmark gates for the round-11 SPA items (see benches/ROUND11.md):
+ *
+ * [1] `ResourceList.selectedEntries` re-filtered the ENTIRE items array on
+ *     every selection change once the batch toolbar was mounted — and the
+ *     favorites/recent hosts ignored the snippet param and recomputed their
+ *     own `entries.filter(...)` shadow, so each toggle ran TWO full O(N)
+ *     scans (O(N²)-ish across a shift-range gesture). The shipped shape
+ *     derives an id→index Map (rebuilt only when `items` changes) and
+ *     projects the selection in O(k · log k), preserving item order; hosts
+ *     now consume the snippet param.
+ *
+ * [2] The Recent page mapper baked `favoriteIds.has(id)` into every entry,
+ *     subscribing the whole O(N) map to the SvelteSet — one star click
+ *     rebuilt all N entries and re-rendered every visible row. The shipped
+ *     shape reads membership in the star widget via ResourceList's new
+ *     `favoriteIds` prop, so the mapper no longer depends on the set.
+ *
+ * [3] The admin "time ago" >30-day fallback called `toLocaleDateString()`
+ *     (a fresh Intl.DateTimeFormat per call) instead of the cached
+ *     `dateTimeFormatFor` the rest of the app uses.
+ *
+ * All modeled as pure replicas of the derive bodies with instrumentation
+ * counters (the listDerives.bench.test.ts convention).
+ */
+
+interface Entry {
+	id: string;
+	name: string;
+}
+
+const buildItems = (n: number): Entry[] =>
+	Array.from({ length: n }, (_, i) => ({ id: `it-${i}`, name: `Item ${i}` }));
+
+/** BEFORE — component derive + host shadow, each a full O(N) scan. */
+function selectedBefore(
+	items: Entry[],
+	selected: Set<string>,
+	counter: { comparisons: number }
+): { component: Entry[]; host: Entry[] } {
+	const component = items.filter((i) => {
+		counter.comparisons++;
+		return selected.has(i.id);
+	});
+	const host = items.filter((i) => {
+		counter.comparisons++;
+		return selected.has(i.id);
+	});
+	return { component, host };
+}
+
+/** AFTER — id→index Map projection, index rebuilt only on items change. */
+function makeAfterProjector(items: Entry[]) {
+	const indexById = new Map(items.map((i, idx) => [i.id, idx]));
+	return (selected: Set<string>, counter: { comparisons: number }): Entry[] => {
+		const picked: { idx: number; item: Entry }[] = [];
+		for (const id of selected) {
+			counter.comparisons++;
+			const idx = indexById.get(id);
+			if (idx !== undefined) picked.push({ idx, item: items[idx] });
+		}
+		picked.sort((a, b) => a.idx - b.idx);
+		return picked.map((p) => p.item);
+	};
+}
+
+describe('ResourceList selectedEntries projection (benchmark gate)', () => {
+	it('identical output (order + membership) and O(k) vs O(2N) comparisons per toggle', () => {
+		const N = 2000;
+		const items = buildItems(N);
+		const project = makeAfterProjector(items);
+
+		// Model a 50-item shift-range selection built one id at a time,
+		// re-deriving after each toggle (what the reactive graph does).
+		const selected = new Set<string>();
+		const beforeCounter = { comparisons: 0 };
+		const afterCounter = { comparisons: 0 };
+		// Insert in REVERSE order so selection order ≠ item order — the
+		// order-preservation gate below must still hold. Each toggle
+		// re-derives both shapes (what the reactive graph does).
+		for (let i = 149; i >= 100; i--) {
+			selected.add(`it-${i}`);
+			selectedBefore(items, selected, beforeCounter);
+			project(selected, afterCounter);
+		}
+		// Stale ids (deleted rows) must be dropped by both shapes.
+		selected.add('it-ghost');
+		const lastBefore = selectedBefore(items, selected, beforeCounter).component;
+		const lastAfter = project(selected, afterCounter);
+
+		expect(lastAfter).toEqual(lastBefore); // same entries, same (item) order
+		// BEFORE: 2 scans × N per toggle. AFTER: k probes per toggle.
+		expect(beforeCounter.comparisons).toBe(51 * 2 * N);
+		expect(afterCounter.comparisons).toBeLessThan(51 * 51 + 1);
+	});
+
+	it('wall clock: 500-toggle sweep on a 5k list is faster with the projection', () => {
+		const N = 5000;
+		const items = buildItems(N);
+		const project = makeAfterProjector(items);
+		const selected = new Set<string>();
+		const nul = { comparisons: 0 };
+
+		const t0 = performance.now();
+		for (let i = 0; i < 500; i++) {
+			selected.add(`it-${i}`);
+			selectedBefore(items, selected, nul);
+		}
+		const tBefore = performance.now() - t0;
+
+		selected.clear();
+		const t1 = performance.now();
+		for (let i = 0; i < 500; i++) {
+			selected.add(`it-${i}`);
+			project(selected, nul);
+		}
+		const tAfter = performance.now() - t1;
+
+		// Generous bound to keep CI stable; locally ~10-40x.
+		expect(tAfter).toBeLessThan(tBefore);
+	});
+});
+
+// ─── [2] Recent favorite-star dependency ────────────────────────────────────
+
+interface RawItem {
+	id: string;
+	name: string;
+}
+
+/** BEFORE — mapper reads the favorite set: every toggle re-maps ALL rows. */
+function entriesBefore(
+	raw: RawItem[],
+	favoriteIds: Set<string>,
+	counter: { mapperRows: number }
+): { id: string; isFavorite: boolean }[] {
+	return raw.map((it) => {
+		counter.mapperRows++;
+		return { id: it.id, isFavorite: favoriteIds.has(it.id) };
+	});
+}
+
+/** AFTER — mapper is set-independent; the star widget reads membership. */
+function entriesAfter(raw: RawItem[], counter: { mapperRows: number }): { id: string }[] {
+	return raw.map((it) => {
+		counter.mapperRows++;
+		return { id: it.id };
+	});
+}
+function starStateAfter(favoriteIds: Set<string>, id: string): boolean {
+	return favoriteIds.has(id);
+}
+
+describe('Recent favorite-star fine-grained dependency (benchmark gate)', () => {
+	it('a star toggle re-maps 0 rows (was N) and renders the same star states', () => {
+		const N = 400;
+		const raw: RawItem[] = Array.from({ length: N }, (_, i) => ({
+			id: `r-${i}`,
+			name: `File ${i}`
+		}));
+		const favoriteIds = new Set<string>(['r-3']);
+
+		const beforeCounter = { mapperRows: 0 };
+		const afterCounter = { mapperRows: 0 };
+
+		// Initial render: both shapes map all rows once.
+		let entriesB = entriesBefore(raw, favoriteIds, beforeCounter);
+		const entriesA = entriesAfter(raw, afterCounter);
+		expect(beforeCounter.mapperRows).toBe(N);
+		expect(afterCounter.mapperRows).toBe(N);
+
+		// 10 star toggles. BEFORE: the mapper depends on the set → full
+		// re-map each time. AFTER: the mapper doesn't run at all.
+		for (let k = 0; k < 10; k++) {
+			const id = `r-${k * 7}`;
+			if (favoriteIds.has(id)) favoriteIds.delete(id);
+			else favoriteIds.add(id);
+			entriesB = entriesBefore(raw, favoriteIds, beforeCounter); // reactive re-run
+			// AFTER: no mapper re-run; only the affected star re-reads.
+			starStateAfter(favoriteIds, id);
+		}
+
+		expect(beforeCounter.mapperRows).toBe(N + 10 * N);
+		expect(afterCounter.mapperRows).toBe(N); // unchanged since initial render
+
+		// Gate: identical star state for every row under the AFTER shape.
+		for (let i = 0; i < N; i++) {
+			expect(starStateAfter(favoriteIds, entriesA[i].id)).toBe(entriesB[i].isFavorite);
+		}
+	});
+});
+
+// ─── [3] admin timeAgo date fallback ────────────────────────────────────────
+
+describe('admin timeAgo >30d fallback formatter cache (benchmark gate)', () => {
+	it('cached formatter output is identical to toLocaleDateString()', async () => {
+		const { dateTimeFormatFor } = await import('../utils/display');
+		const dates = [
+			new Date('2025-01-15T10:30:00Z'),
+			new Date('2024-12-31T23:59:59Z'),
+			new Date('2020-06-01T00:00:00Z'),
+			new Date('1999-02-28T12:00:00Z')
+		];
+		for (const d of dates) {
+			expect(dateTimeFormatFor(undefined).format(d)).toBe(d.toLocaleDateString());
+		}
+	});
+
+	it('1000 formats construct ≤1 Intl.DateTimeFormat (was 1000)', async () => {
+		const { dateTimeFormatFor } = await import('../utils/display');
+		const RealDTF = Intl.DateTimeFormat;
+		let constructed = 0;
+		// Count constructions through both paths.
+		const Counting = new Proxy(RealDTF, {
+			construct(target, args: [string?, Intl.DateTimeFormatOptions?]) {
+				constructed++;
+				return new target(...args);
+			}
+		});
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(Intl as any).DateTimeFormat = Counting;
+		try {
+			const d = new Date('2020-06-01T00:00:00Z');
+			constructed = 0;
+			for (let i = 0; i < 1000; i++) {
+				d.toLocaleDateString();
+			}
+			// jsdom implements toLocaleDateString via Intl internally in some
+			// versions; count only if observable. The load-bearing assertion
+			// is the cached path below.
+			const beforeConstructed = constructed;
+
+			constructed = 0;
+			for (let i = 0; i < 1000; i++) {
+				dateTimeFormatFor(undefined).format(d);
+			}
+			expect(constructed).toBeLessThanOrEqual(1);
+			// When the environment exposes per-call constructions, require
+			// the cached path to be strictly cheaper.
+			if (beforeConstructed > 1) {
+				expect(constructed).toBeLessThan(beforeConstructed);
+			}
+		} finally {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(Intl as any).DateTimeFormat = RealDTF;
+		}
+	});
+});

--- a/frontend/src/routes/admin/+page.svelte
+++ b/frontend/src/routes/admin/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { errorMessage, errorToast } from '$lib/utils/errors';
+	import { dateTimeFormatFor } from '$lib/utils/display';
 	import {
 		clearPluginLogs,
 		createUser,
@@ -101,7 +102,10 @@
 		if (hours < 24) return t('admin.time_hour_ago', { n: hours }, '{{n}} h ago');
 		const days = Math.round(hours / 24);
 		if (days < 30) return t('admin.time_day_ago', { n: days }, '{{n}} d ago');
-		return new Date(dateStr).toLocaleDateString();
+		// `toLocaleDateString()` constructs a fresh Intl.DateTimeFormat per
+		// call; the no-options cached formatter is the exact equivalent
+		// (both default to numeric year/month/day in the default locale).
+		return dateTimeFormatFor(undefined).format(new Date(dateStr));
 	}
 
 	/** Quota unit options (bytes per unit) for the quota/create modals. */

--- a/frontend/src/routes/favorites/+page.svelte
+++ b/frontend/src/routes/favorites/+page.svelte
@@ -246,36 +246,34 @@
 	];
 
 	// ── Selection + batch ─────────────────────────────────────────────────────
-	let selectedIds = $state<Set<string>>(new Set());
-	const selectedEntries = $derived(entries.filter((e) => selectedIds.has(e.id)));
+	// Selected entries arrive via the batchToolbar snippet param —
+	// ResourceList derives them once (O(selection)); the old host-side
+	// `entries.filter(...)` shadow re-ran a second full O(N) scan per
+	// selection toggle, and its id mirror is gone with it (the component
+	// prunes its own selection when items reload) — benches/ROUND11.md.
 
-	function batchTargets() {
-		return selectedEntries.map((e) => ({ id: e.id, name: e.name, kind: e.kind }));
+	function batchTargets(sel: ResourceEntry[]) {
+		return sel.map((e) => ({ id: e.id, name: e.name, kind: e.kind }));
 	}
 
-	function batchDownload() {
-		for (const e of selectedEntries) downloadEntry(e);
+	function batchDownload(sel: ResourceEntry[]) {
+		for (const e of sel) downloadEntry(e);
 	}
 
-	async function batchDelete() {
+	async function batchDelete(sel: ResourceEntry[]) {
 		const ok = await confirmDialog({
 			title: t('common.delete', 'Delete'),
-			message: t(
-				'files.confirm_delete_n',
-				{ count: selectedEntries.length },
-				'Delete {{count}} item(s)?'
-			),
+			message: t('files.confirm_delete_n', { count: sel.length }, 'Delete {{count}} item(s)?'),
 			confirmText: t('common.delete', 'Delete'),
 			danger: true
 		});
 		if (!ok) return;
 		try {
 			await Promise.all(
-				selectedEntries.map((e) => (e.kind === 'file' ? deleteFile(e.id) : deleteFolder(e.id)))
+				sel.map((e) => (e.kind === 'file' ? deleteFile(e.id) : deleteFolder(e.id)))
 			);
-			const removed = new Set(selectedEntries.map((e) => e.id));
+			const removed = new Set(sel.map((e) => e.id));
 			raw = raw.filter((i) => !removed.has(i.resource.id));
-			selectedIds = new Set();
 		} catch (e) {
 			errorToast(e);
 		}
@@ -308,18 +306,19 @@
 		cursor = undefined;
 		load(true, orderBy, rev);
 	}}
-	onselectionchange={(ids) => (selectedIds = ids)}
 >
-	{#snippet batchToolbar()}
-		<Button icon="download" data-testid="favorites-batch-download-btn" onclick={batchDownload}
-			>{t('common.download', 'Download')}</Button
+	{#snippet batchToolbar(sel)}
+		<Button
+			icon="download"
+			data-testid="favorites-batch-download-btn"
+			onclick={() => batchDownload(sel)}>{t('common.download', 'Download')}</Button
 		>
 		<Button
 			icon="arrows-alt"
 			data-testid="favorites-batch-move-btn"
 			onclick={() => {
 				moveTarget = null;
-				moveItems = batchTargets();
+				moveItems = batchTargets(sel);
 				moveOpen = true;
 			}}>{t('files.move', 'Move')}</Button
 		>
@@ -327,7 +326,7 @@
 			variant="danger"
 			icon="trash"
 			data-testid="favorites-batch-delete-btn"
-			onclick={batchDelete}>{t('common.delete', 'Delete')}</Button
+			onclick={() => batchDelete(sel)}>{t('common.delete', 'Delete')}</Button
 		>
 	{/snippet}
 </ResourceList>
@@ -342,10 +341,7 @@
 		bind:open={moveOpen}
 		item={moveTarget}
 		items={moveItems}
-		onmoved={() => {
-			selectedIds = new Set();
-			load(true, orderByForGroup());
-		}}
+		onmoved={() => load(true, orderByForGroup())}
 	/>
 {/if}
 {#if shareDialog.component}

--- a/frontend/src/routes/recent/+page.svelte
+++ b/frontend/src/routes/recent/+page.svelte
@@ -61,7 +61,10 @@
 				date: it.accessed_at,
 				ownerId,
 				ownerName: owners.name(ownerId),
-				isFavorite: favoriteIds.has(it.resource.id),
+				// Star state comes from the `favoriteIds` prop on ResourceList,
+				// NOT from the entry — reading the SvelteSet here subscribed
+				// this whole mapper to it, so one star click rebuilt all N
+				// entries + re-rendered every visible row (benches/ROUND11.md).
 				category: isFile ? it.resource.category : 'Folder',
 				modifiedAt: it.resource.modified_at
 			};
@@ -285,36 +288,34 @@
 	];
 
 	// ── Selection + batch ─────────────────────────────────────────────────────
-	let selectedIds = $state<Set<string>>(new Set());
-	const selectedEntries = $derived(entries.filter((e) => selectedIds.has(e.id)));
+	// The selected entries come in through the batchToolbar snippet param —
+	// ResourceList already derives them (O(selection), not O(N)); the old
+	// host-side `entries.filter(...)` shadow re-ran a second full scan per
+	// toggle, and its id mirror is gone with it (the component prunes its
+	// own selection when items reload) — benches/ROUND11.md.
 
-	function batchTargets() {
-		return selectedEntries.map((e) => ({ id: e.id, name: e.name, kind: e.kind }));
+	function batchTargets(sel: ResourceEntry[]) {
+		return sel.map((e) => ({ id: e.id, name: e.name, kind: e.kind }));
 	}
 
-	function batchDownload() {
-		for (const e of selectedEntries) downloadEntry(e);
+	function batchDownload(sel: ResourceEntry[]) {
+		for (const e of sel) downloadEntry(e);
 	}
 
-	async function batchDelete() {
+	async function batchDelete(sel: ResourceEntry[]) {
 		const ok = await confirmDialog({
 			title: t('common.delete', 'Delete'),
-			message: t(
-				'files.confirm_delete_n',
-				{ count: selectedEntries.length },
-				'Delete {{count}} item(s)?'
-			),
+			message: t('files.confirm_delete_n', { count: sel.length }, 'Delete {{count}} item(s)?'),
 			confirmText: t('common.delete', 'Delete'),
 			danger: true
 		});
 		if (!ok) return;
 		try {
 			await Promise.all(
-				selectedEntries.map((e) => (e.kind === 'file' ? deleteFile(e.id) : deleteFolder(e.id)))
+				sel.map((e) => (e.kind === 'file' ? deleteFile(e.id) : deleteFolder(e.id)))
 			);
-			const removed = new Set(selectedEntries.map((e) => e.id));
+			const removed = new Set(sel.map((e) => e.id));
 			raw = raw.filter((i) => !removed.has(i.resource.id));
-			selectedIds = new Set();
 		} catch (e) {
 			errorToast(e);
 		}
@@ -348,6 +349,7 @@
 	onloadmore={() => load(false, orderByForGroup())}
 	onopen={open}
 	onfavorite={toggleFavorite}
+	{favoriteIds}
 	showOwner
 	showDotfileToggle
 	selectable
@@ -359,7 +361,6 @@
 		cursor = undefined;
 		load(true, orderBy, rev);
 	}}
-	onselectionchange={(ids) => (selectedIds = ids)}
 >
 	{#snippet toolbar()}
 		{#if entries.length > 0}
@@ -368,16 +369,18 @@
 			>
 		{/if}
 	{/snippet}
-	{#snippet batchToolbar()}
-		<Button icon="download" data-testid="recent-batch-download-btn" onclick={batchDownload}
-			>{t('common.download', 'Download')}</Button
+	{#snippet batchToolbar(sel)}
+		<Button
+			icon="download"
+			data-testid="recent-batch-download-btn"
+			onclick={() => batchDownload(sel)}>{t('common.download', 'Download')}</Button
 		>
 		<Button
 			icon="arrows-alt"
 			data-testid="recent-batch-move-btn"
 			onclick={() => {
 				moveTarget = null;
-				moveItems = batchTargets();
+				moveItems = batchTargets(sel);
 				moveOpen = true;
 			}}>{t('files.move', 'Move')}</Button
 		>
@@ -385,7 +388,7 @@
 			variant="danger"
 			icon="trash"
 			data-testid="recent-batch-delete-btn"
-			onclick={batchDelete}>{t('common.delete', 'Delete')}</Button
+			onclick={() => batchDelete(sel)}>{t('common.delete', 'Delete')}</Button
 		>
 	{/snippet}
 </ResourceList>
@@ -400,10 +403,7 @@
 		bind:open={moveOpen}
 		item={moveTarget}
 		items={moveItems}
-		onmoved={() => {
-			selectedIds = new Set();
-			load(true, orderByForGroup());
-		}}
+		onmoved={() => load(true, orderByForGroup())}
 	/>
 {/if}
 {#if shareDialog.component}

--- a/src/application/adapters/carddav_adapter.rs
+++ b/src/application/adapters/carddav_adapter.rs
@@ -797,9 +797,24 @@ impl CardDavAdapter {
                     ("DAV:", "getlastmodified") => {
                         xml_writer
                             .write_event(Event::Start(BytesStart::new("D:getlastmodified")))?;
-                        xml_writer.write_event(Event::Text(BytesText::new(
-                            &contact.updated_at.to_rfc2822(),
-                        )))?;
+                        // Stack render (ROUND10 §13, byte-identical to
+                        // chrono) with the chrono fallback for
+                        // out-of-range timestamps — per-contact on the
+                        // multiget/PROPFIND path.
+                        let mut lm_buf = [0u8; 31];
+                        match crate::common::fmt::rfc2822_utc(
+                            &mut lm_buf,
+                            contact.updated_at.timestamp(),
+                        ) {
+                            Some(s) => {
+                                xml_writer.write_event(Event::Text(BytesText::new(s)))?;
+                            }
+                            None => {
+                                xml_writer.write_event(Event::Text(BytesText::new(
+                                    &contact.updated_at.to_rfc2822(),
+                                )))?;
+                            }
+                        }
                         xml_writer.write_event(Event::End(BytesEnd::new("D:getlastmodified")))?;
                     }
                     ("urn:ietf:params:xml:ns:carddav", "address-data") => {

--- a/src/application/dtos/calendar_dto.rs
+++ b/src/application/dtos/calendar_dto.rs
@@ -132,21 +132,26 @@ impl Default for CalendarEventDto {
 
 impl From<CalendarEvent> for CalendarEventDto {
     fn from(event: CalendarEvent) -> Self {
+        // Move every owned field out of the consumed entity — the old
+        // getter-clone shape deep-copied 6 Strings per event, dominated by
+        // the ~11 KB `ical_data` blob, on every CalDAV listing row
+        // (benches/ROUND11.md §19: 1.45x + the 11 KB memcpy gone).
+        let parts = event.into_parts();
         Self {
-            id: event.id().to_string(),
-            calendar_id: event.calendar_id().to_string(),
-            summary: event.summary().to_string(),
-            description: event.description().map(|s| s.to_string()),
-            location: event.location().map(|s| s.to_string()),
-            start_time: *event.start_time(),
-            end_time: *event.end_time(),
-            all_day: event.all_day(),
-            rrule: event.rrule().map(|s| s.to_string()),
-            ical_uid: event.ical_uid().to_string(),
-            recurrence_id: event.recurrence_id().copied(),
-            ical_data: event.ical_data().to_string(),
-            created_at: *event.created_at(),
-            updated_at: *event.updated_at(),
+            id: parts.id.to_string(),
+            calendar_id: parts.calendar_id.to_string(),
+            summary: parts.summary,
+            description: parts.description,
+            location: parts.location,
+            start_time: parts.start_time,
+            end_time: parts.end_time,
+            all_day: parts.all_day,
+            rrule: parts.rrule,
+            ical_uid: parts.ical_uid,
+            recurrence_id: parts.recurrence_id,
+            ical_data: parts.ical_data,
+            created_at: parts.created_at,
+            updated_at: parts.updated_at,
         }
     }
 }

--- a/src/application/dtos/display_helpers.rs
+++ b/src/application/dtos/display_helpers.rs
@@ -188,6 +188,50 @@ fn ext_of(name: &str) -> Option<&str> {
     Some(after_dot)
 }
 
+/// Longest extension any classifier table matches ("appimage", "markdown"
+/// — 8 bytes). Longer extensions can only ever hit the `_` arms, so they
+/// skip the buffer entirely.
+const MAX_CLASSIFIED_EXT: usize = 16;
+
+/// Lowercase `ext` into `buf` without heap allocation. Returns `None` for
+/// extensions longer than any table entry — the caller must then take the
+/// same default arm `ext.to_ascii_lowercase()` would have fallen into.
+fn lower_ext_into<'b>(ext: &str, buf: &'b mut [u8; MAX_CLASSIFIED_EXT]) -> Option<&'b str> {
+    let bytes = ext.as_bytes();
+    if bytes.len() > MAX_CLASSIFIED_EXT {
+        return None;
+    }
+    for (i, b) in bytes.iter().enumerate() {
+        buf[i] = b.to_ascii_lowercase();
+    }
+    // ASCII-lowercasing bytes keeps UTF-8 validity (non-ASCII bytes pass
+    // through untouched).
+    std::str::from_utf8(&buf[..bytes.len()]).ok()
+}
+
+/// The three display classifications for one `(name, mime)` pair.
+pub struct DisplayClass {
+    pub icon_class: &'static str,
+    pub icon_special_class: &'static str,
+    pub category: &'static str,
+}
+
+/// Run all three classifiers over one `(name, mime)` pair, lowering the
+/// extension **once into a stack buffer** instead of each classifier
+/// allocating its own `to_ascii_lowercase()` String on the fallback path
+/// (generic/empty MIME rows — common for code and unknown types). Each
+/// decision tree is byte-for-byte the classifier it replaces
+/// (benches/ROUND11.md §21 gates the equivalence over a corpus).
+pub fn classify_display(name: &str, mime: &str) -> DisplayClass {
+    let mut buf = [0u8; MAX_CLASSIFIED_EXT];
+    let ext = ext_of(name).and_then(|e| lower_ext_into(e, &mut buf));
+    DisplayClass {
+        icon_class: icon_class_with_ext(mime, ext),
+        icon_special_class: icon_special_class_with_ext(mime, ext),
+        category: category_with_ext(mime, ext),
+    }
+}
+
 // ─── Icon class (FontAwesome) ────────────────────────────────────────
 
 /// Returns the FontAwesome icon class for a file, considering both MIME
@@ -196,6 +240,12 @@ fn ext_of(name: &str) -> Option<&str> {
 /// Use this instead of the old `mime_to_icon_class` whenever the filename
 /// is available.
 pub fn icon_class_for(name: &str, mime: &str) -> &'static str {
+    let mut buf = [0u8; MAX_CLASSIFIED_EXT];
+    let ext = ext_of(name).and_then(|e| lower_ext_into(e, &mut buf));
+    icon_class_with_ext(mime, ext)
+}
+
+fn icon_class_with_ext(mime: &str, ext: Option<&str>) -> &'static str {
     // 1. Try specific MIME matches first
     match mime {
         "application/pdf" => return "fas fa-file-pdf",
@@ -273,8 +323,8 @@ pub fn icon_class_for(name: &str, mime: &str) -> &'static str {
     }
 
     // 3. Extension-based fallback (for application/octet-stream, empty, etc.)
-    if let Some(ext) = ext_of(name) {
-        return match ext.to_ascii_lowercase().as_str() {
+    if let Some(ext) = ext {
+        return match ext {
             "pdf" => "fas fa-file-pdf",
             "doc" | "docx" | "odt" | "rtf" => "fas fa-file-word",
             "xls" | "xlsx" | "ods" | "csv" => "fas fa-file-excel",
@@ -311,6 +361,12 @@ pub fn icon_class_for(name: &str, mime: &str) -> &'static str {
 /// The returned class maps to CSS rules in `style.css` that set colours,
 /// backgrounds and decorative pseudo-elements per file type.
 pub fn icon_special_class_for(name: &str, mime: &str) -> &'static str {
+    let mut buf = [0u8; MAX_CLASSIFIED_EXT];
+    let ext = ext_of(name).and_then(|e| lower_ext_into(e, &mut buf));
+    icon_special_class_with_ext(mime, ext)
+}
+
+fn icon_special_class_with_ext(mime: &str, ext: Option<&str>) -> &'static str {
     // 1. Specific MIME matches
     match mime {
         "application/pdf" => return "pdf-icon",
@@ -390,8 +446,8 @@ pub fn icon_special_class_for(name: &str, mime: &str) -> &'static str {
     }
 
     // 3. Extension-based fallback
-    if let Some(ext) = ext_of(name) {
-        return match ext.to_ascii_lowercase().as_str() {
+    if let Some(ext) = ext {
+        return match ext {
             "pdf" => "pdf-icon",
             "doc" | "docx" | "odt" | "rtf" => "doc-icon",
             "xls" | "xlsx" | "ods" | "csv" => "spreadsheet-icon",
@@ -437,6 +493,12 @@ pub fn icon_special_class_for(name: &str, mime: &str) -> &'static str {
 
 /// Returns a human-readable category label, considering MIME + extension.
 pub fn category_for(name: &str, mime: &str) -> &'static str {
+    let mut buf = [0u8; MAX_CLASSIFIED_EXT];
+    let ext = ext_of(name).and_then(|e| lower_ext_into(e, &mut buf));
+    category_with_ext(mime, ext)
+}
+
+fn category_with_ext(mime: &str, ext: Option<&str>) -> &'static str {
     // 1. Specific MIME matches
     match mime {
         "application/pdf" => return "PDF",
@@ -489,8 +551,8 @@ pub fn category_for(name: &str, mime: &str) -> &'static str {
     }
 
     // 3. Extension fallback
-    if let Some(ext) = ext_of(name) {
-        return match ext.to_ascii_lowercase().as_str() {
+    if let Some(ext) = ext {
+        return match ext {
             "pdf" => "PDF",
             "doc" | "docx" | "odt" | "rtf" | "txt" => "Document",
             "xls" | "xlsx" | "ods" | "csv" => "Spreadsheet",

--- a/src/application/dtos/favorites_dto.rs
+++ b/src/application/dtos/favorites_dto.rs
@@ -4,9 +4,7 @@ use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use super::cursor::{CursorListResponse, CursorQuery, PageCursor};
-use super::display_helpers::{
-    category_for, format_file_size, icon_class_for, icon_special_class_for,
-};
+use super::display_helpers::{classify_display, format_file_size};
 use super::grant_dto::{ResourceContentDto, ResourceTypeDto};
 use crate::domain::services::authorization::ResourceKind;
 
@@ -84,9 +82,10 @@ impl FavoriteItemDto {
                 .item_mime_type
                 .as_deref()
                 .unwrap_or("application/octet-stream");
-            self.icon_class = icon_class_for(name, mime).to_string();
-            self.icon_special_class = icon_special_class_for(name, mime).to_string();
-            self.category = category_for(name, mime).to_string();
+            let classes = classify_display(name, mime);
+            self.icon_class = classes.icon_class.to_string();
+            self.icon_special_class = classes.icon_special_class.to_string();
+            self.category = classes.category.to_string();
             self.size_formatted = format_file_size(self.item_size.unwrap_or(0) as u64);
         }
         self

--- a/src/application/dtos/file_dto.rs
+++ b/src/application/dtos/file_dto.rs
@@ -5,10 +5,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use super::display_helpers::{
-    category_for, format_file_size, icon_class_for, icon_special_class_for, intern_display,
-    intern_mime,
-};
+use super::display_helpers::{classify_display, format_file_size, intern_display, intern_mime};
 
 /// DTO for file responses
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -105,17 +102,17 @@ impl From<File> for FileDto {
         // Display fields come from closed static tables and MIME values
         // repeat massively across rows — intern instead of allocating a
         // fresh Arc<str> per row (`Arc::from(&str)` always allocs+copies).
-        let icon_class = intern_display(icon_class_for(&parts.name, &parts.mime_type));
-        let icon_special_class =
-            intern_display(icon_special_class_for(&parts.name, &parts.mime_type));
-        let category = intern_display(category_for(&parts.name, &parts.mime_type));
+        let classes = classify_display(&parts.name, &parts.mime_type);
+        let icon_class = intern_display(classes.icon_class);
+        let icon_special_class = intern_display(classes.icon_special_class);
+        let category = intern_display(classes.category);
         let size_formatted = format_file_size(parts.size);
         let mime_type = intern_mime(&parts.mime_type);
 
         Self {
             id: parts.id,
             name: parts.name,
-            path: parts.path_string,
+            path: parts.storage_path.into_joined(),
             size: parts.size,
             mime_type,
             folder_id: parts.folder_id,

--- a/src/application/dtos/folder_dto.rs
+++ b/src/application/dtos/folder_dto.rs
@@ -113,7 +113,7 @@ impl From<Folder> for FolderDto {
         Self {
             id: parts.id,
             name: parts.name,
-            path: parts.path_string,
+            path: parts.storage_path.into_joined(),
             parent_id: parts.parent_id,
             drive_id: parts.drive_id,
             created_at: parts.created_at,

--- a/src/application/dtos/recent_dto.rs
+++ b/src/application/dtos/recent_dto.rs
@@ -4,9 +4,7 @@ use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use super::cursor::{CursorListResponse, CursorQuery, PageCursor};
-use super::display_helpers::{
-    category_for, format_file_size, icon_class_for, icon_special_class_for,
-};
+use super::display_helpers::{classify_display, format_file_size};
 use super::grant_dto::{ResourceContentDto, ResourceTypeDto};
 use crate::domain::services::authorization::ResourceKind;
 
@@ -80,9 +78,10 @@ impl RecentItemDto {
                 .item_mime_type
                 .as_deref()
                 .unwrap_or("application/octet-stream");
-            self.icon_class = icon_class_for(name, mime).to_string();
-            self.icon_special_class = icon_special_class_for(name, mime).to_string();
-            self.category = category_for(name, mime).to_string();
+            let classes = classify_display(name, mime);
+            self.icon_class = classes.icon_class.to_string();
+            self.icon_special_class = classes.icon_special_class.to_string();
+            self.category = classes.category.to_string();
             self.size_formatted = format_file_size(self.item_size.unwrap_or(0) as u64);
         }
         self

--- a/src/application/ports/face_ports.rs
+++ b/src/application/ports/face_ports.rs
@@ -62,6 +62,15 @@ pub trait FaceRepository: Send + Sync + 'static {
         person_id: Option<Uuid>,
     ) -> Result<(), DomainError>;
 
+    /// Batch variant of [`Self::assign_person`]: apply every
+    /// `(face_id, person_id)` pair in one statement. Reclustering an
+    /// F-face library used to issue F sequential UPDATE round-trips
+    /// (benches/ROUND11.md §Q5 — the ROUND10 `save_faces` UNNEST pattern).
+    async fn assign_person_batch(
+        &self,
+        assignments: &[(Uuid, Option<Uuid>)],
+    ) -> Result<(), DomainError>;
+
     // ── persons ────────────────────────────────────────────────────
     async fn create_person(&self, person: &Person) -> Result<(), DomainError>;
     async fn persons_for_user(&self, user_id: Uuid) -> Result<Vec<Person>, DomainError>;

--- a/src/application/ports/thumbnail_ports.rs
+++ b/src/application/ports/thumbnail_ports.rs
@@ -21,6 +21,19 @@ pub enum ThumbnailSize {
 }
 
 impl ThumbnailSize {
+    /// Stable name, byte-identical to the derived `Debug` output. Used by
+    /// the thumbnail/preview ETags on the hottest revalidation path — a
+    /// `&'static str` push beats routing through the `Debug` machinery
+    /// (benches/ROUND11.md §7) while keeping every already-cached client
+    /// ETag valid.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ThumbnailSize::Icon => "Icon",
+            ThumbnailSize::Preview => "Preview",
+            ThumbnailSize::Large => "Large",
+        }
+    }
+
     /// Get the maximum dimension for this size.
     pub fn max_dimension(&self) -> u32 {
         match self {
@@ -64,6 +77,15 @@ pub enum ThumbnailFormat {
 }
 
 impl ThumbnailFormat {
+    /// Stable name, byte-identical to the derived `Debug` output (see
+    /// [`ThumbnailSize::as_str`] — same ETag-stability contract).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ThumbnailFormat::Webp => "Webp",
+            ThumbnailFormat::Jpeg => "Jpeg",
+        }
+    }
+
     /// On-disk file extension for this format (no dot).
     pub fn ext(self) -> &'static str {
         match self {

--- a/src/application/services/contact_service.rs
+++ b/src/application/services/contact_service.rs
@@ -263,27 +263,32 @@ impl ContactService {
     }
 
     fn generate_vcard(&self, contact: &Contact) -> String {
+        // `write!` formats straight into `vcard`; the old
+        // `push_str(&format!(…))` allocated a throwaway String per emitted
+        // line (benches/ROUND11.md §10: 766 → 357 ns, 21 → 5 allocs).
+        use std::fmt::Write as _;
         let mut vcard = String::from("BEGIN:VCARD\r\nVERSION:3.0\r\n");
 
         // UID
-        vcard.push_str(&format!("UID:{}\r\n", contact.uid()));
+        let _ = write!(vcard, "UID:{}\r\n", contact.uid());
 
         // Name fields
         if let Some(full_name) = contact.full_name() {
-            vcard.push_str(&format!("FN:{}\r\n", full_name));
+            let _ = write!(vcard, "FN:{}\r\n", full_name);
         }
 
-        let last_name = contact.last_name().unwrap_or_default().to_string();
-        let first_name = contact.first_name().unwrap_or_default().to_string();
-        vcard.push_str(&format!("N:{};{};;;\r\n", last_name, first_name));
+        let last_name = contact.last_name().unwrap_or_default();
+        let first_name = contact.first_name().unwrap_or_default();
+        let _ = write!(vcard, "N:{};{};;;\r\n", last_name, first_name);
 
         // Email addresses
         for email in contact.email() {
-            vcard.push_str(&format!(
+            let _ = write!(
+                vcard,
                 "EMAIL;TYPE={}:{}\r\n",
                 email.r#type.to_uppercase(),
                 email.email
-            ));
+            );
         }
 
         // Phone numbers
@@ -295,49 +300,51 @@ impl ContactService {
                 "fax" => "FAX",
                 _ => "OTHER",
             };
-            vcard.push_str(&format!("TEL;TYPE={}:{}\r\n", tel_type, phone.number));
+            let _ = write!(vcard, "TEL;TYPE={}:{}\r\n", tel_type, phone.number);
         }
 
         // Addresses
         for addr in contact.address() {
             let addr_type = addr.r#type.to_uppercase();
-            let street = addr.street.clone().unwrap_or_default();
-            let city = addr.city.clone().unwrap_or_default();
-            let state = addr.state.clone().unwrap_or_default();
-            let postal_code = addr.postal_code.clone().unwrap_or_default();
-            let country = addr.country.clone().unwrap_or_default();
+            let street = addr.street.as_deref().unwrap_or_default();
+            let city = addr.city.as_deref().unwrap_or_default();
+            let state = addr.state.as_deref().unwrap_or_default();
+            let postal_code = addr.postal_code.as_deref().unwrap_or_default();
+            let country = addr.country.as_deref().unwrap_or_default();
 
-            vcard.push_str(&format!(
+            let _ = write!(
+                vcard,
                 "ADR;TYPE={}:;;{};{};{};{};{}\r\n",
                 addr_type, street, city, state, postal_code, country
-            ));
+            );
         }
 
         // Organization
         if let Some(org) = contact.organization() {
-            vcard.push_str(&format!("ORG:{}\r\n", org));
+            let _ = write!(vcard, "ORG:{}\r\n", org);
         }
 
         // Title
         if let Some(title) = contact.title() {
-            vcard.push_str(&format!("TITLE:{}\r\n", title));
+            let _ = write!(vcard, "TITLE:{}\r\n", title);
         }
 
         // Notes
         if let Some(notes) = contact.notes() {
-            vcard.push_str(&format!("NOTE:{}\r\n", notes));
+            let _ = write!(vcard, "NOTE:{}\r\n", notes);
         }
 
         // Birthday
         if let Some(birthday) = contact.birthday() {
-            vcard.push_str(&format!("BDAY:{}\r\n", birthday.format("%Y%m%d")));
+            let _ = write!(vcard, "BDAY:{}\r\n", birthday.format("%Y%m%d"));
         }
 
         // Revision (last update)
-        vcard.push_str(&format!(
+        let _ = write!(
+            vcard,
             "REV:{}\r\n",
             contact.updated_at().format("%Y%m%dT%H%M%SZ")
-        ));
+        );
 
         vcard.push_str("END:VCARD\r\n");
 

--- a/src/application/services/people_service.rs
+++ b/src/application/services/people_service.rs
@@ -23,17 +23,30 @@ use crate::common::errors::DomainError;
 use crate::domain::entities::face::Person;
 use crate::infrastructure::repositories::pg::FacePgRepository;
 
-/// Cosine similarity of two equal-length vectors. Embeddings are produced
-/// L2-normalized, so this is ~a dot product; we normalize anyway for safety.
-fn cosine(a: &[f32], b: &[f32]) -> f32 {
+/// Squared L2 norm, accumulated in the same order `cosine` used to, so
+/// the precomputed-norm path is bit-identical to the old per-pair one.
+fn norm_sq(v: &[f32]) -> f32 {
+    let mut n = 0.0f32;
+    for &x in v {
+        n += x * x;
+    }
+    n
+}
+
+/// Cosine similarity of two equal-length vectors given their precomputed
+/// squared norms. Embeddings are produced L2-normalized, so this is ~a dot
+/// product; we normalize anyway for safety. The O(N²) recluster pair loop
+/// used to re-accumulate BOTH norms on every pair — precomputing them once
+/// per face keeps only the dot product in the hot loop while the final
+/// `dot / (√na · √nb)` expression (and the zero guards) stay exactly as
+/// before, so results are bit-identical (benches/ROUND11.md §17).
+fn cosine_with_norms(a: &[f32], b: &[f32], na: f32, nb: f32) -> f32 {
     if a.len() != b.len() || a.is_empty() {
         return 0.0;
     }
-    let (mut dot, mut na, mut nb) = (0.0f32, 0.0f32, 0.0f32);
+    let mut dot = 0.0f32;
     for (&x, &y) in a.iter().zip(b.iter()) {
         dot += x * y;
-        na += x * x;
-        nb += y * y;
     }
     if na == 0.0 || nb == 0.0 {
         return 0.0;
@@ -102,10 +115,13 @@ impl PeopleService {
             return Ok(0);
         }
 
+        let norms: Vec<f32> = faces.iter().map(|f| norm_sq(&f.embedding)).collect();
         let mut uf = UnionFind::new(n);
         for i in 0..n {
             for j in (i + 1)..n {
-                if cosine(&faces[i].embedding, &faces[j].embedding) >= self.cluster_threshold {
+                if cosine_with_norms(&faces[i].embedding, &faces[j].embedding, norms[i], norms[j])
+                    >= self.cluster_threshold
+                {
                     uf.union(i, j);
                 }
             }
@@ -117,13 +133,19 @@ impl PeopleService {
             groups.entry(root).or_default().push(i);
         }
 
+        // Accumulate every (face, person) change and apply them in ONE
+        // UNNEST batch at the end — the old per-face `assign_person` loop
+        // issued up to F sequential UPDATE round-trips per recluster
+        // (benches/ROUND11.md §Q5; the ROUND10 `save_faces` pattern). The
+        // final column state is identical.
+        let mut assignments: Vec<(Uuid, Option<Uuid>)> = Vec::new();
         let mut created = 0usize;
         for idxs in groups.into_values() {
             if idxs.len() < self.min_faces {
                 // Too small to be a person — leave/reset these faces unassigned.
                 for &i in &idxs {
                     if faces[i].person_id.is_some() {
-                        self.repo.assign_person(faces[i].id, None).await?;
+                        assignments.push((faces[i].id, None));
                     }
                 }
                 continue;
@@ -151,9 +173,7 @@ impl PeopleService {
             };
             for &i in &idxs {
                 if faces[i].person_id != Some(person_id) {
-                    self.repo
-                        .assign_person(faces[i].id, Some(person_id))
-                        .await?;
+                    assignments.push((faces[i].id, Some(person_id)));
                 }
             }
             let _ = self
@@ -161,6 +181,7 @@ impl PeopleService {
                 .set_person_cover(person_id, faces[idxs[0]].id)
                 .await;
         }
+        self.repo.assign_person_batch(&assignments).await?;
 
         Ok(created)
     }

--- a/src/application/services/search_service.rs
+++ b/src/application/services/search_service.rs
@@ -381,15 +381,19 @@ impl SearchService {
         // log it) — never leak. Batched: one drive-resolution query for
         // the whole page instead of up to CONTENT_HITS_LIMIT sequential
         // point SELECTs (benches/SEARCH-REBAC.md).
-        let mut hit_ids = Vec::with_capacity(hits.len());
-        for hit in &hits {
+        // Parse each hit id ONCE and carry the pair through the verify loop
+        // — the old shape re-parsed every `file_id` a second time below
+        // (benches/ROUND11.md §12: 1.6x on a 100-hit page).
+        let mut pairs = Vec::with_capacity(hits.len());
+        for hit in hits {
             match Uuid::parse_str(&hit.file_id) {
-                Ok(u) => hit_ids.push(u),
+                Ok(u) => pairs.push((hit, u)),
                 Err(_) => {
                     tracing::warn!("Content-index hit had non-UUID file_id: {}", hit.file_id);
                 }
             }
         }
+        let hit_ids: Vec<Uuid> = pairs.iter().map(|(_, u)| *u).collect();
         let allowed = match authz
             .check_files_read_batch(Subject::User(user_id), &hit_ids)
             .await
@@ -400,11 +404,8 @@ impl SearchService {
                 return Vec::new();
             }
         };
-        let mut verified = Vec::with_capacity(hits.len());
-        for hit in hits {
-            let Ok(file_uuid) = Uuid::parse_str(&hit.file_id) else {
-                continue; // already warned above
-            };
+        let mut verified = Vec::with_capacity(pairs.len());
+        for (hit, file_uuid) in pairs {
             if allowed.contains(&file_uuid) {
                 verified.push(hit);
             } else {
@@ -692,13 +693,24 @@ impl SearchUseCase for SearchService {
 
                     let folder_start = start_idx.min(folder_count);
                     let folder_end = end_idx.min(folder_count);
-                    let paginated_folders = enriched_folders[folder_start..folder_end].to_vec();
+                    // Move the page out of the owned vecs instead of
+                    // deep-cloning the slice — the source is dropped right
+                    // after (benches/ROUND11.md §11: −300 allocs per page).
+                    let paginated_folders: Vec<_> = enriched_folders
+                        .into_iter()
+                        .skip(folder_start)
+                        .take(folder_end - folder_start)
+                        .collect();
 
                     let file_start = start_idx.saturating_sub(folder_count);
                     let file_end = end_idx
                         .saturating_sub(folder_count)
                         .min(enriched_files.len());
-                    let paginated_files = enriched_files[file_start..file_end].to_vec();
+                    let paginated_files: Vec<_> = enriched_files
+                        .into_iter()
+                        .skip(file_start)
+                        .take(file_end - file_start)
+                        .collect();
 
                     let elapsed_ms = start.elapsed().as_millis() as u64;
 
@@ -783,13 +795,24 @@ impl SearchUseCase for SearchService {
 
                 let folder_start = start_idx.min(folder_count);
                 let folder_end = end_idx.min(folder_count);
-                let paginated_folders = enriched_folders[folder_start..folder_end].to_vec();
+                // Move the page out instead of deep-cloning the slice — the
+                // recursive branch's vecs can hold the whole subtree match
+                // set, all dropped right after (benches/ROUND11.md §11).
+                let paginated_folders: Vec<_> = enriched_folders
+                    .into_iter()
+                    .skip(folder_start)
+                    .take(folder_end - folder_start)
+                    .collect();
 
                 let file_start = start_idx.saturating_sub(folder_count);
                 let file_end = end_idx
                     .saturating_sub(folder_count)
                     .min(enriched_files.len());
-                let paginated_files = enriched_files[file_start..file_end].to_vec();
+                let paginated_files: Vec<_> = enriched_files
+                    .into_iter()
+                    .skip(file_start)
+                    .take(file_end - file_start)
+                    .collect();
 
                 let elapsed_ms = start.elapsed().as_millis() as u64;
 

--- a/src/application/services/subject_group_service.rs
+++ b/src/application/services/subject_group_service.rs
@@ -496,7 +496,11 @@ impl SubjectGroupService {
                         .list_transitive_users(child_id)
                         .await
                         .map_err(map_repo_err)?;
-                    !child_users.is_empty() && users_before.iter().all(|u| child_users.contains(u))
+                    // Set probe instead of an O(|before|·|child|) slice scan
+                    // (benches/ROUND11.md §13: 5.7x at 500×500).
+                    let child_set: std::collections::HashSet<&uuid::Uuid> =
+                        child_users.iter().collect();
+                    !child_users.is_empty() && users_before.iter().all(|u| child_set.contains(u))
                 }
             };
             if would_be_empty {

--- a/src/application/services/trash_service.rs
+++ b/src/application/services/trash_service.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::application::dtos::cursor::PageCursor;
 use crate::application::dtos::display_helpers::{
-    category_for, format_file_size, icon_class_for, icon_special_class_for,
+    classify_display, format_file_size, intern_display, intern_mime,
 };
 use crate::application::dtos::file_dto::FileDto;
 use crate::application::dtos::folder_dto::FolderDto;
@@ -115,25 +115,31 @@ impl TrashService {
                 "folder-icon".to_string(),
             ),
             TrashedItemType::File => {
-                let name = item.name();
-                // Use empty MIME type to leverage extension fallback
-                let category = category_for(name, "").to_string();
-                let icon_class = icon_class_for(name, "").to_string();
-                let icon_special_class = icon_special_class_for(name, "").to_string();
-                (category, icon_class, icon_special_class)
+                // Use empty MIME type to leverage extension fallback; one
+                // fused pass lowers the extension once instead of three
+                // times (benches/ROUND11.md §21).
+                let classes = classify_display(item.name(), "");
+                (
+                    classes.category.to_string(),
+                    classes.icon_class.to_string(),
+                    classes.icon_special_class.to_string(),
+                )
             }
         };
 
+        // Move the owned Strings out of the consumed item — the getter
+        // `.to_string()` clones paid 2 extra allocations per trash row.
+        let parts = item.into_parts();
         TrashedItemDto {
-            id: item.id().to_string(),
-            original_id: item.original_id().to_string(),
-            item_type: match item.item_type() {
+            id: parts.id.to_string(),
+            original_id: parts.original_id.to_string(),
+            item_type: match parts.item_type {
                 TrashedItemType::File => "file".to_string(),
                 TrashedItemType::Folder => "folder".to_string(),
             },
-            name: item.name().to_string(),
-            original_path: item.original_path().to_string(),
-            trashed_at: item.trashed_at(),
+            name: parts.name,
+            original_path: parts.original_path,
+            trashed_at: parts.trashed_at,
             days_until_deletion,
             category,
             icon_class,
@@ -906,18 +912,19 @@ fn row_to_item_dto(row: TrashResourceRow) -> TrashResourceItemDto {
         } else {
             File::compute_etag(&content_hash, modified_at_u)
         };
+        let classes = classify_display(&row.name, mime);
         let dto = FileDto {
             id: row.resource_id.to_string(),
             name: row.name.clone(),
             path,
             size: size_bytes,
-            mime_type: std::sync::Arc::from(mime),
+            mime_type: intern_mime(mime),
             folder_id: row.parent_id.map(|u| u.to_string()),
             created_at: row.resource_created_at.timestamp() as u64,
             modified_at: modified_at_u,
-            icon_class: std::sync::Arc::from(icon_class_for(&row.name, mime)),
-            icon_special_class: std::sync::Arc::from(icon_special_class_for(&row.name, mime)),
-            category: std::sync::Arc::from(category_for(&row.name, mime)),
+            icon_class: intern_display(classes.icon_class),
+            icon_special_class: intern_display(classes.icon_special_class),
+            category: intern_display(classes.category),
             size_formatted: format_file_size(size_bytes),
             sort_date: None,
             content_hash,

--- a/src/domain/entities/calendar_event.rs
+++ b/src/domain/entities/calendar_event.rs
@@ -22,6 +22,25 @@ pub use super::entity_errors::CalendarEventError;
  * Represents a calendar event or appointment that can be synced via CalDAV.
  * Follows the iCalendar format (RFC 5545) for compatibility with CalDAV clients.
  */
+/// Owned decomposition of a [`CalendarEvent`] (see
+/// [`CalendarEvent::into_parts`]).
+pub struct CalendarEventParts {
+    pub id: Uuid,
+    pub calendar_id: Uuid,
+    pub summary: String,
+    pub description: Option<String>,
+    pub location: Option<String>,
+    pub start_time: DateTime<Utc>,
+    pub end_time: DateTime<Utc>,
+    pub all_day: bool,
+    pub rrule: Option<String>,
+    pub recurrence_id: Option<DateTime<Utc>>,
+    pub ical_uid: String,
+    pub ical_data: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 #[derive(Debug, Clone)]
 pub struct CalendarEvent {
     /// Unique identifier for the event
@@ -454,6 +473,30 @@ impl CalendarEvent {
     /// Returns the time when the event was last modified
     pub fn updated_at(&self) -> &DateTime<Utc> {
         &self.updated_at
+    }
+
+    /// Decompose into owned parts for DTO conversion — the `File`/`Folder`/
+    /// `Contact` pattern. Moving the owned `String`s (most importantly the
+    /// unbounded `ical_data` blob, ~11 KB with attendees/VALARMs) replaces
+    /// the per-event deep copies `CalendarEventDto::from` used to make via
+    /// getters (benches/ROUND11.md §19).
+    pub fn into_parts(self) -> CalendarEventParts {
+        CalendarEventParts {
+            id: self.id,
+            calendar_id: self.calendar_id,
+            summary: self.summary,
+            description: self.description,
+            location: self.location,
+            start_time: self.start_time,
+            end_time: self.end_time,
+            all_day: self.all_day,
+            rrule: self.rrule,
+            recurrence_id: self.recurrence_id,
+            ical_uid: self.ical_uid,
+            ical_data: self.ical_data,
+            created_at: self.created_at,
+            updated_at: self.updated_at,
+        }
     }
 
     /// Returns the duration of the event

--- a/src/domain/entities/file.rs
+++ b/src/domain/entities/file.rs
@@ -16,7 +16,6 @@ pub struct FileParts {
     pub id: String,
     pub name: String,
     pub storage_path: StoragePath,
-    pub path_string: String,
     pub size: u64,
     pub mime_type: String,
     pub folder_id: Option<String>,
@@ -48,11 +47,10 @@ pub struct File {
     /// Name of the file including extension
     name: String,
 
-    /// Path to the file in the domain model
+    /// Path to the file in the domain model. Owns the canonical joined
+    /// string; `path_string()` borrows it (the separate duplicate field
+    /// was removed in ROUND11 §20 along with per-segment allocations).
     storage_path: StoragePath,
-
-    /// String representation of the path for API compatibility
-    path_string: String,
 
     /// Size of the file in bytes
     size: u64,
@@ -99,7 +97,6 @@ impl Default for File {
             id: "stub-id".to_string(),
             name: "stub-file.txt".to_string(),
             storage_path: StoragePath::from_string("/"),
-            path_string: "/".to_string(),
             size: 0,
             mime_type: "application/octet-stream".to_string(),
             folder_id: None,
@@ -132,14 +129,10 @@ impl File {
             .unwrap_or_default()
             .as_secs();
 
-        // Store the path string for serialization compatibility
-        let path_string = storage_path.to_path_string();
-
         Ok(Self {
             id,
             name,
             storage_path,
-            path_string,
             size,
             mime_type,
             folder_id,
@@ -165,14 +158,10 @@ impl File {
             return Err(FileError::InvalidFileName(format!("{name}: {reason}")));
         }
 
-        // Store the path string for serialization compatibility
-        let path_string = storage_path.to_path_string();
-
         Ok(Self {
             id,
             name,
             storage_path,
-            path_string,
             size: 0,                            // Folders have zero size
             mime_type: "directory".to_string(), // Standard MIME type for directories
             folder_id: parent_id,
@@ -257,14 +246,10 @@ impl File {
             return Err(FileError::InvalidFileName(format!("{name}: {reason}")));
         }
 
-        // Store the path string for serialization compatibility
-        let path_string = storage_path.to_path_string();
-
         Ok(Self {
             id,
             name,
             storage_path,
-            path_string,
             size,
             mime_type,
             folder_id,
@@ -304,7 +289,7 @@ impl File {
         created_by: Option<Uuid>,
         updated_by: Option<Uuid>,
     ) -> FileResult<Self> {
-        let (storage_path, path_string) = StoragePath::from_folder_and_name(folder_path, &name);
+        let storage_path = StoragePath::from_folder_and_name(folder_path, &name);
 
         let name = normalize_storage_name_owned(name);
         if let Err(reason) = validate_storage_name(&name) {
@@ -315,7 +300,6 @@ impl File {
             id,
             name,
             storage_path,
-            path_string,
             size,
             mime_type,
             folder_id,
@@ -336,7 +320,6 @@ impl File {
             id: self.id,
             name: self.name,
             storage_path: self.storage_path,
-            path_string: self.path_string,
             size: self.size,
             mime_type: self.mime_type,
             folder_id: self.folder_id,
@@ -438,7 +421,7 @@ impl File {
     }
 
     pub fn path_string(&self) -> &str {
-        &self.path_string
+        self.storage_path.as_str()
     }
 
     pub fn size(&self) -> u64 {
@@ -487,8 +470,9 @@ impl File {
         created_at: u64,
         modified_at: u64,
     ) -> Self {
-        // Create storage_path from string
-        let storage_path = StoragePath::from_string(&path);
+        // Adopt the DTO path (canonical inputs are reused with zero
+        // copies; non-canonical ones are normalized like from_string did).
+        let storage_path = StoragePath::from_joined(path);
 
         // Create directly without validation to avoid errors in DTO
         // conversions. Still NFC-normalize so even DTO-reconstructed
@@ -499,7 +483,6 @@ impl File {
             id,
             name,
             storage_path,
-            path_string: path,
             size,
             mime_type,
             folder_id,
@@ -536,7 +519,6 @@ impl File {
         // Consume `self` and mutate in place — only the path, name and mtime
         // change; id / mime_type / folder_id / blob_hash are carried over
         // without the per-field clone the old `&self` builder paid.
-        self.path_string = new_storage_path.to_path_string();
         self.storage_path = new_storage_path;
         self.name = new_name;
         self.modified_at = now;
@@ -561,7 +543,6 @@ impl File {
             .as_secs();
 
         // Consume `self`: only the path, folder_id and mtime change.
-        self.path_string = new_storage_path.to_path_string();
         self.storage_path = new_storage_path;
         self.folder_id = folder_id;
         self.modified_at = now;

--- a/src/domain/entities/folder.rs
+++ b/src/domain/entities/folder.rs
@@ -17,7 +17,6 @@ pub struct FolderParts {
     pub id: String,
     pub name: String,
     pub storage_path: StoragePath,
-    pub path_string: String,
     pub parent_id: Option<String>,
     /// Drive that owns this folder. See [`Folder::drive_id`].
     pub drive_id: Uuid,
@@ -40,11 +39,9 @@ pub struct Folder {
     /// Name of the folder
     name: String,
 
-    /// Path to the folder in the domain model
+    /// Path to the folder in the domain model. Owns the canonical joined
+    /// string; `path_string()` borrows it (ROUND11 §20).
     storage_path: StoragePath,
-
-    /// String representation of the path (for API compatibility)
-    path_string: String,
 
     /// Parent folder ID (None if it's a root folder)
     parent_id: Option<String>,
@@ -94,7 +91,6 @@ impl Default for Folder {
             id: "stub-id".to_string(),
             name: "stub-folder".to_string(),
             storage_path: StoragePath::from_string("/"),
-            path_string: "/".to_string(),
             parent_id: None,
             drive_id: Uuid::nil(),
             created_at: 0,
@@ -130,13 +126,10 @@ impl Folder {
             .unwrap_or_default()
             .as_secs();
 
-        let path_string = storage_path.to_path_string();
-
         Ok(Self {
             id,
             name,
             storage_path,
-            path_string,
             parent_id,
             drive_id: Uuid::nil(),
             created_at: now,
@@ -226,13 +219,10 @@ impl Folder {
             return Err(FolderError::InvalidFolderName(format!("{name}: {reason}")));
         }
 
-        let path_string = storage_path.to_path_string();
-
         Ok(Self {
             id,
             name,
             storage_path,
-            path_string,
             parent_id,
             drive_id,
             created_at,
@@ -270,13 +260,12 @@ impl Folder {
             return Err(FolderError::InvalidFolderName(format!("{name}: {reason}")));
         }
 
-        let (storage_path, path_string) = StoragePath::from_joined(path);
+        let storage_path = StoragePath::from_joined(path);
 
         Ok(Self {
             id,
             name,
             storage_path,
-            path_string,
             parent_id,
             drive_id,
             created_at,
@@ -296,7 +285,6 @@ impl Folder {
             id: self.id,
             name: self.name,
             storage_path: self.storage_path,
-            path_string: self.path_string,
             parent_id: self.parent_id,
             drive_id: self.drive_id,
             created_at: self.created_at,
@@ -321,7 +309,7 @@ impl Folder {
     }
 
     pub fn path_string(&self) -> &str {
-        &self.path_string
+        self.storage_path.as_str()
     }
 
     pub fn parent_id(&self) -> Option<&str> {
@@ -445,8 +433,8 @@ impl Folder {
         created_at: u64,
         modified_at: u64,
     ) -> Self {
-        // Create storage_path from the string
-        let storage_path = StoragePath::from_string(&path);
+        // Adopt the DTO path (canonical inputs reused with zero copies).
+        let storage_path = StoragePath::from_joined(path);
 
         // Create directly without validation to avoid errors in DTO
         // conversions. Still NFC-normalize so DTO-reconstructed
@@ -460,7 +448,6 @@ impl Folder {
             id,
             name,
             storage_path,
-            path_string: path,
             parent_id,
             // DTO round-trips lose drive_id (FolderDto carries it,
             // but the legacy `from_dto` signature predates this
@@ -495,9 +482,6 @@ impl Folder {
             None => StoragePath::from_string(&new_name),
         };
 
-        // Update string representation
-        let new_path_string = new_storage_path.to_path_string();
-
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -507,7 +491,6 @@ impl Folder {
             id: self.id.clone(),
             name: new_name,
             storage_path: new_storage_path,
-            path_string: new_path_string,
             parent_id: self.parent_id.clone(),
             drive_id: self.drive_id,
             created_at: self.created_at,
@@ -535,9 +518,6 @@ impl Folder {
             None => StoragePath::from_string(&self.name), // Root
         };
 
-        // Update string representation
-        let new_path_string = new_storage_path.to_path_string();
-
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap_or_default()
@@ -547,7 +527,6 @@ impl Folder {
             id: self.id.clone(),
             name: self.name.clone(),
             storage_path: new_storage_path,
-            path_string: new_path_string,
             parent_id,
             drive_id: self.drive_id,
             created_at: self.created_at,
@@ -562,12 +541,9 @@ impl Folder {
     pub fn get_absolute_path<P: AsRef<std::path::Path>>(&self, root_path: P) -> std::path::PathBuf {
         let mut result = std::path::PathBuf::from(root_path.as_ref());
 
-        // Skip leading '/' from path_string to avoid creating absolute path incorrectly
-        let relative_path = if self.path_string.starts_with('/') {
-            &self.path_string[1..]
-        } else {
-            &self.path_string
-        };
+        // Skip leading '/' to avoid creating an absolute path incorrectly
+        let path_string = self.storage_path.as_str();
+        let relative_path = path_string.strip_prefix('/').unwrap_or(path_string);
 
         if !relative_path.is_empty() {
             result.push(relative_path);

--- a/src/domain/entities/trashed_item.rs
+++ b/src/domain/entities/trashed_item.rs
@@ -7,7 +7,6 @@ pub enum TrashedItemType {
     Folder,
 }
 
-#[derive(Debug, Clone)]
 /// Owned decomposition of a [`TrashedItem`] (see
 /// [`TrashedItem::into_parts`]).
 pub struct TrashedItemParts {
@@ -19,6 +18,7 @@ pub struct TrashedItemParts {
     pub trashed_at: DateTime<Utc>,
 }
 
+#[derive(Debug, Clone)]
 pub struct TrashedItem {
     id: Uuid,
     original_id: Uuid,

--- a/src/domain/entities/trashed_item.rs
+++ b/src/domain/entities/trashed_item.rs
@@ -8,6 +8,17 @@ pub enum TrashedItemType {
 }
 
 #[derive(Debug, Clone)]
+/// Owned decomposition of a [`TrashedItem`] (see
+/// [`TrashedItem::into_parts`]).
+pub struct TrashedItemParts {
+    pub id: Uuid,
+    pub original_id: Uuid,
+    pub item_type: TrashedItemType,
+    pub name: String,
+    pub original_path: String,
+    pub trashed_at: DateTime<Utc>,
+}
+
 pub struct TrashedItem {
     id: Uuid,
     original_id: Uuid,
@@ -96,6 +107,20 @@ impl TrashedItem {
 
     pub fn deletion_date(&self) -> DateTime<Utc> {
         self.deletion_date
+    }
+
+    /// Decompose into owned parts for DTO conversion — moves `name` /
+    /// `original_path` instead of the getter clones `to_dto` used to make
+    /// per trash row (benches/ROUND11.md; the File/Folder/Contact pattern).
+    pub fn into_parts(self) -> TrashedItemParts {
+        TrashedItemParts {
+            id: self.id,
+            original_id: self.original_id,
+            item_type: self.item_type,
+            name: self.name,
+            original_path: self.original_path,
+            trashed_at: self.trashed_at,
+        }
     }
 
     pub fn days_until_deletion(&self) -> i64 {

--- a/src/domain/errors.rs
+++ b/src/domain/errors.rs
@@ -41,21 +41,30 @@ pub enum ErrorKind {
     Conflict,
 }
 
+impl ErrorKind {
+    /// Stable human-readable name; `Display` delegates here so the two can
+    /// never drift. Being `&'static` it lets the HTTP error path borrow the
+    /// value instead of allocating per response (benches/ROUND11.md §9).
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ErrorKind::NotFound => "Not Found",
+            ErrorKind::AlreadyExists => "Already Exists",
+            ErrorKind::InvalidInput => "Invalid Input",
+            ErrorKind::AccessDenied => "Access Denied",
+            ErrorKind::Timeout => "Timeout",
+            ErrorKind::InternalError => "Internal Error",
+            ErrorKind::NotImplemented => "Not Implemented",
+            ErrorKind::UnsupportedOperation => "Unsupported Operation",
+            ErrorKind::DatabaseError => "Database Error",
+            ErrorKind::QuotaExceeded => "Quota Exceeded",
+            ErrorKind::Conflict => "Conflict",
+        }
+    }
+}
+
 impl Display for ErrorKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            ErrorKind::NotFound => write!(f, "Not Found"),
-            ErrorKind::AlreadyExists => write!(f, "Already Exists"),
-            ErrorKind::InvalidInput => write!(f, "Invalid Input"),
-            ErrorKind::AccessDenied => write!(f, "Access Denied"),
-            ErrorKind::Timeout => write!(f, "Timeout"),
-            ErrorKind::InternalError => write!(f, "Internal Error"),
-            ErrorKind::NotImplemented => write!(f, "Not Implemented"),
-            ErrorKind::UnsupportedOperation => write!(f, "Unsupported Operation"),
-            ErrorKind::DatabaseError => write!(f, "Database Error"),
-            ErrorKind::QuotaExceeded => write!(f, "Quota Exceeded"),
-            ErrorKind::Conflict => write!(f, "Conflict"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
@@ -91,11 +100,14 @@ impl DomainError {
     /// Creates an entity not found error
     pub fn not_found<S: Into<String>>(entity_type: &'static str, entity_id: S) -> Self {
         let id = entity_id.into();
+        // Message first, then move the id — the old `Some(id.clone())`
+        // paid an extra allocation on every 404 construction.
+        let message = format!("{} not found: {}", entity_type, id);
         Self {
             kind: ErrorKind::NotFound,
             entity_type,
-            entity_id: Some(id.clone()),
-            message: format!("{} not found: {}", entity_type, id),
+            entity_id: Some(id),
+            message,
             source: None,
         }
     }
@@ -103,11 +115,12 @@ impl DomainError {
     /// Creates an entity already exists error
     pub fn already_exists<S: Into<String>>(entity_type: &'static str, entity_id: S) -> Self {
         let id = entity_id.into();
+        let message = format!("{} already exists: {}", entity_type, id);
         Self {
             kind: ErrorKind::AlreadyExists,
             entity_type,
-            entity_id: Some(id.clone()),
-            message: format!("{} already exists: {}", entity_type, id),
+            entity_id: Some(id),
+            message,
             source: None,
         }
     }

--- a/src/domain/services/path_service.rs
+++ b/src/domain/services/path_service.rs
@@ -76,10 +76,25 @@ pub fn validate_storage_name(name: &str) -> Result<(), &'static str> {
     Ok(())
 }
 
-/// Represents a storage path in the domain (Value Object)
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+/// Represents a storage path in the domain (Value Object).
+///
+/// Stored as the single **canonical joined form**: `"/"` for the root, or
+/// `/seg(/seg)*` with every segment safe (non-empty, not `.`/`..`, no
+/// `/`). Round 11 replaced the old `segments: Vec<String>` representation
+/// — one heap `String` per component built on EVERY hydrated listing row
+/// even though the DTO path only ever consumed the joined form — with this
+/// one-allocation shape; segment views are derived on demand
+/// (benches/ROUND11.md §20: 4 000 → 1 000 allocs on a 500-row page).
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StoragePath {
-    segments: Vec<String>,
+    /// Canonical joined rendering (`Display`'s output).
+    joined: String,
+}
+
+impl Default for StoragePath {
+    fn default() -> Self {
+        Self::root()
+    }
 }
 
 impl StoragePath {
@@ -88,20 +103,30 @@ impl StoragePath {
         !s.is_empty() && s != "." && s != ".." && !s.contains('/')
     }
 
+    /// Builds the canonical joined form from an iterator of raw segments,
+    /// silently dropping unsafe ones. `cap` pre-sizes the buffer.
+    fn build<'a>(segments: impl Iterator<Item = &'a str>, cap: usize) -> Self {
+        let mut joined = String::with_capacity(cap);
+        for seg in segments.filter(|s| Self::is_safe_segment(s)) {
+            joined.push('/');
+            joined.push_str(seg);
+        }
+        if joined.is_empty() {
+            joined.push('/');
+        }
+        Self { joined }
+    }
+
     /// Creates a new storage path, silently dropping any traversal segments
     pub fn new(segments: Vec<String>) -> Self {
-        Self {
-            segments: segments
-                .into_iter()
-                .filter(|s| Self::is_safe_segment(s))
-                .collect(),
-        }
+        let cap = segments.iter().map(|s| s.len() + 1).sum();
+        Self::build(segments.iter().map(String::as_str), cap)
     }
 
     /// Creates an empty path (root)
     pub fn root() -> Self {
         Self {
-            segments: Vec::new(),
+            joined: "/".to_string(),
         }
     }
 
@@ -110,81 +135,38 @@ impl StoragePath {
     /// Traversal segments (`.`, `..`) are silently stripped to prevent
     /// path-traversal attacks.
     pub fn from_string(path: &str) -> Self {
-        let segments = path
-            .split('/')
-            .filter(|s| Self::is_safe_segment(s))
-            .map(|s| s.to_string())
-            .collect();
-        Self { segments }
+        Self::build(path.split('/'), path.len() + 1)
     }
 
     /// One-pass builder for PG listing rows: materialized folder path +
-    /// file name → `(StoragePath, path_string)`.
+    /// file name → the canonical joined path.
     ///
-    /// Replaces the old per-row chain
-    /// `StoragePath::from_string(&format!("{fp}/{name}"))` +
-    /// `storage_path.to_string()`, which allocated a joined temporary,
-    /// split it back into per-segment `String`s, and then re-joined those
-    /// segments (via `join` + `write!`) into the `path_string` the DTOs
-    /// actually serve. Here both representations are built in a single
-    /// pass with exactly one `String` for the joined form and no
-    /// intermediate temporaries.
-    ///
-    /// Byte-equivalence with the old chain holds because concatenating
-    /// with a `/` separator distributes over `split('/')`:
+    /// Byte-equivalence with the historical segment chain holds because
+    /// concatenating with a `/` separator distributes over `split('/')`:
     /// `(fp + "/" + name).split('/') == fp.split('/') ⧺ name.split('/')`,
     /// and the joined form is exactly `Display`'s `/`-prefixed rendering
     /// of the surviving segments (root renders as `"/"`).
-    pub fn from_folder_and_name(folder_path: Option<&str>, file_name: &str) -> (Self, String) {
+    pub fn from_folder_and_name(folder_path: Option<&str>, file_name: &str) -> Self {
         let fp = folder_path.unwrap_or("");
-        // Upper bounds: every byte of both inputs survives at most once,
-        // plus one leading '/' per segment (≤ segment count) — sizing to
-        // input length + 2 covers the worst case without a second scan.
-        let mut joined = String::with_capacity(fp.len() + file_name.len() + 2);
-        let mut segments: Vec<String> =
-            Vec::with_capacity(fp.bytes().filter(|&b| b == b'/').count() + 2);
-        for seg in fp
-            .split('/')
-            .chain(file_name.split('/'))
-            .filter(|s| Self::is_safe_segment(s))
-        {
-            joined.push('/');
-            joined.push_str(seg);
-            segments.push(seg.to_string());
-        }
-        if segments.is_empty() {
-            joined.push('/');
-        }
-        (Self { segments }, joined)
+        Self::build(
+            fp.split('/').chain(file_name.split('/')),
+            fp.len() + file_name.len() + 2,
+        )
     }
 
-    /// One-pass splitter for a pre-joined materialized path (the
-    /// `storage.folders.path` column) → `(StoragePath, path_string)`.
+    /// Wrapper for a pre-joined materialized path (the
+    /// `storage.folders.path` column).
     ///
-    /// When the input is already in canonical joined form (leading `/`,
-    /// no empty/`.`/`..` segments, no trailing `/`) — which is every row
-    /// the repository writes — the input `String` is reused as the
-    /// `path_string` with zero copies. Non-canonical inputs fall back to
-    /// the filtering rebuild and produce exactly what
-    /// `from_string(&path).to_string()` used to.
-    pub fn from_joined(path: String) -> (Self, String) {
+    /// When the input is already canonical (leading `/`, no empty/`.`/`..`
+    /// segments, no trailing `/`) — which is every row the repository
+    /// writes — the input `String` is adopted with zero copies.
+    /// Non-canonical inputs fall back to the filtering rebuild and produce
+    /// exactly what `from_string(&path)` yields.
+    pub fn from_joined(path: String) -> Self {
         if Self::is_canonical_joined(&path) {
-            let segments: Vec<String> = if path.len() == 1 {
-                Vec::new()
-            } else {
-                path[1..].split('/').map(str::to_string).collect()
-            };
-            return (Self { segments }, path);
+            return Self { joined: path };
         }
-        // Fallback: identical to the old from_string + to_string pair.
-        let segments: Vec<String> = path
-            .split('/')
-            .filter(|s| Self::is_safe_segment(s))
-            .map(str::to_string)
-            .collect();
-        let sp = Self { segments };
-        let joined = sp.to_path_string();
-        (sp, joined)
+        Self::from_string(&path)
     }
 
     /// `true` when `path` is exactly `Display`'s canonical rendering of
@@ -202,99 +184,99 @@ impl StoragePath {
 
     /// Creates a path from a PathBuf
     pub fn from(path_buf: PathBuf) -> Self {
-        let segments = path_buf
-            .components()
-            .filter_map(|c| match c {
-                std::path::Component::Normal(os_str) => Some(os_str.to_string_lossy().to_string()),
-                _ => None,
-            })
-            .collect();
-        Self { segments }
+        let mut joined = String::new();
+        for c in path_buf.components() {
+            if let std::path::Component::Normal(os_str) = c {
+                let seg = os_str.to_string_lossy();
+                if Self::is_safe_segment(&seg) {
+                    joined.push('/');
+                    joined.push_str(&seg);
+                }
+            }
+        }
+        if joined.is_empty() {
+            joined.push('/');
+        }
+        Self { joined }
     }
 
     /// Appends a segment to the path, consuming `self` so the existing
-    /// segment buffer is reused instead of deep-cloned.
+    /// buffer is reused instead of deep-cloned.
     ///
     /// Traversal segments (`.`, `..`) and segments containing `/` are
     /// silently ignored to prevent path-traversal attacks.
     pub fn join(mut self, segment: &str) -> Self {
         if Self::is_safe_segment(segment) {
-            self.segments.push(segment.to_string());
+            if self.joined == "/" {
+                self.joined.clear();
+            }
+            self.joined.push('/');
+            self.joined.push_str(segment);
         }
         self
     }
 
     /// Gets the file name (last segment)
     pub fn file_name(&self) -> Option<String> {
-        self.segments.last().cloned()
+        if self.joined == "/" {
+            None
+        } else {
+            self.joined.rsplit('/').next().map(str::to_string)
+        }
     }
 
     /// Gets the parent directory path
     pub fn parent(&self) -> Option<Self> {
-        if self.segments.is_empty() {
-            None
-        } else {
-            let parent_segments = self.segments[..self.segments.len() - 1].to_vec();
-            Some(Self {
-                segments: parent_segments,
-            })
+        if self.joined == "/" {
+            return None;
         }
+        let cut = self.joined.rfind('/').expect("canonical path has '/'");
+        Some(if cut == 0 {
+            Self::root()
+        } else {
+            Self {
+                joined: self.joined[..cut].to_string(),
+            }
+        })
     }
 
     /// Checks if the path is empty (is the root)
     pub fn is_empty(&self) -> bool {
-        self.segments.is_empty()
+        self.joined == "/"
     }
 }
 
 impl std::fmt::Display for StoragePath {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.segments.is_empty() {
-            return f.write_str("/");
-        }
-        // Write segments directly — the old `self.segments.join("/")`
-        // allocated a full joined temporary inside every `format!`/
-        // `to_string` of a path.
-        for seg in &self.segments {
-            f.write_str("/")?;
-            f.write_str(seg)?;
-        }
-        Ok(())
+        f.write_str(&self.joined)
     }
 }
 
 impl StoragePath {
-    /// The canonical joined form (`Display`'s output) in exactly one
-    /// pre-sized allocation.
-    ///
-    /// `to_string()` routes through `Display` into an unsized `String`
-    /// that grows geometrically (multiple reallocs + copies for typical
-    /// path lengths). Entity constructors call this once per row on
-    /// every listing, so the sized single-alloc variant is the default
-    /// there.
+    /// The canonical joined form as an owned `String` (one memcpy).
     pub fn to_path_string(&self) -> String {
-        if self.segments.is_empty() {
-            return "/".to_string();
-        }
-        let mut s = String::with_capacity(self.segments.iter().map(|seg| seg.len() + 1).sum());
-        for seg in &self.segments {
-            s.push('/');
-            s.push_str(seg);
-        }
-        s
+        self.joined.clone()
     }
 
-    /// Returns the path representation as a string
+    /// Consume `self`, yielding the canonical joined `String` with zero
+    /// copies. This is the row→entity→DTO hand-off path.
+    pub fn into_joined(self) -> String {
+        self.joined
+    }
+
+    /// Returns the path representation as a string (canonical joined form).
     pub fn as_str(&self) -> &str {
-        // Note: The implementation should really store the string,
-        // but here we do a temporary implementation that always returns "/"
-        // This is only used for the get_folder_path_str implementation
-        "/"
+        &self.joined
     }
 
-    /// Gets the path segments
-    pub fn segments(&self) -> &[String] {
-        &self.segments
+    /// Iterates the path segments (derived views over the joined form).
+    pub fn segments(&self) -> impl Iterator<Item = &str> {
+        let inner = if self.joined == "/" {
+            ""
+        } else {
+            &self.joined[1..]
+        };
+        inner.split('/').filter(|s| !s.is_empty())
     }
 }
 
@@ -305,7 +287,10 @@ mod tests {
     #[test]
     fn test_storage_path_from_string() {
         let path = StoragePath::from_string("folder/subfolder/file.txt");
-        assert_eq!(path.segments(), &["folder", "subfolder", "file.txt"]);
+        assert_eq!(
+            path.segments().collect::<Vec<_>>(),
+            &["folder", "subfolder", "file.txt"]
+        );
         assert_eq!(path.to_string(), "/folder/subfolder/file.txt");
     }
 
@@ -341,19 +326,19 @@ mod tests {
     #[test]
     fn test_from_string_strips_dot_dot() {
         let path = StoragePath::from_string("../../etc/passwd");
-        assert_eq!(path.segments(), &["etc", "passwd"]);
+        assert_eq!(path.segments().collect::<Vec<_>>(), &["etc", "passwd"]);
     }
 
     #[test]
     fn test_from_string_strips_single_dot() {
         let path = StoragePath::from_string("folder/./file.txt");
-        assert_eq!(path.segments(), &["folder", "file.txt"]);
+        assert_eq!(path.segments().collect::<Vec<_>>(), &["folder", "file.txt"]);
     }
 
     #[test]
     fn test_from_string_strips_mixed_traversal() {
         let path = StoragePath::from_string("a/../b/./c/../../d");
-        assert_eq!(path.segments(), &["a", "b", "c", "d"]);
+        assert_eq!(path.segments().collect::<Vec<_>>(), &["a", "b", "c", "d"]);
     }
 
     #[test]
@@ -366,13 +351,13 @@ mod tests {
     #[test]
     fn test_new_strips_traversal_segments() {
         let path = StoragePath::new(vec!["..".into(), "etc".into(), ".".into(), "passwd".into()]);
-        assert_eq!(path.segments(), &["etc", "passwd"]);
+        assert_eq!(path.segments().collect::<Vec<_>>(), &["etc", "passwd"]);
     }
 
     #[test]
     fn test_new_strips_empty_segments() {
         let path = StoragePath::new(vec!["a".into(), "".into(), "b".into()]);
-        assert_eq!(path.segments(), &["a", "b"]);
+        assert_eq!(path.segments().collect::<Vec<_>>(), &["a", "b"]);
     }
 
     #[test]
@@ -380,14 +365,14 @@ mod tests {
         let base = StoragePath::from_string("folder");
         let joined = base.join("..");
         // ".." is silently ignored — path stays unchanged
-        assert_eq!(joined.segments(), &["folder"]);
+        assert_eq!(joined.segments().collect::<Vec<_>>(), &["folder"]);
     }
 
     #[test]
     fn test_join_rejects_single_dot() {
         let base = StoragePath::from_string("folder");
         let joined = base.join(".");
-        assert_eq!(joined.segments(), &["folder"]);
+        assert_eq!(joined.segments().collect::<Vec<_>>(), &["folder"]);
     }
 
     #[test]
@@ -395,7 +380,7 @@ mod tests {
         let base = StoragePath::from_string("folder");
         let joined = base.join("sub/../../etc/passwd");
         // Segment contains '/' → silently ignored
-        assert_eq!(joined.segments(), &["folder"]);
+        assert_eq!(joined.segments().collect::<Vec<_>>(), &["folder"]);
     }
 
     #[test]
@@ -404,8 +389,8 @@ mod tests {
         // PathBuf Component::Normal only yields the normal parts
         // On most platforms this strips . and ..
         // but regardless, our from() only accepts Component::Normal
-        assert!(!path.segments().contains(&"..".to_string()));
-        assert!(!path.segments().contains(&".".to_string()));
+        assert!(!path.segments().any(|s| s == ".."));
+        assert!(!path.segments().any(|s| s == "."));
     }
 
     // ── NFC normalization tests ─────────────────────────────────

--- a/src/infrastructure/repositories/pg/face_pg_repository.rs
+++ b/src/infrastructure/repositories/pg/face_pg_repository.rs
@@ -295,6 +295,28 @@ impl FaceRepository for FacePgRepository {
         Ok(())
     }
 
+    async fn assign_person_batch(
+        &self,
+        assignments: &[(Uuid, Option<Uuid>)],
+    ) -> Result<(), DomainError> {
+        if assignments.is_empty() {
+            return Ok(());
+        }
+        let (face_ids, person_ids): (Vec<Uuid>, Vec<Option<Uuid>>) =
+            assignments.iter().cloned().unzip();
+        sqlx::query(
+            "UPDATE faces.faces f SET person_id = u.pid
+               FROM (SELECT unnest($1::uuid[]) AS fid, unnest($2::uuid[]) AS pid) u
+              WHERE f.id = u.fid",
+        )
+        .bind(&face_ids)
+        .bind(&person_ids)
+        .execute(self.pool.as_ref())
+        .await
+        .map_err(|e| db_err("assign_person_batch", e))?;
+        Ok(())
+    }
+
     async fn create_person(&self, person: &Person) -> Result<(), DomainError> {
         sqlx::query(
             r#"

--- a/src/infrastructure/repositories/pg/file_blob_read_repository.rs
+++ b/src/infrastructure/repositories/pg/file_blob_read_repository.rs
@@ -625,10 +625,12 @@ impl FileBlobReadRepository {
             SELECT count(*)              AS n,
                    avg(fm.longitude)     AS clng,
                    avg(fm.latitude)      AS clat,
-                   -- Cast once per cluster, not once per row: uuid byte
-                   -- order == canonical-text order, so the chosen sample
-                   -- is identical (benches/ROUND11.md §Q4).
-                   min(fm.file_id)::text AS sample_id
+                   -- NOTE: `min(fm.file_id)::text` (cast per cluster, not
+                   -- per row) was attempted in ROUND11 §Q4 and REJECTED by
+                   -- its benchmark gate: PostgreSQL has no `min(uuid)`
+                   -- aggregate, and adding a custom one is schema surface
+                   -- this viewport query doesn't justify.
+                   min(fm.file_id::text) AS sample_id
               FROM storage.file_metadata fm
               JOIN storage.files fi ON fi.id = fm.file_id
              WHERE fi.drive_id IN (

--- a/src/infrastructure/repositories/pg/file_blob_read_repository.rs
+++ b/src/infrastructure/repositories/pg/file_blob_read_repository.rs
@@ -625,7 +625,10 @@ impl FileBlobReadRepository {
             SELECT count(*)              AS n,
                    avg(fm.longitude)     AS clng,
                    avg(fm.latitude)      AS clat,
-                   min(fm.file_id::text) AS sample_id
+                   -- Cast once per cluster, not once per row: uuid byte
+                   -- order == canonical-text order, so the chosen sample
+                   -- is identical (benches/ROUND11.md §Q4).
+                   min(fm.file_id)::text AS sample_id
               FROM storage.file_metadata fm
               JOIN storage.files fi ON fi.id = fm.file_id
              WHERE fi.drive_id IN (
@@ -921,7 +924,7 @@ impl FileReadPort for FileBlobReadRepository {
         .map_err(|e| DomainError::internal_error("FileBlobRead", format!("path: {e}")))?
         .ok_or_else(|| DomainError::not_found("File", id))?;
 
-        Ok(StoragePath::from_folder_and_name(row.1.as_deref(), &row.0).0)
+        Ok(StoragePath::from_folder_and_name(row.1.as_deref(), &row.0))
     }
 
     async fn get_parent_folder_id(

--- a/src/infrastructure/repositories/pg/file_blob_write_repository.rs
+++ b/src/infrastructure/repositories/pg/file_blob_write_repository.rs
@@ -812,42 +812,84 @@ impl FileWritePort for FileBlobWriteRepository {
         size: u64,
         caller_id: Uuid,
     ) -> Result<(File, PathBuf), DomainError> {
-        let drive_id = self.resolve_parent_drive(folder_id.as_deref()).await?;
-
         // For deferred registration we use a placeholder hash.
         // The write-behind cache will call update_file_content later.
         let placeholder_hash = "0000000000000000000000000000000000000000000000000000000000000000";
 
         // Post-D7: `user_id` omitted from the INSERT column list.
-        // §14: `created_by = $8 = updated_by = caller_id`.
-        let row = retry_on_deadlock("files.insert_deferred", || {
-            sqlx::query_as::<_, (String, i64, i64, Option<Uuid>, Option<Uuid>)>(
-                r#"
-                INSERT INTO storage.files
-                    (name, folder_id, drive_id, blob_hash, size,
-                     mime_type, category_order, created_by, updated_by)
-                VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8, $8)
-                RETURNING id::text,
-                          EXTRACT(EPOCH FROM created_at)::bigint,
-                          EXTRACT(EPOCH FROM updated_at)::bigint,
-                          created_by,
-                          updated_by
-                "#,
-            )
-            .bind(&name)
-            .bind(&folder_id)
-            .bind(drive_id)
-            .bind(placeholder_hash)
-            .bind(size as i64)
-            .bind(&content_type)
-            .bind(category_order_for(&name, &content_type))
-            .bind(caller_id)
-            .fetch_one(self.pool.as_ref())
-        })
-        .await
-        .map_err(|e| DomainError::internal_error("FileBlobWrite", format!("deferred: {e}")))?;
+        // §14: `created_by = <caller> = updated_by`.
+        //
+        // With a parent folder this is the SAME single-round-trip `WITH
+        // parent AS (…) INSERT … RETURNING` template `persist_file` uses:
+        // the old shape ran three queries per uploaded file — parent drive
+        // SELECT, INSERT, parent path SELECT — with the first and third
+        // re-reading the identical folders row (benches/ROUND11.md
+        // §Q1: 3 → 1 round-trips on the default REST upload path).
+        let (row, folder_path) = if let Some(fid) = folder_id.as_deref() {
+            let row = retry_on_deadlock("files.insert_deferred", || {
+                sqlx::query_as::<_, (String, String, i64, i64, Option<Uuid>, Option<Uuid>)>(
+                    r#"
+                    WITH parent AS (
+                        SELECT id, drive_id, path FROM storage.folders WHERE id = $2::uuid
+                    )
+                    INSERT INTO storage.files
+                        (name, folder_id, drive_id, blob_hash, size,
+                         mime_type, category_order, created_by, updated_by)
+                    SELECT $1, parent.id, parent.drive_id, $3, $4, $5, $6, $7, $7
+                      FROM parent
+                    RETURNING id::text,
+                              (SELECT path FROM parent),
+                              EXTRACT(EPOCH FROM created_at)::bigint,
+                              EXTRACT(EPOCH FROM updated_at)::bigint,
+                              created_by,
+                              updated_by
+                    "#,
+                )
+                .bind(&name)
+                .bind(fid)
+                .bind(placeholder_hash)
+                .bind(size as i64)
+                .bind(&content_type)
+                .bind(category_order_for(&name, &content_type))
+                .bind(caller_id)
+                .fetch_optional(self.pool.as_ref())
+            })
+            .await
+            .map_err(|e| DomainError::internal_error("FileBlobWrite", format!("deferred: {e}")))?
+            // 0 rows ⇒ the parent folder doesn't exist — same not-found the
+            // old `resolve_parent_drive` first query produced.
+            .ok_or_else(|| DomainError::not_found("Folder", fid))?;
+            ((row.0, row.2, row.3, row.4, row.5), Some(row.1))
+        } else {
+            let drive_id = self.resolve_parent_drive(None).await?;
+            let row = retry_on_deadlock("files.insert_deferred", || {
+                sqlx::query_as::<_, (String, i64, i64, Option<Uuid>, Option<Uuid>)>(
+                    r#"
+                    INSERT INTO storage.files
+                        (name, folder_id, drive_id, blob_hash, size,
+                         mime_type, category_order, created_by, updated_by)
+                    VALUES ($1, NULL, $2, $3, $4, $5, $6, $7, $7)
+                    RETURNING id::text,
+                              EXTRACT(EPOCH FROM created_at)::bigint,
+                              EXTRACT(EPOCH FROM updated_at)::bigint,
+                              created_by,
+                              updated_by
+                    "#,
+                )
+                .bind(&name)
+                .bind(drive_id)
+                .bind(placeholder_hash)
+                .bind(size as i64)
+                .bind(&content_type)
+                .bind(category_order_for(&name, &content_type))
+                .bind(caller_id)
+                .fetch_one(self.pool.as_ref())
+            })
+            .await
+            .map_err(|e| DomainError::internal_error("FileBlobWrite", format!("deferred: {e}")))?;
+            (row, None)
+        };
 
-        let folder_path = self.lookup_folder_path(folder_id.as_deref()).await?;
         let file = Self::row_to_file(
             row.0.clone(),
             name,

--- a/src/infrastructure/services/encrypted_blob_backend.rs
+++ b/src/infrastructure/services/encrypted_blob_backend.rs
@@ -30,7 +30,7 @@
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 
-use aes_gcm::aead::{Aead, AeadInPlace, KeyInit, OsRng};
+use aes_gcm::aead::{AeadInPlace, KeyInit, OsRng};
 use aes_gcm::{AeadCore, Aes256Gcm, Nonce};
 use bytes::Bytes;
 use std::sync::Arc;
@@ -43,6 +43,9 @@ use crate::domain::errors::DomainError;
 
 /// Nonce size for AES-256-GCM (96 bits = 12 bytes).
 const NONCE_SIZE: usize = 12;
+
+/// AES-256-GCM authentication tag length appended after the ciphertext.
+const TAG_SIZE: usize = 16;
 
 /// Payloads at or above this size run crypto on the blocking pool; below
 /// it the `spawn_blocking` round-trip costs more than the AES work itself.
@@ -82,16 +85,23 @@ impl EncryptedBlobBackend {
 }
 
 /// Encrypt `data` into the on-disk layout: `[12-byte nonce][ciphertext + tag]`.
+///
+/// Single output buffer, mirroring the read side's `decrypt_in_place`:
+/// the payload is copied exactly once and encrypted in place with the tag
+/// appended. The old shape let `cipher.encrypt` allocate a full ciphertext
+/// `Vec` and then copied it a second time behind the nonce — one extra
+/// allocation + a full-size memcpy on every encrypted chunk write
+/// (benches/ROUND11.md §15; output bytes identical for a given nonce).
 fn encrypt_bytes(cipher: &Aes256Gcm, data: &[u8]) -> Result<Bytes, DomainError> {
     let nonce = Aes256Gcm::generate_nonce(&mut OsRng);
-    let ciphertext = cipher
-        .encrypt(&nonce, data)
+    let mut out = Vec::with_capacity(NONCE_SIZE + data.len() + TAG_SIZE);
+    out.extend_from_slice(nonce.as_slice());
+    out.extend_from_slice(data);
+    let tag = cipher
+        .encrypt_in_place_detached(&nonce, b"", &mut out[NONCE_SIZE..])
         .map_err(|e| DomainError::internal_error("Encryption", format!("encrypt failed: {e}")))?;
-
-    let mut encrypted = Vec::with_capacity(NONCE_SIZE + ciphertext.len());
-    encrypted.extend_from_slice(nonce.as_slice());
-    encrypted.extend_from_slice(&ciphertext);
-    Ok(Bytes::from(encrypted))
+    out.extend_from_slice(&tag);
+    Ok(Bytes::from(out))
 }
 
 /// Decrypt the on-disk layout `[nonce][ciphertext + tag]` **in place**.
@@ -322,6 +332,13 @@ impl BlobStorageBackend for EncryptedBlobBackend {
 }
 
 /// Collect a byte stream into a single `Vec<u8>`.
+///
+/// Modern blobs are CDC chunks (≤ `CDC_MAX_CHUNK` + nonce/tag overhead),
+/// delivered here as small reader frames — growing from `Vec::new()` paid
+/// ~log₂(n) reallocations + a wasted ~0.75×-size memcpy per read. Reserving
+/// one chunk's worth up front on the first frame makes the common case a
+/// single allocation; legacy whole-file blobs beyond that fall back to
+/// normal doubling (benches/ROUND11.md §16: 9 → 1 allocs on a 1 MiB blob).
 async fn collect_stream(stream: BlobStream) -> Result<Vec<u8>, DomainError> {
     use futures::StreamExt;
     let mut stream = stream;
@@ -329,6 +346,14 @@ async fn collect_stream(stream: BlobStream) -> Result<Vec<u8>, DomainError> {
     while let Some(chunk) = stream.next().await {
         let bytes = chunk
             .map_err(|e| DomainError::internal_error("Encryption", format!("stream read: {e}")))?;
+        if buf.capacity() == 0 {
+            buf.reserve(
+                (crate::infrastructure::services::dedup_service::CDC_MAX_CHUNK
+                    + NONCE_SIZE
+                    + TAG_SIZE)
+                    .max(bytes.len()),
+            );
+        }
         buf.extend_from_slice(&bytes);
     }
     Ok(buf)

--- a/src/infrastructure/services/path_resolver_service.rs
+++ b/src/infrastructure/services/path_resolver_service.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use uuid::Uuid;
 
 use crate::application::dtos::display_helpers::{
-    category_for, format_file_size, icon_class_for, icon_special_class_for,
+    classify_display, format_file_size, intern_display, intern_mime,
 };
 use crate::application::dtos::file_dto::FileDto;
 use crate::application::dtos::folder_dto::FolderDto;
@@ -197,18 +197,19 @@ impl PathResolverService {
                 let hash = blob_hash.unwrap_or_default();
                 let modified_at_u = modified_at as u64;
                 let etag = File::compute_etag(&hash, modified_at_u);
+                let classes = classify_display(&name, &mime);
                 Ok(ResolvedResource::File(FileDto {
                     id,
                     name: name.clone(),
                     path: res_path,
                     size: sz,
-                    mime_type: Arc::from(&*mime),
+                    mime_type: intern_mime(&mime),
                     folder_id,
                     created_at: created_at as u64,
                     modified_at: modified_at_u,
-                    icon_class: Arc::from(icon_class_for(&name, &mime)),
-                    icon_special_class: Arc::from(icon_special_class_for(&name, &mime)),
-                    category: Arc::from(category_for(&name, &mime)),
+                    icon_class: intern_display(classes.icon_class),
+                    icon_special_class: intern_display(classes.icon_special_class),
+                    category: intern_display(classes.category),
                     size_formatted: format_file_size(sz),
                     sort_date: None,
                     content_hash: hash,

--- a/src/infrastructure/services/path_service.rs
+++ b/src/infrastructure/services/path_service.rs
@@ -95,7 +95,7 @@ impl PathService {
     /// Validates a path to ensure it doesn't contain dangerous components
     pub fn validate_path(&self, path: &StoragePath) -> Result<(), DomainError> {
         // Check for empty segments
-        if path.segments().iter().any(|s| s.is_empty()) {
+        if path.segments().any(|s| s.is_empty()) {
             return Err(DomainError::new(
                 ErrorKind::InvalidInput,
                 "Path",

--- a/src/infrastructure/services/pg_acl_engine.rs
+++ b/src/infrastructure/services/pg_acl_engine.rs
@@ -117,6 +117,16 @@ const CASCADE_GRANT_CACHE_CAPACITY: u64 = 100_000;
 /// invalidation tree". Short enough that any such change takes effect in <1 min.
 const CASCADE_GRANT_CACHE_TTL: Duration = Duration::from_secs(30);
 
+/// `direct_grant_cache` bound/TTL: memoises the Calendar / AddressBook /
+/// Playlist `role_grants` point decision — the only `check()` arms that had
+/// NO result cache, re-run on every CalDAV/CardDAV/music request by clients
+/// that poll continuously. Same invalidation contract as
+/// `cascade_grant_cache`: grant writes on these resource types flush the
+/// whole cache; group/expiry churn self-heals within the TTL
+/// (benches/ROUND11.md §Q2).
+const DIRECT_GRANT_CACHE_CAPACITY: u64 = 100_000;
+const DIRECT_GRANT_CACHE_TTL: Duration = Duration::from_secs(30);
+
 /// `file_parent_cache` bound/TTL: `file_id → Option<folder_id>` point rows
 /// (~50 B each) resolved on the file-cascade path so an N-file album pays
 /// ONE folder-cascade query instead of N (ROUND9). Parentage changes only
@@ -212,6 +222,11 @@ pub struct PgAclEngine {
     /// only positively-or-negatively for at most the TTL. A revoke via
     /// `clear_role` flushes immediately; anything missed self-heals in ≤30 s.
     cascade_grant_cache: Cache<(Subject, Resource, Permission), bool>,
+
+    /// Memoised Calendar/AddressBook/Playlist direct-grant decision (the
+    /// top-level resources with no cascade parent). See
+    /// `DIRECT_GRANT_CACHE_CAPACITY` for the contract.
+    direct_grant_cache: Cache<(Subject, Resource, Permission), bool>,
     /// `file_id → Option<parent folder_id>` memo for the file-cascade
     /// decomposition (see `cascade_grant_cached`): resolving the parent lets
     /// a whole folder's files share ONE folder-cascade decision, so a shared
@@ -315,6 +330,10 @@ impl PgAclEngine {
                 .max_capacity(CASCADE_GRANT_CACHE_CAPACITY)
                 .time_to_live(CASCADE_GRANT_CACHE_TTL)
                 .build(),
+            direct_grant_cache: Cache::builder()
+                .max_capacity(DIRECT_GRANT_CACHE_CAPACITY)
+                .time_to_live(DIRECT_GRANT_CACHE_TTL)
+                .build(),
             file_parent_cache: Cache::builder()
                 .max_capacity(FILE_PARENT_CACHE_CAPACITY)
                 .time_to_live(FILE_PARENT_CACHE_TTL)
@@ -392,6 +411,10 @@ impl PgAclEngine {
                 .time_to_live(Duration::from_secs(1))
                 .build(),
             cascade_grant_cache: Cache::builder()
+                .max_capacity(1)
+                .time_to_live(Duration::from_secs(1))
+                .build(),
+            direct_grant_cache: Cache::builder()
                 .max_capacity(1)
                 .time_to_live(Duration::from_secs(1))
                 .build(),
@@ -568,26 +591,38 @@ impl PgAclEngine {
         // belong to the Internal virtual group. Unknown user (no row) is
         // treated as external to fail closed: a deleted or bogus user_id
         // must not gain implicit Internal membership.
+        //
+        // The `is_external` point read and the recursive groups CTE are
+        // independent — `join!` overlaps their round-trips on every cold
+        // expansion instead of paying them serially (benches/ROUND11.md
+        // §Q3; the ROUND9/10 pattern).
         counters.sql_queries.fetch_add(1, Ordering::Relaxed);
-        let is_external: bool =
-            sqlx::query_scalar("SELECT is_external FROM auth.users WHERE id = $1")
+        let is_external_fut = async {
+            sqlx::query_scalar::<_, bool>("SELECT is_external FROM auth.users WHERE id = $1")
                 .bind(user_id)
                 .fetch_optional(self.pool.as_ref())
                 .await
                 .map_err(|e| {
                     DomainError::internal_error("PgAcl", format!("lookup is_external: {e}"))
-                })?
-                .unwrap_or(true);
-
-        if !is_external {
+                })
+                .map(|row| row.unwrap_or(true))
+        };
+        let groups_fut = async {
+            match &self.group_repo {
+                Some(repo) => {
+                    counters.sql_queries.fetch_add(1, Ordering::Relaxed);
+                    repo.groups_for_user(user_id).await.map(Some).map_err(|e| {
+                        DomainError::internal_error("PgAcl", format!("groups_for_user: {e}"))
+                    })
+                }
+                None => Ok(None),
+            }
+        };
+        let (is_external, direct) = tokio::join!(is_external_fut, groups_fut);
+        if !is_external? {
             set.insert(INTERNAL_GROUP_ID);
         }
-
-        if let Some(repo) = &self.group_repo {
-            counters.sql_queries.fetch_add(1, Ordering::Relaxed);
-            let direct = repo.groups_for_user(user_id).await.map_err(|e| {
-                DomainError::internal_error("PgAcl", format!("groups_for_user: {e}"))
-            })?;
+        if let Some(direct) = direct? {
             set.extend(direct);
         }
 
@@ -1099,6 +1134,48 @@ impl PgAclEngine {
     /// (on File/Folder grant writes — it holds file AND folder decisions in
     /// the same map) and the 30 s TTL (indirect changes, incl. moves for the
     /// parent memo) keep it fresh. See the `cascade_grant_cache` field doc.
+    /// Cached wrapper for the Calendar/AddressBook/Playlist direct-grant
+    /// decision (`try_get_with`: a cold herd on one key coalesces into ONE
+    /// loader run, the ROUND10 single-flight pattern; loader errors are
+    /// never cached). `resource_type` is the `role_grants.resource_type`
+    /// discriminant for `resource`.
+    async fn direct_grant_cached(
+        &self,
+        subject: Subject,
+        resource: Resource,
+        permission: Permission,
+        resource_type: &'static str,
+        id: Uuid,
+        counters: &QueryCounters,
+    ) -> Result<bool, DomainError> {
+        if let Some(allowed) = self
+            .direct_grant_cache
+            .get(&(subject, resource, permission))
+            .await
+        {
+            counters.cache_hit.fetch_add(1, Ordering::Relaxed);
+            return Ok(allowed);
+        }
+        self.direct_grant_cache
+            .try_get_with((subject, resource, permission), async {
+                let (subject_types, subject_ids) =
+                    self.subject_match_set(subject, counters).await?;
+                self.direct_grant_exists(
+                    &subject_types,
+                    &subject_ids,
+                    permission,
+                    resource_type,
+                    id,
+                    counters,
+                )
+                .await
+            })
+            .await
+            .map_err(|e: Arc<DomainError>| {
+                DomainError::internal_error("PgAcl", format!("direct grant load: {e}"))
+            })
+    }
+
     async fn cascade_grant_cached(
         &self,
         subject: Subject,
@@ -1493,24 +1570,13 @@ impl PgAclEngine {
             // round-trip — no drive_role_cache short-circuit (no
             // drive), no cascade.
             Resource::Calendar(id) => {
-                let (subject_types, subject_ids) =
-                    self.subject_match_set(subject, counters).await?;
-                self.direct_grant_exists(
-                    &subject_types,
-                    &subject_ids,
-                    permission,
-                    "calendar",
-                    id,
-                    counters,
-                )
-                .await
+                self.direct_grant_cached(subject, resource, permission, "calendar", id, counters)
+                    .await
             }
             Resource::AddressBook(id) => {
-                let (subject_types, subject_ids) =
-                    self.subject_match_set(subject, counters).await?;
-                self.direct_grant_exists(
-                    &subject_types,
-                    &subject_ids,
+                self.direct_grant_cached(
+                    subject,
+                    resource,
                     permission,
                     "address_book",
                     id,
@@ -1519,17 +1585,8 @@ impl PgAclEngine {
                 .await
             }
             Resource::Playlist(id) => {
-                let (subject_types, subject_ids) =
-                    self.subject_match_set(subject, counters).await?;
-                self.direct_grant_exists(
-                    &subject_types,
-                    &subject_ids,
-                    permission,
-                    "playlist",
-                    id,
-                    counters,
-                )
-                .await
+                self.direct_grant_cached(subject, resource, permission, "playlist", id, counters)
+                    .await
             }
         }
     }
@@ -2874,6 +2931,13 @@ impl AuthorizationEngine for PgAclEngine {
         if matches!(resource, Resource::File(_) | Resource::Folder(_)) {
             self.invalidate_cascade_grant_cache_all().await;
         }
+        // Same immediacy contract for the memoised top-level decisions.
+        if matches!(
+            resource,
+            Resource::Calendar(_) | Resource::AddressBook(_) | Resource::Playlist(_)
+        ) {
+            self.direct_grant_cache.invalidate_all();
+        }
 
         Self::row_to_grant(row)
     }
@@ -2902,6 +2966,14 @@ impl AuthorizationEngine for PgAclEngine {
         // now, not in ≤30 s — flush the cascade cache (see `set_role`).
         if matches!(resource, Resource::File(_) | Resource::Folder(_)) {
             self.invalidate_cascade_grant_cache_all().await;
+        }
+        // A revoked calendar/address-book/playlist grant must fail the next
+        // check now, not in ≤30 s (see `set_role`).
+        if matches!(
+            resource,
+            Resource::Calendar(_) | Resource::AddressBook(_) | Resource::Playlist(_)
+        ) {
+            self.direct_grant_cache.invalidate_all();
         }
 
         Ok(())

--- a/src/infrastructure/services/retry_blob_backend.rs
+++ b/src/infrastructure/services/retry_blob_backend.rs
@@ -57,14 +57,20 @@ impl RetryBlobBackend {
 }
 
 /// Execute an async closure with exponential backoff retry.
-async fn retry_async<F, Fut, T>(
+///
+/// `name` is a lazy label: the success path (the overwhelmingly common
+/// case) never materializes it, so per-op `format!("op({hash})")`
+/// allocations only happen on an actual retry (benches/ROUND11.md §14:
+/// 64.5 → 0.7 ns, −2 allocs per blob op).
+async fn retry_async<F, Fut, T, L>(
     policy: &RetryPolicy,
-    name: &str,
+    name: L,
     mut f: F,
 ) -> Result<T, DomainError>
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = Result<T, DomainError>>,
+    L: Fn() -> String,
 {
     let mut attempt = 0u32;
     let mut backoff = policy.initial_backoff;
@@ -78,7 +84,7 @@ where
                     "Retry {}/{} for {} after error: {} (backoff {:?})",
                     attempt,
                     policy.max_retries,
-                    name,
+                    name(),
                     e,
                     backoff
                 );
@@ -112,10 +118,14 @@ impl BlobStorageBackend for RetryBlobBackend {
         let inner = self.inner.clone();
         let policy = self.policy.clone();
         Box::pin(async move {
-            retry_async(&policy, "initialize", || {
-                let inner = inner.clone();
-                async move { inner.initialize().await }
-            })
+            retry_async(
+                &policy,
+                || "initialize".to_string(),
+                || {
+                    let inner = inner.clone();
+                    async move { inner.initialize().await }
+                },
+            )
             .await
         })
     }
@@ -130,12 +140,16 @@ impl BlobStorageBackend for RetryBlobBackend {
         let hash = hash.to_string();
         let path = source_path.to_path_buf();
         Box::pin(async move {
-            retry_async(&policy, &format!("put_blob({hash})"), || {
-                let inner = inner.clone();
-                let hash = hash.clone();
-                let path = path.clone();
-                async move { inner.put_blob(&hash, &path).await }
-            })
+            retry_async(
+                &policy,
+                || format!("put_blob({hash})"),
+                || {
+                    let inner = inner.clone();
+                    let hash = hash.clone();
+                    let path = path.clone();
+                    async move { inner.put_blob(&hash, &path).await }
+                },
+            )
             .await
         })
     }
@@ -149,12 +163,16 @@ impl BlobStorageBackend for RetryBlobBackend {
         let policy = self.policy.clone();
         let hash = hash.to_string();
         Box::pin(async move {
-            retry_async(&policy, &format!("put_blob_from_bytes({hash})"), || {
-                let inner = inner.clone();
-                let hash = hash.clone();
-                let data = data.clone();
-                async move { inner.put_blob_from_bytes(&hash, data).await }
-            })
+            retry_async(
+                &policy,
+                || format!("put_blob_from_bytes({hash})"),
+                || {
+                    let inner = inner.clone();
+                    let hash = hash.clone();
+                    let data = data.clone();
+                    async move { inner.put_blob_from_bytes(&hash, data).await }
+                },
+            )
             .await
         })
     }
@@ -174,7 +192,7 @@ impl BlobStorageBackend for RetryBlobBackend {
         Box::pin(async move {
             retry_async(
                 &policy,
-                &format!("put_blob_from_bytes_unsynced({hash})"),
+                || format!("put_blob_from_bytes_unsynced({hash})"),
                 || {
                     let inner = inner.clone();
                     let hash = hash.clone();
@@ -205,11 +223,15 @@ impl BlobStorageBackend for RetryBlobBackend {
         let policy = self.policy.clone();
         let hash = hash.to_string();
         Box::pin(async move {
-            retry_async(&policy, &format!("get_blob_stream({hash})"), || {
-                let inner = inner.clone();
-                let hash = hash.clone();
-                async move { inner.get_blob_stream(&hash).await }
-            })
+            retry_async(
+                &policy,
+                || format!("get_blob_stream({hash})"),
+                || {
+                    let inner = inner.clone();
+                    let hash = hash.clone();
+                    async move { inner.get_blob_stream(&hash).await }
+                },
+            )
             .await
         })
     }
@@ -225,11 +247,15 @@ impl BlobStorageBackend for RetryBlobBackend {
         let policy = self.policy.clone();
         let hash = hash.to_string();
         Box::pin(async move {
-            retry_async(&policy, &format!("get_blob_range({hash})"), || {
-                let inner = inner.clone();
-                let hash = hash.clone();
-                async move { inner.get_blob_range_stream(&hash, start, end).await }
-            })
+            retry_async(
+                &policy,
+                || format!("get_blob_range({hash})"),
+                || {
+                    let inner = inner.clone();
+                    let hash = hash.clone();
+                    async move { inner.get_blob_range_stream(&hash, start, end).await }
+                },
+            )
             .await
         })
     }
@@ -242,11 +268,15 @@ impl BlobStorageBackend for RetryBlobBackend {
         let policy = self.policy.clone();
         let hash = hash.to_string();
         Box::pin(async move {
-            retry_async(&policy, &format!("delete_blob({hash})"), || {
-                let inner = inner.clone();
-                let hash = hash.clone();
-                async move { inner.delete_blob(&hash).await }
-            })
+            retry_async(
+                &policy,
+                || format!("delete_blob({hash})"),
+                || {
+                    let inner = inner.clone();
+                    let hash = hash.clone();
+                    async move { inner.delete_blob(&hash).await }
+                },
+            )
             .await
         })
     }
@@ -259,11 +289,15 @@ impl BlobStorageBackend for RetryBlobBackend {
         let policy = self.policy.clone();
         let hash = hash.to_string();
         Box::pin(async move {
-            retry_async(&policy, &format!("blob_exists({hash})"), || {
-                let inner = inner.clone();
-                let hash = hash.clone();
-                async move { inner.blob_exists(&hash).await }
-            })
+            retry_async(
+                &policy,
+                || format!("blob_exists({hash})"),
+                || {
+                    let inner = inner.clone();
+                    let hash = hash.clone();
+                    async move { inner.blob_exists(&hash).await }
+                },
+            )
             .await
         })
     }
@@ -276,11 +310,15 @@ impl BlobStorageBackend for RetryBlobBackend {
         let policy = self.policy.clone();
         let hash = hash.to_string();
         Box::pin(async move {
-            retry_async(&policy, &format!("blob_size({hash})"), || {
-                let inner = inner.clone();
-                let hash = hash.clone();
-                async move { inner.blob_size(&hash).await }
-            })
+            retry_async(
+                &policy,
+                || format!("blob_size({hash})"),
+                || {
+                    let inner = inner.clone();
+                    let hash = hash.clone();
+                    async move { inner.blob_size(&hash).await }
+                },
+            )
             .await
         })
     }
@@ -293,10 +331,14 @@ impl BlobStorageBackend for RetryBlobBackend {
         let inner = self.inner.clone();
         let policy = self.policy.clone();
         Box::pin(async move {
-            retry_async(&policy, "health_check", || {
-                let inner = inner.clone();
-                async move { inner.health_check().await }
-            })
+            retry_async(
+                &policy,
+                || "health_check".to_string(),
+                || {
+                    let inner = inner.clone();
+                    async move { inner.health_check().await }
+                },
+            )
             .await
         })
     }

--- a/src/interfaces/api/cookie_auth.rs
+++ b/src/interfaces/api/cookie_auth.rs
@@ -141,8 +141,10 @@ pub fn append_clear_cookies(headers: &mut HeaderMap) {
     }
 }
 
-/// Extract a named cookie value from the `Cookie` request header.
-pub fn extract_cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
+/// Extract a named cookie value from the `Cookie` request header,
+/// borrowing from the header map. Callers that only compare or parse the
+/// value (CSRF check) avoid the per-request copy.
+pub fn extract_cookie_str<'h>(headers: &'h HeaderMap, name: &str) -> Option<&'h str> {
     let cookie_header = headers.get(axum::http::header::COOKIE)?;
     let cookie_str = cookie_header.to_str().ok()?;
 
@@ -151,11 +153,16 @@ pub fn extract_cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
         if let Some(val) = pair.strip_prefix(name) {
             let val = val.strip_prefix('=')?;
             if !val.is_empty() {
-                return Some(val.to_string());
+                return Some(val);
             }
         }
     }
     None
+}
+
+/// Extract a named cookie value from the `Cookie` request header.
+pub fn extract_cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    extract_cookie_str(headers, name).map(str::to_string)
 }
 
 // ────────────────────────────────────────────────────────────

--- a/src/interfaces/api/handlers/favorites_handler.rs
+++ b/src/interfaces/api/handlers/favorites_handler.rs
@@ -10,8 +10,7 @@ use tracing::info;
 use utoipa::ToSchema;
 
 use crate::application::dtos::display_helpers::{
-    category_for, format_file_size, icon_class_for, icon_special_class_for, intern_display,
-    intern_mime,
+    classify_display, format_file_size, intern_display, intern_mime,
 };
 use crate::application::dtos::favorites_dto::{
     FavoritesResourceItemDto, FavoritesResourcesDto, FavoritesResourcesQuery,
@@ -247,10 +246,10 @@ pub async fn list_favorites_resources(
                         };
                         // Name-derived display classes borrow `row.name`;
                         // compute them before the name moves into the DTO.
-                        let icon_class = intern_display(icon_class_for(&row.name, mime));
-                        let icon_special_class =
-                            intern_display(icon_special_class_for(&row.name, mime));
-                        let category = intern_display(category_for(&row.name, mime));
+                        let classes = classify_display(&row.name, mime);
+                        let icon_class = intern_display(classes.icon_class);
+                        let icon_special_class = intern_display(classes.icon_special_class);
+                        let category = intern_display(classes.category);
                         let dto = FileDto {
                             id: row.resource_id.to_string(),
                             name: row.name,

--- a/src/interfaces/api/handlers/file_handler.rs
+++ b/src/interfaces/api/handlers/file_handler.rs
@@ -404,7 +404,18 @@ impl FileHandler {
         // (file_id, size, format) triple.  If the browser already has it, return
         // 304 with zero I/O or DB work. Format is in the ETag so a client that
         // switched codecs doesn't get a stale 304.
-        let etag = format!("\"thumb-{}-{:?}-{:?}\"", id, thumb_size, format);
+        let etag = {
+            let (s, f) = (thumb_size.as_str(), format.as_str());
+            let mut e = String::with_capacity(9 + id.len() + s.len() + f.len());
+            e.push_str("\"thumb-");
+            e.push_str(&id);
+            e.push('-');
+            e.push_str(s);
+            e.push('-');
+            e.push_str(f);
+            e.push('"');
+            e
+        };
         if let Some(if_none_match) = headers.get(header::IF_NONE_MATCH)
             && let Ok(val) = if_none_match.to_str()
             && (val == etag || val == "*")
@@ -776,9 +787,15 @@ impl FileHandler {
 
         // Use the ownership-scoped optimized download.
         // Ownership was already verified by get_file_owned above,
-        // so we can safely use the preloaded variant.
+        // so we can safely use the preloaded variant. Capture the two
+        // fields the stream arm needs (one Arc bump + a u64 copy) and MOVE
+        // the DTO in — the old `file_dto.clone()` deep-copied all 7 owned
+        // Strings on every download, purely to read mime/size afterwards
+        // (benches/ROUND11.md §1).
+        let dto_mime = file_dto.mime_type.clone();
+        let dto_size = file_dto.size;
         match retrieval
-            .get_file_optimized_preloaded(&id, file_dto.clone(), accept_webp, prefer_original)
+            .get_file_optimized_preloaded(&id, file_dto, accept_webp, prefer_original)
             .await
         {
             Ok((_file, content)) => match content {
@@ -788,9 +805,9 @@ impl FileHandler {
                     .into_response(),
                 OptimizedFileContent::Stream(pinned_stream) => Response::builder()
                     .status(StatusCode::OK)
-                    .header(header::CONTENT_TYPE, &*file_dto.mime_type)
+                    .header(header::CONTENT_TYPE, &*dto_mime)
                     .header(header::CONTENT_DISPOSITION, &disposition)
-                    .header(header::CONTENT_LENGTH, file_dto.size)
+                    .header(header::CONTENT_LENGTH, dto_size)
                     .header(header::ETAG, &etag)
                     .header(
                         header::CACHE_CONTROL,

--- a/src/interfaces/api/handlers/folder_handler.rs
+++ b/src/interfaces/api/handlers/folder_handler.rs
@@ -8,8 +8,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::application::dtos::display_helpers::{
-    category_for, format_file_size, icon_class_for, icon_special_class_for, intern_display,
-    intern_mime,
+    classify_display, format_file_size, intern_display, intern_mime,
 };
 use crate::application::dtos::file_dto::FileDto;
 use crate::application::dtos::folder_dto::{
@@ -520,10 +519,10 @@ pub async fn list_folder_resources(
                         // (they borrow `&row.name`), so `name` can be moved into
                         // the DTO below instead of cloned — one fewer String
                         // alloc per file row (benches/ROUND7.md).
-                        let icon_class = intern_display(icon_class_for(&row.name, mime));
-                        let icon_special_class =
-                            intern_display(icon_special_class_for(&row.name, mime));
-                        let category = intern_display(category_for(&row.name, mime));
+                        let classes = classify_display(&row.name, mime);
+                        let icon_class = intern_display(classes.icon_class);
+                        let icon_special_class = intern_display(classes.icon_special_class);
+                        let category = intern_display(classes.category);
                         let dto = FileDto {
                             id: row.id.to_string(),
                             name: row.name,

--- a/src/interfaces/api/handlers/recent_handler.rs
+++ b/src/interfaces/api/handlers/recent_handler.rs
@@ -8,8 +8,7 @@ use std::sync::Arc;
 use tracing::info;
 
 use crate::application::dtos::display_helpers::{
-    category_for, format_file_size, icon_class_for, icon_special_class_for, intern_display,
-    intern_mime,
+    classify_display, format_file_size, intern_display, intern_mime,
 };
 use crate::application::dtos::file_dto::FileDto;
 use crate::application::dtos::folder_dto::FolderDto;
@@ -57,8 +56,10 @@ pub async fn record_item_access(
             .into_response();
     }
 
+    let mut id_buf = [0u8; 36];
+    let item_id_str: &str = item_id.as_hyphenated().encode_lower(&mut id_buf);
     match recent_service
-        .record_item_access(user_id, &item_id.to_string(), &item_type)
+        .record_item_access(user_id, item_id_str, &item_type)
         .await
     {
         Ok(_) => {
@@ -100,8 +101,10 @@ pub async fn remove_from_recent(
 ) -> impl IntoResponse {
     let user_id = auth_user.id;
 
+    let mut id_buf = [0u8; 36];
+    let item_id_str: &str = item_id.as_hyphenated().encode_lower(&mut id_buf);
     match recent_service
-        .remove_from_recent(user_id, &item_id.to_string(), &item_type)
+        .remove_from_recent(user_id, item_id_str, &item_type)
         .await
     {
         Ok(removed) => {
@@ -261,10 +264,10 @@ pub async fn list_recent_resources(
                         };
                         // Name-derived display classes borrow `row.name`;
                         // compute them before the name moves into the DTO.
-                        let icon_class = intern_display(icon_class_for(&row.name, mime));
-                        let icon_special_class =
-                            intern_display(icon_special_class_for(&row.name, mime));
-                        let category = intern_display(category_for(&row.name, mime));
+                        let classes = classify_display(&row.name, mime);
+                        let icon_class = intern_display(classes.icon_class);
+                        let icon_special_class = intern_display(classes.icon_special_class);
+                        let category = intern_display(classes.category);
                         let dto = FileDto {
                             id: row.resource_id.to_string(),
                             name: row.name,

--- a/src/interfaces/api/routes.rs
+++ b/src/interfaces/api/routes.rs
@@ -46,8 +46,23 @@ async fn get_version() -> AxumJson<serde_json::Value> {
     }))
 }
 
-async fn get_openapi_spec() -> AxumJson<utoipa::openapi::OpenApi> {
-    AxumJson(super::ApiDoc::openapi())
+/// Pre-serialized OpenAPI spec. `ApiDoc::openapi()` reconstructs the whole
+/// 171 KiB paths/schemas tree and re-serializes it per request (2.8 ms /
+/// 12 474 allocs); the spec is process-invariant, so serialize once and
+/// hand back a `Bytes` refcount bump (~18 ns — benches/ROUND11.md).
+static OPENAPI_BODY: std::sync::OnceLock<bytes::Bytes> = std::sync::OnceLock::new();
+
+async fn get_openapi_spec() -> axum::response::Response {
+    let body = OPENAPI_BODY.get_or_init(|| {
+        bytes::Bytes::from(
+            serde_json::to_vec(&super::ApiDoc::openapi()).expect("openapi spec serializes"),
+        )
+    });
+    axum::response::Response::builder()
+        .status(axum::http::StatusCode::OK)
+        .header(axum::http::header::CONTENT_TYPE, "application/json")
+        .body(axum::body::Body::from(body.clone()))
+        .expect("static openapi response")
 }
 
 use crate::interfaces::api::handlers::admin_handler;

--- a/src/interfaces/errors.rs
+++ b/src/interfaces/errors.rs
@@ -3,6 +3,8 @@
 //! This module contains error types specific to the HTTP/API layer.
 //! These errors handle the conversion from domain errors to HTTP responses.
 
+use std::borrow::Cow;
+
 use axum::Json;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
@@ -13,25 +15,28 @@ use crate::domain::errors::{DomainError, ErrorKind};
 /// Error type for HTTP/API responses.
 ///
 /// This struct represents errors that will be returned to HTTP clients.
-/// It contains the HTTP status code, a user-friendly message, and an error type identifier.
+/// It contains the HTTP status code, a user-friendly message, and an error
+/// type identifier. `error_type` is a `Cow`: every built-in constructor and
+/// the `DomainError` conversion use a `&'static str` from a closed set, so
+/// the common 4xx path allocates nothing for it (benches/ROUND11.md §9).
 #[derive(Debug)]
 pub struct AppError {
     pub status_code: StatusCode,
     pub message: String,
-    pub error_type: String,
+    pub error_type: Cow<'static, str>,
 }
 
-/// JSON response structure for errors.
-///
-/// Both `error` and `message` carry the same content for backwards compatibility:
-/// - Legacy ad-hoc handlers returned `{"error": "..."}` (frontend reads `.error`)
-/// - AppError returned `{"message": "..."}` (admin panel reads `.message`)
+/// JSON response structure for errors, borrowing from the `AppError` it
+/// renders — `error` and `message` intentionally serialize the SAME string
+/// for backwards compatibility (legacy handlers returned `{"error": …}`,
+/// AppError returned `{"message": …}`); serializing one buffer twice
+/// replaces the old per-response deep clone.
 #[derive(Serialize)]
-pub struct ErrorResponse {
-    pub status: String,
-    pub error: String,
-    pub message: String,
-    pub error_type: String,
+pub struct ErrorResponse<'a> {
+    pub status: &'a str,
+    pub error: &'a str,
+    pub message: &'a str,
+    pub error_type: &'a str,
 }
 
 impl AppError {
@@ -39,7 +44,7 @@ impl AppError {
     pub fn new(
         status_code: StatusCode,
         message: impl Into<String>,
-        error_type: impl Into<String>,
+        error_type: impl Into<Cow<'static, str>>,
     ) -> Self {
         Self {
             status_code,
@@ -131,7 +136,7 @@ impl From<DomainError> for AppError {
         Self {
             status_code,
             message: err.message,
-            error_type: err.kind.to_string(),
+            error_type: Cow::Borrowed(err.kind.as_str()),
         }
     }
 }
@@ -144,25 +149,26 @@ impl IntoResponse for AppError {
         // Log the full error server-side for debugging, return a generic
         // message to the client. Other status codes (including 5xx like
         // 501, 503, 507) keep their intentionally user-facing messages.
-        let client_message = if status == StatusCode::INTERNAL_SERVER_ERROR {
+        let client_message: &str = if status == StatusCode::INTERNAL_SERVER_ERROR {
             tracing::error!(
                 error_type = %self.error_type,
                 "Internal server error: {}",
                 self.message
             );
-            "An internal error occurred. Please try again later.".to_string()
+            "An internal error occurred. Please try again later."
         } else {
-            self.message
+            &self.message
         };
 
+        let status_line = status.to_string();
         let error_response = ErrorResponse {
-            status: status.to_string(),
-            error: client_message.clone(),
+            status: &status_line,
+            error: client_message,
             message: client_message,
-            error_type: self.error_type,
+            error_type: &self.error_type,
         };
 
-        let body = Json(error_response);
+        let body = Json(&error_response);
         (status, body).into_response()
     }
 }

--- a/src/interfaces/middleware/csrf.rs
+++ b/src/interfaces/middleware/csrf.rs
@@ -39,16 +39,17 @@ pub async fn csrf_middleware(request: Request, next: Next) -> Result<Response, R
         return Ok(next.run(request).await);
     }
 
-    // Extract the CSRF token from the cookie.
-    let cookie_token =
-        cookie_auth::extract_cookie_value(request.headers(), cookie_auth::CSRF_COOKIE);
+    // Extract the CSRF token from the cookie (borrow-only).
+    let cookie_token = cookie_auth::extract_cookie_str(request.headers(), cookie_auth::CSRF_COOKIE);
 
-    // Extract the CSRF token from the request header.
+    // Extract the CSRF token from the request header. Borrow-only:
+    // `String: PartialEq<&str>` covers the comparison, so materializing an
+    // owned copy per state-changing request was a pure waste
+    // (benches/ROUND11.md §6: 15.7 → 1.3 ns, −1 alloc).
     let header_token = request
         .headers()
         .get(cookie_auth::CSRF_HEADER)
-        .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
+        .and_then(|v| v.to_str().ok());
 
     match (cookie_token, header_token) {
         (Some(c), Some(h)) if !c.is_empty() && c == h => {

--- a/src/interfaces/middleware/rate_limit.rs
+++ b/src/interfaces/middleware/rate_limit.rs
@@ -55,18 +55,18 @@ impl RateLimiter {
     /// `Err(StatusCode::TOO_MANY_REQUESTS)`.
     #[allow(clippy::result_unit_err)]
     pub fn check_and_increment(&self, ip: &str) -> Result<u32, ()> {
-        let key = ip.to_string();
-        // moka's entry API lets us atomically read-modify-write.
-        // On first access the entry is inserted with count = 1 and the TTL
-        // starts. Subsequent accesses within the window increment the count.
-        let count = self.cache.entry(key).or_insert_with(|| 0).into_value() + 1;
+        // Lock-free read (borrows the key — no allocation), then one
+        // write-back. The previous shape allocated the key TWICE and paid
+        // a locking `entry()` op on top of the insert; moka's
+        // `and_upsert_with` alternative benchmarked slower still
+        // (benches/ROUND11.md §20). Read-then-write is not atomic, but it
+        // never was — under a concurrent burst both shapes can undercount
+        // the same way, which only makes the limiter marginally lenient,
+        // never wrongly strict.
+        let count = self.cache.get(ip).unwrap_or(0) + 1;
 
-        // Write back the incremented value.  Because `or_insert_with` returns
-        // the *existing* value when the key was already present, we must always
-        // re-insert so the counter actually advances. The TTL of the **first**
-        // insert still governs eviction because moka uses insert-time TTL.
-        // However, on re-insert moka resets the TTL, for rate limiting this
-        // is fine because it means the window "slides" forward on activity.
+        // On re-insert moka resets the TTL; for rate limiting this is fine
+        // because it means the window "slides" forward on activity.
         self.cache.insert(ip.to_string(), count);
 
         if count > self.max_requests {

--- a/src/interfaces/nextcloud/ocs_handler.rs
+++ b/src/interfaces/nextcloud/ocs_handler.rs
@@ -35,12 +35,12 @@ fn ocs_err(statuscode: u16, message: &str) -> serde_json::Value {
 }
 
 pub async fn handle_capabilities_v1(State(state): State<Arc<AppState>>) -> Response {
-    tracing::info!("[NC] capabilities v1 requested, returning payload");
+    tracing::debug!("[NC] capabilities v1 requested, returning payload");
     capabilities_response(&state, 1)
 }
 
 pub async fn handle_capabilities_v2(State(state): State<Arc<AppState>>) -> Response {
-    tracing::info!("[NC] capabilities v2 requested, returning payload");
+    tracing::debug!("[NC] capabilities v2 requested, returning payload");
     capabilities_response(&state, 2)
 }
 

--- a/src/interfaces/nextcloud/preview_handler.rs
+++ b/src/interfaces/nextcloud/preview_handler.rs
@@ -144,7 +144,16 @@ pub async fn handle_preview(
     // compared it, so every revalidation re-ran the whole pipeline and
     // re-shipped the body (ROUND10). Authz already passed above; a 304
     // must never skip the Read check.
-    let etag = format!("\"thumb-{}-{:?}\"", object_id, thumb_size);
+    let etag = {
+        let s = thumb_size.as_str();
+        let mut e = String::with_capacity(9 + object_id.len() + s.len());
+        e.push_str("\"thumb-");
+        e.push_str(&object_id);
+        e.push('-');
+        e.push_str(s);
+        e.push('"');
+        e
+    };
     if let Some(inm) = headers.get(header::IF_NONE_MATCH)
         && let Ok(client_etag) = inm.to_str()
         && (client_etag == etag || client_etag == "*")

--- a/src/interfaces/nextcloud/status_handler.rs
+++ b/src/interfaces/nextcloud/status_handler.rs
@@ -1,22 +1,36 @@
-use axum::Json;
 use axum::extract::State;
-use axum::response::{IntoResponse, Response};
+use axum::http::header;
+use axum::response::Response;
 use serde_json::json;
 use std::sync::Arc;
 
 use crate::common::di::AppState;
 
+/// Pre-serialized `/status.php` body. The payload is process-invariant
+/// (pure config: emulated NC version), yet every NC desktop/mobile client
+/// polls it on connect and periodically — the old handler re-built the
+/// `json!` tree and re-serialized on every poll (793 ns / 14 allocs;
+/// now a `Bytes` refcount bump at ~29 ns / 0 allocs — benches/ROUND11.md).
+static STATUS_BODY: std::sync::OnceLock<bytes::Bytes> = std::sync::OnceLock::new();
+
 pub async fn handle_status(State(state): State<Arc<AppState>>) -> Response {
-    let (major, minor, patch) = state.core.config.nextcloud.emulated_version;
-    let version_string = state.core.config.nextcloud.version_string();
-    Json(json!({
-        "installed": true,
-        "maintenance": false,
-        "needsDbUpgrade": false,
-        "version": format!("{}.{}.{}.1", major, minor, patch),
-        "versionstring": version_string,
-        "productname": "OxiCloud",
-        "edition": ""
-    }))
-    .into_response()
+    let body = STATUS_BODY.get_or_init(|| {
+        let (major, minor, patch) = state.core.config.nextcloud.emulated_version;
+        let version_string = state.core.config.nextcloud.version_string();
+        let v = json!({
+            "installed": true,
+            "maintenance": false,
+            "needsDbUpgrade": false,
+            "version": format!("{}.{}.{}.1", major, minor, patch),
+            "versionstring": version_string,
+            "productname": "OxiCloud",
+            "edition": ""
+        });
+        bytes::Bytes::from(serde_json::to_vec(&v).expect("status.php body serializes"))
+    });
+    Response::builder()
+        .status(axum::http::StatusCode::OK)
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(axum::body::Body::from(body.clone()))
+        .expect("static status.php response")
 }

--- a/src/interfaces/nextcloud/uploads_handler.rs
+++ b/src/interfaces/nextcloud/uploads_handler.rs
@@ -171,53 +171,71 @@ async fn handle_propfind_session(
     // `handle_assemble`'s destination-URL parsing. Storage-side keying
     // stays on `user.username` — upload sessions are per-user, not
     // per-drive.
-    let session_href = format!(
-        "/remote.php/dav/uploads/{}/{}/",
-        session.raw_username, upload_id
-    );
-    let session_last_modified =
-        chrono::DateTime::<chrono::Utc>::from_timestamp(listing.session_mtime as i64, 0)
-            .unwrap_or_else(chrono::Utc::now)
-            .to_rfc2822();
+    // `write!` formats every element straight into a pre-sized `body`; the
+    // old `push_str(&format!(…))` chain allocated a throwaway String per
+    // element per chunk plus growth reallocations from `String::new()`, and
+    // ran the chrono format interpreter per chunk (benches/ROUND11.md §4:
+    // 2.3-2.6x, allocs 2582 → 772 on a 256-chunk session).
+    use std::fmt::Write as _;
 
-    let mut body = String::new();
+    /// `<d:getlastmodified>` via the stack renderer; chrono fallback for
+    /// out-of-range timestamps (same shape as `nextcloud/webdav_handler`).
+    /// RFC 2822 output contains no XML-special characters by construction.
+    fn write_lastmodified(body: &mut String, secs: i64) {
+        let mut buf = [0u8; 31];
+        match crate::common::fmt::rfc2822_utc(&mut buf, secs) {
+            Some(s) => {
+                let _ = write!(body, "<d:getlastmodified>{}</d:getlastmodified>", s);
+            }
+            None => {
+                let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(secs, 0)
+                    .unwrap_or_else(chrono::Utc::now)
+                    .to_rfc2822();
+                let _ = write!(
+                    body,
+                    "<d:getlastmodified>{}</d:getlastmodified>",
+                    xml_escape(&dt)
+                );
+            }
+        }
+    }
+
+    let mut body = String::with_capacity(256 + listing.chunks.len() * 256);
     body.push_str(r#"<?xml version="1.0" encoding="utf-8"?>"#);
     body.push_str(r#"<d:multistatus xmlns:d="DAV:">"#);
 
     // Session collection itself.
     body.push_str("<d:response>");
-    body.push_str(&format!("<d:href>{}</d:href>", xml_escape(&session_href)));
+    let _ = write!(
+        body,
+        "<d:href>/remote.php/dav/uploads/{}/{}/</d:href>",
+        xml_escape(&session.raw_username),
+        xml_escape(upload_id)
+    );
     body.push_str("<d:propstat><d:prop>");
     body.push_str("<d:resourcetype><d:collection/></d:resourcetype>");
-    body.push_str(&format!(
-        "<d:getlastmodified>{}</d:getlastmodified>",
-        xml_escape(&session_last_modified)
-    ));
+    write_lastmodified(&mut body, listing.session_mtime as i64);
     body.push_str("</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>");
     body.push_str("</d:response>");
 
     // One entry per chunk file.
     for chunk in &listing.chunks {
-        let chunk_href = format!(
-            "/remote.php/dav/uploads/{}/{}/{}",
-            session.raw_username, upload_id, chunk.name
-        );
-        let chunk_modified = chrono::DateTime::<chrono::Utc>::from_timestamp(chunk.mtime as i64, 0)
-            .unwrap_or_else(chrono::Utc::now)
-            .to_rfc2822();
-
         body.push_str("<d:response>");
-        body.push_str(&format!("<d:href>{}</d:href>", xml_escape(&chunk_href)));
+        let _ = write!(
+            body,
+            "<d:href>/remote.php/dav/uploads/{}/{}/{}</d:href>",
+            xml_escape(&session.raw_username),
+            xml_escape(upload_id),
+            xml_escape(&chunk.name)
+        );
         body.push_str("<d:propstat><d:prop>");
         body.push_str("<d:resourcetype/>");
-        body.push_str(&format!(
+        let _ = write!(
+            body,
             "<d:getcontentlength>{}</d:getcontentlength>",
             chunk.size
-        ));
-        body.push_str(&format!(
-            "<d:getlastmodified>{}</d:getlastmodified>",
-            xml_escape(&chunk_modified)
-        ));
+        );
+        write_lastmodified(&mut body, chunk.mtime as i64);
         body.push_str("</d:prop><d:status>HTTP/1.1 200 OK</d:status></d:propstat>");
         body.push_str("</d:response>");
     }


### PR DESCRIPTION
## Description

Round 11 performance optimization pack with benchmark-gated changes across CPU, allocation, and query shapes. All changes ship with BEFORE/AFTER benchmarks and equivalence gates; candidates that don't beat their baseline are rolled back.

### Key Changes

**StoragePath re-representation (§20)**
- Replaced `segments: Vec<String>` with single canonical `joined: String`
- Eliminates one heap allocation per segment on every hydrated listing row
- Segment views derived on demand via `segments()`, `file_name()`, `parent()`
- Benchmark: 500-row page (depth 4) → 4,000 → 1,000 allocs (1.51x faster)
- Removed duplicate `path_string` field from `File` and `Folder` entities

**Display classifier fusion (§3)**
- Unified `category_for`, `icon_class_for`, `icon_special_class_for` into single `classify_display` function
- Stack-lowercases extension once instead of three times per file
- Benchmark: 13-row mixed corpus → 4,390 → 2,074 ns (2.12x faster, 21 → 0 allocs)

**Memoized static bodies**
- `/status.php` → `OnceLock<Bytes>` (836 → 28.8 ns, 29x faster)
- `/openapi.json` → `OnceLock<Bytes>` (was rebuilding 171 KiB spec per request; 2.77 ms → 18.5 ns)

**Query shape optimizations**
- Deferred upload registration: 3 round-trips → single `WITH parent AS (…) INSERT … RETURNING` template
- Calendar/AddressBook/Playlist authz: added `direct_grant_cache` (moka) for uncached `role_grants` point queries
- `expand_user` cache miss: serial `is_external` + recursive groups → `tokio::join!`
- Recluster persistence: F sequential `assign_person` UPDATEs → one `UPDATE … FROM unnest($1,$2)` batch

**Micro-optimizations**
- NC upload-session PROPFIND: `write!` + pre-sized body + stack dates (203.7 → 75.4 µs, 2.70x faster)
- CSRF token: borrow-only compare (55.2 → 2.2 ns)
- Thumbnail ETag: `as_str` instead of Debug (150.5 → 87.7 ns, cached client ETags stay valid)
- Recent-handler id: stack `encode_lower` (52.2 → 10.7 ns)
- 4xx error body: borrowed `ErrorResponse` + `ErrorKind::as_str` (426 → 367 ns)
- vCard emit: `write!` instead of `push_str(&format!)` (766 → 357 ns)
- Search page slice: `drain` move instead of `.to_vec()` clone
- Content-hit verify: parse-once pairs instead of double `Uuid::parse_str`
- Group last-user check: HashSet instead of O(N·M) slice contains
- Retry op label: lazy closure (success path never materializes format)
- Encrypted blob: in-place detached instead of alloc + copy
- Face clustering: precomputed sqrt norms instead of per-pair recompute

**Frontend optimizations**
- `ResourceList.selectedEntries`: id→index Map projection (O(k · log k)) instead of full O(N) filter on every selection
- Recent page: read star state from `favoriteIds` prop instead of baking it into mapper (eliminates SvelteSet subscription)
- Admin "time ago": use cached `dateTimeFormatFor` instead of fresh `toLocaleDateString()` per call

### Rejected Candidates
- moka `and_upsert_with` rate-limiter rewrite (slower + more allocs)
- GET/HEAD `Last-Modified` stack-render port (chrono String is already terminal allocation)
-

https://claude.ai/code/session_01ABhTEHuGujvwoodh67Kga7