### PR TITLE
fix(merge): fix merge of mount + is_favorite feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "oxicloud"
-version = "0.8.2"
+version = "0.8.7"
 dependencies = [
  "accept-language",
  "aes-gcm",

--- a/src/application/services/mount_dto.rs
+++ b/src/application/services/mount_dto.rs
@@ -67,6 +67,11 @@ pub fn mount_folder_dto(cfg: &MountConfig, parent_id: &str, stat: &MountStat) ->
         category: Arc::from("Folder"),
         created_by: Some(cfg.owner_id),
         updated_by: Some(cfg.owner_id),
+        // Mount entries carry synthetic `ext:*` ids that don't exist in
+        // `auth.user_favorites` or `storage.role_grants`, so both flags
+        // are always false — they can't be favorited or grant-listed.
+        is_favorite: false,
+        is_shared: false,
     }
 }
 
@@ -88,6 +93,8 @@ pub fn mount_entry_folder_dto(cfg: &MountConfig, parent_id: &str, entry: &MountE
         category: Arc::from("Folder"),
         created_by: Some(cfg.owner_id),
         updated_by: Some(cfg.owner_id),
+        is_favorite: false,
+        is_shared: false,
     }
 }
 
@@ -115,6 +122,8 @@ pub fn mount_entry_file_dto(cfg: &MountConfig, parent_id: &str, entry: &MountEnt
         etag: virtual_file_etag(entry.size, entry.modified_at),
         created_by: Some(cfg.owner_id),
         updated_by: Some(cfg.owner_id),
+        is_favorite: false,
+        is_shared: false,
     }
 }
 
@@ -141,5 +150,7 @@ pub fn mount_file_dto(cfg: &MountConfig, parent_id: &str, stat: &MountStat) -> F
         etag: virtual_file_etag(stat.size, stat.modified_at),
         created_by: Some(cfg.owner_id),
         updated_by: Some(cfg.owner_id),
+        is_favorite: false,
+        is_shared: false,
     }
 }

--- a/src/interfaces/api/handlers/folder_handler.rs
+++ b/src/interfaces/api/handlers/folder_handler.rs
@@ -686,6 +686,10 @@ fn mount_entry_to_item(
             category: Arc::from("Folder"),
             created_by: Some(cfg.owner_id),
             updated_by: Some(cfg.owner_id),
+            // Mount entries use synthetic `ext:*` ids — no favorites /
+            // grants rows can ever key against them.
+            is_favorite: false,
+            is_shared: false,
         };
         FolderResourceItemDto {
             resource_type: ResourceTypeDto::Folder,
@@ -713,6 +717,8 @@ fn mount_entry_to_item(
             etag: virtual_file_etag(entry.size, entry.modified_at),
             created_by: Some(cfg.owner_id),
             updated_by: Some(cfg.owner_id),
+            is_favorite: false,
+            is_shared: false,
         };
         FolderResourceItemDto {
             resource_type: ResourceTypeDto::File,


### PR DESCRIPTION
fix the merge of mount feature and is_favorite + is_shared feature
2 merge isolated are working, but together it is raising an impossible 
build due to missing schema

👌 unit test, functional test, hurl test ok

was raising:

```
  cargo build
     Compiling oxicloud v0.8.7 (/Users/ed/Lab/OxiCloud-main)
  warning: oxicloud@0.8.7: OxiCloud built with git hash: 06875bc72884202ec724604e573b781572db6674 and branch: main2
  error[E0063]: missing fields `is_favorite` and `is_shared` in initializer of `FolderDto`
    --> src/application/services/mount_dto.rs:55:5
     |
  55 |     FolderDto {
     |     ^^^^^^^^^ missing `is_favorite` and `is_shared`

  error[E0063]: missing fields `is_favorite` and `is_shared` in initializer of `FolderDto`
    --> src/application/services/mount_dto.rs:76:5
     |
  76 |     FolderDto {
     |     ^^^^^^^^^ missing `is_favorite` and `is_shared`

  error[E0063]: missing fields `is_favorite` and `is_shared` in initializer of `FileDto`
     --> src/application/services/mount_dto.rs:100:5
      |
  100 |     FileDto {
      |     ^^^^^^^ missing `is_favorite` and `is_shared`

  error[E0063]: missing fields `is_favorite` and `is_shared` in initializer of `FileDto`
     --> src/application/services/mount_dto.rs:126:5
      |
  126 |     FileDto {
      |     ^^^^^^^ missing `is_favorite` and `is_shared`

  error[E0063]: missing fields `is_favorite` and `is_shared` in initializer of `FolderDto`
     --> src/interfaces/api/handlers/folder_handler.rs:674:19
      |
  674 |         let dto = FolderDto {
      |                   ^^^^^^^^^ missing `is_favorite` and `is_shared`

  error[E0063]: missing fields `is_favorite` and `is_shared` in initializer of `FileDto`
     --> src/interfaces/api/handlers/folder_handler.rs:698:19
      |
  698 |         let dto = FileDto {
      |                   ^^^^^^^ missing `is_favorite` and `is_shared`
```

cc @DioCrafts  this fix `v0.8.7`
cc @BCNelson 
