### PR TITLE
fix: Make oidc check if email verification is required

### DIFF
--- a/src/application/services/auth_application_service.rs
+++ b/src/application/services/auth_application_service.rs
@@ -2773,20 +2773,22 @@ impl AuthApplicationService {
         };
 
         let provider_name = oidc.provider_name().to_string();
-        // Check email_verified - only if email is present in claims
-        if let Some(email) = &claims.email {
-            let verified = claims.email_verified.unwrap_or(false);
-            if !verified {
-                tracing::warn!(
-                    "OIDC login rejected: email not verified (provider: {}, email: {})",
-                    provider_name,
-                    email
-                );
-                return Err(DomainError::new(
-                    ErrorKind::AccessDenied,
-                    "OIDC",
-                    "Email verification required. Please verify your email at the identity provider.",
-                ));
+        // Check email_verified - only if email is present in claims, and email verification is required.
+        if self.require_verified_email() {
+            if let Some(email) = &claims.email {
+                let verified = claims.email_verified.unwrap_or(false);
+                if !verified {
+                    tracing::warn!(
+                        "OIDC login rejected: email not verified (provider: {}, email: {})",
+                        provider_name,
+                        email
+                    );
+                    return Err(DomainError::new(
+                        ErrorKind::AccessDenied,
+                        "OIDC",
+                        "Email verification required. Please verify your email at the identity provider.",
+                    ));
+                }
             }
         }
 


### PR DESCRIPTION
## Description

Adds a check for require_verified_email being true before checking if email_verified is true from the OIDC provider. This fixes Azure AD authentication, as it does not return the email_verified claim, as OxiCloud expects.

## Related Issue

N/A

## Type of Change

Please check the option that best describes your change:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Documentation update

## How Has This Been Tested?

I built the docker image, and used it in place of the official image on my instance. With the official image, logging in with SSO returned a `Email verification required. Please verify your email at the identity provider.` error; on my image, the account was provisioned correctly and logged in. This was with the `OXICLOUD_REQUIRE_VERIFIED_EMAIL` env var set to `false` (the default).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules